### PR TITLE
chore: wire in the Galaxio development process

### DIFF
--- a/.claude/hooks/linkage-guard.sh
+++ b/.claude/hooks/linkage-guard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard — gate ONLY release tagging. ~0 tokens. Normal push/merge untouched.
+set -uo pipefail
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+[ -n "$cmd" ] || exit 0
+case "$cmd" in *"git "*) ;; *) exit 0 ;; esac
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+checker="$root/scripts/check-linkage.sh"
+block() { printf 'BLOCKED by linkage-guard:\n%s\n' "$1" >&2; exit 2; }
+is_tag=0
+printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+tag[[:space:]]+v?[0-9]+\.[0-9]+\.[0-9]+' && is_tag=1
+if printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+push\b' \
+   && printf '%s' "$cmd" | grep -qE '(--tags|refs/tags/|[[:space:]](origin[[:space:]]+)?v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)|release/[0-9])'; then
+  is_tag=1
+fi
+printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+(commit|log|show)\b' && is_tag=0
+[ "$is_tag" = 1 ] || exit 0
+[ -x "$checker" ] || block "checker missing ($checker) — release cannot be verified"
+ver=$(printf '%s' "$cmd" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$ver" ] || block "tag/release push without explicit vX.Y.Z — verify: scripts/check-linkage.sh --for-tag <version>"
+out=$("$checker" --for-tag "$ver" 2>&1) || block "$out"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/linkage-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,50 @@
+# Changes here will be overwritten by `copier update` — NEVER EDIT MANUALLY.
+# This file records the answers used to scaffold the project so the template
+# can be re-applied later.  Keep it committed.
+_commit: d8b7cd1
+_src_path: gh:galax-io/spec-kit-galaxio-bootstrap
+architecture: 'The vocabulary is the source of truth: `docs/GLOSSARY.md` defines the
+    terms, the ADRs justify them, and everything else must follow. The intended runtime
+    layering (types -> evaluation -> data sources -> tool adapters) is described in
+    docs/compatibility.md and exists only on paper. Compatibility-sensitive: any OpenTelemetry
+    semantic convention name borrowed by the format, and any field name that appears
+    in an example.'
+build_test_cmd: bash scripts/verify.sh
+commands: '# verify      bash scripts/verify.sh    (YAML parses, links resolve, docs
+    are English)
+
+    # links       grep-based, inside verify.sh
+
+    # yaml        python3 -c ''import yaml,glob; [list(yaml.safe_load_all(open(f)))
+    for f in glob.glob("docs/**/*.yaml", recursive=True)]''
+
+    # no build, no tests — there is nothing to compile yet'
+dep_manifest: none yet — no code. docs/GLOSSARY.md is the vocabulary truth
+do_git: false
+org_repo: galax-io/opennfr
+project_name: OpenNFR
+project_tagline: Design notes toward an open, tool-agnostic format for load testing
+    requirements. Consumers will be load-test adapters and CI backends; the document
+    vocabulary and the OpenTelemetry metric names it borrows are the compatibility
+    surface. Nothing is stable yet.
+publish_mechanism: GitHub Release only — nothing is published to a registry yet
+release_notes_tool: git-cliff
+role: 'Principal Engineer: format and specification design, load testing, observability.
+    This repo is a design notebook, not a product — prefer precision of vocabulary
+    over features, and treat every added term as a cost. Argue in issues before writing
+    files.'
+run_speckit: false
+stack: generic
+stack_detail: No code. Markdown notes plus YAML sketches that nothing validates, because
+    there is no schema yet. A Go reference implementation is anticipated (docs/adr/0002-compatibility.md)
+    but not started; constructs are already screened for whether they decode without
+    a custom unmarshaler.
+structure: '`docs/` -> the notes themselves; `docs/adr/` -> naming arguments in ADR
+    form (status: proposed); `docs/examples/` -> unvalidated sketches of documents;
+    `docs/semconv/` -> proposed `loadtest.*` attribute registry; `docs/references.md`
+    -> survey of prior art, the most finished part; `specs/` -> spec-kit working dir.'
+test_model: Nothing is testable yet — `scripts/verify.sh` only checks that the notes
+    are internally consistent (YAML parses, internal links resolve, the docs stayed
+    English). Once a JSON Schema exists, every file in docs/examples/ must validate
+    against it, and that becomes the real gate.
+

--- a/.github/ISSUE_TEMPLATE/cannot-express.yml
+++ b/.github/ISSUE_TEMPLATE/cannot-express.yml
@@ -1,0 +1,37 @@
+name: The sketches cannot express this
+description: A real load testing requirement that the current notes have no way to state
+labels: [gap]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The most useful kind of issue for this repo. A requirement from real work that the
+        sketches cannot express is direct evidence that the model is wrong — far stronger
+        than an argument about the model in the abstract.
+
+  - type: textarea
+    id: requirement
+    attributes:
+      label: The requirement, in plain words
+      placeholder: "Checkout must stay under 500 ms while the cache is cold, and the first minute after start does not count."
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: How you express it today
+      description: In k6, Gatling, JMeter, a spreadsheet, or a sentence in a Word document — whatever it actually is right now.
+
+  - type: textarea
+    id: blocker
+    attributes:
+      label: Where the sketches fall short
+      description: Optional. If you already tried writing it as a RequirementSet, paste the point where you got stuck.
+
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Tool this comes from
+      multiple: true
+      options: [k6, Gatling, JMeter, Locust, Artillery, yandex-tank, other, not tool-specific]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read the notes first
+    url: https://github.com/galax-io/opennfr/blob/main/docs/GLOSSARY.md
+    about: The glossary lists candidate terms with the alternatives already considered and dropped — check whether your objection is recorded there.
+  - name: Why not just use OpenSLO / Keptn / k6 thresholds?
+    url: https://github.com/galax-io/opennfr/blob/main/docs/references.md
+    about: The survey of prior art, and the most finished part of the repository.

--- a/.github/ISSUE_TEMPLATE/naming.yml
+++ b/.github/ISSUE_TEMPLATE/naming.yml
@@ -1,0 +1,37 @@
+name: Naming argument
+description: A term in the glossary is wrong, ambiguous, or already means something else
+labels: [naming]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The vocabulary is the part of this repo most likely to be wrong, and the cheapest
+        to fix now. See [docs/GLOSSARY.md](../blob/main/docs/GLOSSARY.md).
+
+  - type: input
+    id: term
+    attributes:
+      label: The term
+      placeholder: "criterion / guard / indicator / aggregation / …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong with it
+      description: Collides with an established meaning, is ambiguous in context, does not translate, reads badly in a field name — be specific.
+    validations:
+      required: true
+
+  - type: input
+    id: alternative
+    attributes:
+      label: Proposed alternative
+      description: Optional. "This is wrong and I do not know what is right" is a useful issue too.
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art
+      description: Does another format use this word, and for what? OpenSLO, Keptn, k6, OpenTelemetry, or anything else that would collide.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+  scripts/check-linkage.sh gates this PR in CI. It fails unless the PR carries a
+  milestone AND closes an issue in that same milestone. See AGENTS.md > Milestones.
+-->
+
+Closes #
+
+## What changes
+
+<!-- One concern per PR. A vocabulary change and a docs tidy-up are two PRs. -->
+
+## Why
+
+<!-- For a naming change: what the old term got wrong, and what breaks if we keep it.
+     For a new idea: what case it covers that the current notes cannot express. -->
+
+## Checklist
+
+- [ ] Milestone assigned (CI fails without one)
+- [ ] `Closes #<issue>` above points at an issue in the same milestone
+- [ ] `bash scripts/verify.sh` passes locally
+- [ ] If a term changed: [docs/GLOSSARY.md](../docs/GLOSSARY.md) updated, including the
+      *Rejected* note explaining what the old term got wrong
+- [ ] If a decision changed: the relevant ADR updated rather than contradicted elsewhere

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # AGENTS.md: "Tags ONLY on release/* branches or main". A tag on a feature
+      # branch would publish notes nobody reviewed, so refuse it here rather than
+      # relying on discipline.
+      - name: Tag must sit on main or a release branch
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          branches=$(git branch -r --contains "$tag" | sed 's|origin/||' | tr -d ' ')
+          echo "tag $tag is contained in:"; echo "$branches" | sed 's/^/  /'
+          if echo "$branches" | grep -qxE 'main|release/.*'; then
+            echo "ok: tag sits on an allowed branch"
+          else
+            echo "::error::tag $tag is not on main or a release/* branch"
+            exit 1
+          fi
+
+      # AGENTS.md: "Branch name must match tag version" — release/1.2.0 carries
+      # v1.2.0, v1.2.1, ...
+      - name: Release branch name must match the tag's minor version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          rel=$(git branch -r --contains "${GITHUB_REF_NAME}" | sed 's|origin/||' | tr -d ' ' | grep '^release/' || true)
+          if [ -z "$rel" ]; then
+            echo "tag is on main only — nothing to match"; exit 0
+          fi
+          want="release/${tag%.*}.0"
+          if echo "$rel" | grep -qx "$want"; then
+            echo "ok: $rel matches $GITHUB_REF_NAME"
+          else
+            echo "::error::tag $GITHUB_REF_NAME expects branch $want, found: $rel"
+            exit 1
+          fi
+
+      # AGENTS.md: every PR since the last tag carries the milestone, every issue
+      # whose fix is on main is closed.
+      - name: Milestone must be tag-ready
+        run: scripts/check-linkage.sh --for-tag "${GITHUB_REF_NAME}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+
+      - uses: orhun/git-cliff-action@v4
+        id: notes
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Publish GitHub Release
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file "${{ steps.notes.outputs.changelog }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,42 @@
+name: verify
+
+on:
+  push:
+    branches: [main, "release/*"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install --disable-pip-version-check pyyaml
+
+      # The repo has no code yet, so this checks the only things that can be
+      # wrong: sketches parse, links resolve, docs stayed English.
+      - run: bash scripts/verify.sh
+
+  linkage:
+    # Enforces the issue <-> PR <-> milestone contract from AGENTS.md.
+    # PR-only: pushes to main have no PR to inspect.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/check-linkage.sh --pr "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
+# OS / editor
 .DS_Store
 *.swp
 .idea/
 .vscode/
+
+# Claude Code local (keep settings.json + hooks tracked; ignore local/secret state)
+.claude/settings.local.json
+.claude/worktrees/
+
+# spec-kit scratch
+scratchpad-*.sh
+scratchpad-*.log
+
+# build output
+# extend per stack: target/, build/, dist/, node_modules/, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# OpenNFR — Agent Guide
+
+Design notes toward an open, tool-agnostic format for load testing requirements. Consumers will be load-test adapters and CI backends; the document vocabulary and the OpenTelemetry metric names it borrows are the compatibility surface. Nothing is stable yet.
+
+> The sections above the `---` are **project-specific** — fill them in for each new
+> project. Everything below the `---` is the **stack-agnostic development process**
+> and is meant to be reused verbatim across all projects.
+
+## Role
+
+Principal Engineer: format and specification design, load testing, observability. This repo is a design notebook, not a product — prefer precision of vocabulary over features, and treat every added term as a cost. Argue in issues before writing files.
+
+## Stack
+
+No code. Markdown notes plus YAML sketches that nothing validates, because there is no schema yet. A Go reference implementation is anticipated (docs/adr/0002-compatibility.md) but not started; constructs are already screened for whether they decode without a custom unmarshaler.
+
+## Commands
+
+```bash
+# verify      bash scripts/verify.sh    (YAML parses, links resolve, docs are English)
+# links       grep-based, inside verify.sh
+# yaml        python3 -c 'import yaml,glob; [list(yaml.safe_load_all(open(f))) for f in glob.glob("docs/**/*.yaml", recursive=True)]'
+# no build, no tests — there is nothing to compile yet
+```
+
+## Structure
+
+<!-- A LIGHT search index, not a full tree. List only the entry points an agent needs
+     to FIND code fast — one terse line per area (`dir/ -> what lives there`). Omit
+     anything discoverable by looking; an exhaustive tree is noise and rots fast. -->
+`docs/` -> the notes themselves; `docs/adr/` -> naming arguments in ADR form (status: proposed); `docs/examples/` -> unvalidated sketches of documents; `docs/semconv/` -> proposed `loadtest.*` attribute registry; `docs/references.md` -> survey of prior art, the most finished part; `specs/` -> spec-kit working dir.
+
+## Architecture
+
+The vocabulary is the source of truth: `docs/GLOSSARY.md` defines the terms, the ADRs justify them, and everything else must follow. The intended runtime layering (types -> evaluation -> data sources -> tool adapters) is described in docs/compatibility.md and exists only on paper. Compatibility-sensitive: any OpenTelemetry semantic convention name borrowed by the format, and any field name that appears in an example.
+
+## Test Model
+
+Nothing is testable yet — `scripts/verify.sh` only checks that the notes are internally consistent (YAML parses, internal links resolve, the docs stayed English). Once a JSON Schema exists, every file in docs/examples/ must validate against it, and that becomes the real gate.
+
+---
+
+<!-- ===================================================================== -->
+<!-- STACK-AGNOSTIC DEVELOPMENT PROCESS — reuse verbatim across projects.   -->
+<!-- ===================================================================== -->
+
+## Boundaries
+
+**Always:** format before commit, branch from `main`, keep commits semantic and green, preserve backward compat for published public APIs and any downstream consumers. `none yet — no code. docs/GLOSSARY.md is the vocabulary truth` = dependency truth, `.github/workflows/` = CI/release truth.
+
+**Ask first:** new deps or upgrades, changing public API signatures / observable behavior / serialized formats, editing another repo, release/publish workflow changes.
+
+**Never:** force-push or commit to `main`, merge commits in PR branches (rebase only), commit broken code, opportunistic refactors outside scope, mock external systems where a real integration path exists.
+
+## Milestones (ALWAYS)
+
+Every piece of work is tied to a milestone. No exceptions unless explicitly told otherwise.
+
+- **Every PR** must be assigned to the active milestone before merging. No milestone = do not merge.
+- **Every issue** fixed by a PR must be closed when that PR lands on `main`. Do not leave completed issues open.
+- **Spec work** (`specs/NNN-*/`) belongs to the milestone that owns the spec. Link the spec PR to the milestone immediately when creating it.
+- **Active milestone** = the lowest-numbered open milestone that matches the current spec/plan. Check `gh api repos/galax-io/opennfr/milestones` if unsure.
+
+## Commits & PRs
+
+- **Spec-first.** `specs/NNN-*/` artifacts → `docs(speckit): add NNN-<feature> spec/plan/tasks` commit BEFORE any `feat`/`fix`. Never folded into implementation.
+- **1 issue = 1 commit.** Each tracked GitHub issue maps to one semantic commit (`feat(scope): … (#NNN)`), green on its own (`bash scripts/verify.sh`). Docs, tweaks, and out-of-scope improvements go in separate PRs — never mixed with issue commits.
+- **Intent, not path.** No add-then-remove within a PR. Squash churn before review.
+- **1 concern per PR.** Feature ≠ docs/README. Stack dependent PRs; update with `--force-with-lease`.
+- **Idiomatic code.** Follow the language's idioms and the conventions already in the codebase; no control-flow-by-exception, no dead/duplicated code.
+
+## Release Process (MANDATORY)
+
+Trunk-based with release branches. Trunk is `main`; `release/*` branches are cut from `main` for stabilization. Pushing a `vX.Y.Z` tag on `main` or a `release/*` branch triggers the release workflow (GitHub Release only — nothing is published to a registry yet) and creates a GitHub Release (git-cliff).
+
+### Minor/Major release (e.g. 1.2.0, 2.0.0)
+
+1. `git checkout -b release/X.Y.0 main` — cut release branch from `main`
+2. `git push -u origin release/X.Y.0`
+3. `git tag vX.Y.0` on the release branch
+4. `git push origin vX.Y.0` — triggers release workflow
+
+### Patch release (e.g. 1.2.1)
+
+1. Fix lands on `main` first (via PR as usual)
+2. `git cherry-pick <fix-sha>` onto `release/X.Y.0`
+3. `git tag vX.Y.1` on the release branch
+4. `git push origin vX.Y.1` — triggers release workflow
+
+### Rules
+
+- **Every minor version gets its own `release/X.Y.0` branch** — no exceptions
+- **Tags ONLY on `release/*` branches or `main`** — `release.yml` validates this
+- **Branch name must match tag version**: `release/1.2.0` → `v1.2.0`, `v1.2.1`, etc.
+- **Never delete a release tag** after the registry deployment starts — creates stuck deployments
+- **Never reuse a version number** — most package registries reject duplicates permanently
+- **Before tagging**: every PR merged since the previous tag must be assigned to the milestone; every issue in the milestone whose fix is on `main` must be closed
+
+<!-- The issue↔PR↔milestone contract above is enforced mechanically by         -->
+<!-- scripts/check-linkage.sh + the .claude/hooks/linkage-guard.sh PreToolUse   -->
+<!-- hook (gates release tagging only; normal push/PR/merge untouched).         -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+@AGENTS.md
+
+<!-- Point this at the active plan once spec work starts, e.g.: -->
+<!-- Active plan: [specs/001-<feature>/plan.md](specs/001-<feature>/plan.md) -->

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,62 @@
+# git-cliff — GitHub Release notes for OpenNFR.
+# AGENTS.md names git-cliff as the release-notes tool; this is its config.
+#
+# The commit groups below are ordered for a design repo: what the format now says
+# comes before how the notes are organised. Once there is an implementation,
+# revisit the ordering — "feat" will start meaning code rather than vocabulary.
+
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim | upper_first }}
+{%- endfor %}
+{% endfor %}
+
+{% if version %}\
+{% if previous.version %}\
+**Full diff**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
+{% endif %}\
+{% endif %}\
+
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = true
+sort_commits = "oldest"
+
+commit_parsers = [
+  # A design repo's headline change is a change to what the format says.
+  { message = "^feat", group = "Format changes" },
+  { message = "^docs\\(adr\\)", group = "Decisions revisited" },
+  { message = "^docs\\(speckit\\)", group = "Specs" },
+  { message = "^docs", group = "Notes" },
+  { message = "^fix", group = "Corrections" },
+  { message = "^refactor", group = "Housekeeping" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Housekeeping" },
+  { message = "^ci", group = "Housekeeping" },
+  { body = ".*security", group = "Security" },
+  # Catch-all. Without it, a commit that is not conventional gets no group and
+  # silently vanishes from the notes — which is how you ship an empty release.
+  { message = ".*", group = "Other" },
+]
+
+# Vocabulary changes are breaking by nature — a renamed term invalidates every
+# document written against the old one. Surface them, do not let them hide in a
+# group.
+commit_preprocessors = [
+  { pattern = "\\((\\w+\\s)?#([0-9]+)\\)", replace = "([#${2}](https://github.com/galax-io/opennfr/issues/${2}))" },
+]
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = false   # pre-1.0: breaking vocabulary changes bump minor

--- a/scripts/check-linkage.sh
+++ b/scripts/check-linkage.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# check-linkage.sh — verify the issue ↔ PR ↔ milestone contract (see AGENTS.md "Milestones (ALWAYS)").
+# Run `scripts/check-linkage.sh --help` for full usage.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+check-linkage.sh — verify the issue <-> PR <-> milestone contract (see AGENTS.md "Milestones (ALWAYS)").
+
+What each entity owes (this script enforces it):
+  Issue      belongs to exactly one milestone; closed only when its fix is on main.
+  PR         carries its issue's milestone + a real closing link (Closes #<issue>);
+             the linked issue sits in the same milestone; one issue per PR.
+  Milestone  one release (vX.Y.Z); tag only when every issue is closed and every PR merged.
+
+Usage:
+  scripts/check-linkage.sh --pr <N>          # GATE one PR: milestone + Closes #issue + same milestone
+  scripts/check-linkage.sh --for-tag vX.Y.Z  # GATE a release: tag-readiness of that version's milestone
+  scripts/check-linkage.sh [milestone]       # audit a milestone (default: lowest-numbered open)
+  scripts/check-linkage.sh --tag [ms]        # also assert tag-readiness (all issues closed, all PRs merged)
+  scripts/check-linkage.sh --help
+
+Env:
+  REPO=owner/name   # override repo (default: gh repo view of the current checkout)
+
+Exit: 0 all rules hold | 1 at least one violation | 2 usage/prereq error.
+EOF
+}
+
+for bin in gh jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "error: '$bin' not found on PATH" >&2; exit 2; }
+done
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
+[ -n "$REPO" ] || { echo "error: cannot determine repo — run inside a GitHub checkout or set REPO=owner/name" >&2; exit 2; }
+
+TAG_MODE=0
+MS=""
+PR_NUM=""
+FOR_TAG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tag)      TAG_MODE=1 ;;
+    --pr)       shift; PR_NUM="${1:-}"
+                [[ "$PR_NUM" =~ ^[0-9]+$ ]] || { echo "error: --pr needs a numeric PR id" >&2; exit 2; } ;;
+    --for-tag)  shift; FOR_TAG="${1:-}"
+                [[ "$FOR_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: --for-tag needs vX.Y.Z" >&2; exit 2; } ;;
+    --help|-h)  usage; exit 0 ;;
+    [0-9]*)     MS="$1" ;;
+    *)          echo "error: unknown argument '$1'" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# Gate one PR (the merge gate). Fails if the PR is missing a milestone, closes no
+# issue, or closes an issue in a different milestone. Strict: requires a registered
+# GitHub closing link (no body-text fallback — that lenient path is audit-mode only).
+if [ -n "$PR_NUM" ]; then
+  pj=$(gh pr view "$PR_NUM" --repo "$REPO" --json number,title,state,milestone,closingIssuesReferences) \
+    || { echo "error: PR #$PR_NUM not found in $REPO" >&2; exit 2; }
+  p_title=$(jq -r '.title' <<<"$pj")
+  p_ms=$(jq -r '.milestone.title // ""' <<<"$pj")
+  p_closes=$(jq -r '.closingIssuesReferences[]?.number' <<<"$pj")
+  e=0
+  printf 'PR #%s  %s\n' "$PR_NUM" "$p_title"
+  if [ -z "$p_ms" ]; then printf '  ✗ no milestone — assign one (gh pr edit %s --milestone "…")\n' "$PR_NUM"; e=1
+  else printf '  ✓ milestone: %s\n' "$p_ms"; fi
+  if [ -z "$p_closes" ]; then
+    printf '  ✗ closes no issue — add "Closes #<issue>" to the PR body\n'; e=1
+  else
+    for i in $p_closes; do
+      i_ms=$(gh issue view "$i" --repo "$REPO" --json milestone -q '.milestone.title // ""' 2>/dev/null || echo "")
+      if [ "$i_ms" = "$p_ms" ]; then printf '  ✓ closes #%s (same milestone)\n' "$i"
+      else printf '  ✗ closes #%s but its milestone is "%s", not "%s"\n' "$i" "${i_ms:-none}" "$p_ms"; e=1; fi
+    done
+  fi
+  if [ "$e" = 0 ]; then printf 'PASS: PR #%s is well-formed.\n' "$PR_NUM"; exit 0; fi
+  printf 'FAIL: PR #%s is malformed — fix the above before merge.\n' "$PR_NUM"; exit 1
+fi
+
+# Map a release version (vX.Y.Z) to its milestone, then assert tag-readiness on it.
+# Patch versions map to the vX.Y.0 milestone (e.g. v1.23.1 -> "v1.23.0 …").
+if [ -n "$FOR_TAG" ]; then
+  v="${FOR_TAG#v}"; minor="v${v%.*}.0"
+  MS=$(gh api "repos/$REPO/milestones?state=all&per_page=100" \
+        | jq -r --arg t "$minor" 'map(select(.title | startswith($t))) | .[0].number // empty')
+  [ -n "$MS" ] || { echo "error: no milestone whose title starts with '$minor' for tag $FOR_TAG" >&2; exit 2; }
+  TAG_MODE=1
+fi
+
+# Default to the lowest-numbered open milestone (the "active" one).
+if [ -z "$MS" ]; then
+  MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq 'sort_by(.number) | .[0].number // empty')
+  [ -n "$MS" ] || { echo "error: no open milestone found in $REPO" >&2; exit 2; }
+fi
+
+ms_json=$(gh api "repos/$REPO/milestones/$MS") || { echo "error: milestone #$MS not found in $REPO" >&2; exit 2; }
+ms_title=$(jq -r '.title' <<<"$ms_json")
+ms_state=$(jq -r '.state' <<<"$ms_json")
+
+errors=0
+warns=0
+err()  { printf '  ✗ %s\n' "$1"; errors=$((errors + 1)); }
+warn() { printf '  ! %s\n' "$1"; warns=$((warns + 1)); }
+ok()   { printf '  ✓ %s\n' "$1"; }
+
+printf 'Repo:      %s\n' "$REPO"
+printf 'Milestone: #%s  %s  (%s)\n' "$MS" "$ms_title" "$ms_state"
+[ "$TAG_MODE" = 1 ] && printf 'Mode:      tag-readiness\n'
+printf '\n'
+
+# All issues + PRs carrying this milestone (REST returns both; PRs carry a .pull_request key).
+items=$(gh api --paginate --slurp "repos/$REPO/issues?milestone=$MS&state=all&per_page=100" | jq 'add')
+
+pr_numbers=$(jq -r '.[] | select(.pull_request != null) | .number' <<<"$items")
+issue_numbers=$(jq -r '.[] | select(.pull_request == null) | .number' <<<"$items")
+
+linked_issues=" "   # space-delimited set of issue numbers a PR points at
+
+printf 'Pull requests\n'
+if [ -z "$pr_numbers" ]; then
+  warn "no PRs carry milestone #$MS yet"
+fi
+for pr in $pr_numbers; do
+  pr_json=$(gh pr view "$pr" --repo "$REPO" --json number,title,state,milestone,closingIssuesReferences,body)
+  pr_state=$(jq -r '.state' <<<"$pr_json")
+  pr_title=$(jq -r '.title' <<<"$pr_json")
+
+  # Real GitHub closing links, plus a text fallback for Closes/Fixes/Resolves #N in the body.
+  ref_nums=$(jq -r '.closingIssuesReferences[]?.number' <<<"$pr_json")
+  if [ -z "$ref_nums" ]; then
+    ref_nums=$(jq -r '.body // ""' <<<"$pr_json" \
+      | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+' \
+      | grep -oE '[0-9]+' || true)
+    [ -n "$ref_nums" ] && warn "PR #$pr links via body text only (not a registered GitHub closing link): $pr_title"
+  fi
+
+  if [ -z "$ref_nums" ]; then
+    err "PR #$pr ($pr_state) closes no issue — add 'Closes #<issue>': $pr_title"
+    continue
+  fi
+
+  for ri in $ref_nums; do
+    linked_issues="$linked_issues$ri "
+    ri_ms=$(gh issue view "$ri" --repo "$REPO" --json milestone -q '.milestone.title // ""' 2>/dev/null || echo "")
+    if [ "$ri_ms" != "$ms_title" ]; then
+      err "PR #$pr closes issue #$ri but that issue's milestone is '${ri_ms:-none}', not '$ms_title'"
+    fi
+  done
+
+  if [ "$TAG_MODE" = 1 ] && [ "$pr_state" != "MERGED" ]; then
+    err "PR #$pr is $pr_state — must be MERGED before tagging: $pr_title"
+  else
+    ok "PR #$pr ($pr_state) → closes #$(echo "$ref_nums" | paste -sd, -)"
+  fi
+done
+
+printf '\nIssues\n'
+if [ -z "$issue_numbers" ]; then
+  warn "no issues carry milestone #$MS"
+fi
+for is in $issue_numbers; do
+  is_state=$(jq -r --argjson n "$is" '.[] | select(.number == $n) | .state' <<<"$items")
+  case "$linked_issues" in
+    *" $is "*) linked="linked" ;;
+    *)         linked="" ;;
+  esac
+
+  if [ "$TAG_MODE" = 1 ] && [ "$is_state" != "closed" ]; then
+    err "issue #$is is $is_state — must be closed before tagging"
+  elif [ -z "$linked" ]; then
+    warn "issue #$is ($is_state) has no PR closing it"
+  else
+    ok "issue #$is ($is_state) ← linked"
+  fi
+done
+
+printf '\n'
+if [ "$errors" -gt 0 ]; then
+  printf 'FAIL: %d error(s), %d warning(s).\n' "$errors" "$warns"
+  exit 1
+fi
+printf 'PASS: 0 errors, %d warning(s).\n' "$warns"
+[ "$TAG_MODE" = 1 ] && printf 'Milestone #%s is tag-ready.\n' "$MS"
+exit 0

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# verify.sh — the "green per commit" gate for this repository.
+#
+# There is no code here yet, so this checks the only things that can currently be
+# wrong: that the sketches still parse, that the notes do not link into the void,
+# and that the docs stayed in English (see docs/adr/0001-terminology.md).
+#
+# When a JSON Schema exists, validating docs/examples/ against it belongs here and
+# becomes the real gate.
+#
+# Usage: bash scripts/verify.sh
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || dirname "$(dirname "$0")")"
+
+fail=0
+section() { printf '\n== %s\n' "$1"; }
+ok()      { printf '  ok    %s\n' "$1"; }
+bad()     { printf '  FAIL  %s\n' "$1"; fail=1; }
+
+# ---------------------------------------------------------------------------
+section "YAML sketches parse"
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '  skip  python3 not found\n'
+else
+  python3 - <<'PY'
+import glob, sys
+try:
+    import yaml
+except ImportError:
+    print("  skip  PyYAML not installed (pip install pyyaml)")
+    sys.exit(0)
+rc = 0
+for f in sorted(glob.glob("docs/**/*.yaml", recursive=True)):
+    try:
+        list(yaml.safe_load_all(open(f, encoding="utf-8")))
+        print(f"  ok    {f}")
+    except Exception as e:
+        print(f"  FAIL  {f}: {e}")
+        rc = 1
+sys.exit(rc)
+PY
+  [ $? -eq 0 ] || fail=1
+fi
+
+# ---------------------------------------------------------------------------
+section "Internal markdown links resolve"
+missing=0
+while IFS= read -r line; do
+  src="${line%%:*}"
+  target="${line#*:}"
+  base="$(dirname "$src")"
+  path="${target%%#*}"
+  [ -z "$path" ] && continue                      # pure anchor, same file
+  case "$path" in *'<'*|*'>'*|*'{'*) continue ;; esac   # placeholder, e.g. specs/001-<feature>/
+  if [ ! -e "$base/$path" ]; then
+    bad "$src -> $target"
+    missing=1
+  fi
+done < <(
+  grep -rn --include='*.md' -oE '\]\([^)]+\)' . \
+    | grep -v '^\./\.' \
+    | sed -E 's/^([^:]+):[0-9]+:\]\((.*)\)$/\1:\2/' \
+    | grep -vE ':(https?|mailto):'
+)
+[ "$missing" -eq 0 ] && ok "no dangling internal links"
+
+# ---------------------------------------------------------------------------
+section "Docs are English"
+# ADR-0001 settled on English for everything published. Cyrillic left in a file
+# means a translation was missed, which is silent until someone outside reads it.
+cyr=$(grep -rlP '[\x{0400}-\x{04FF}]' --include='*.md' --include='*.yaml' . 2>/dev/null | grep -v '^\./\.git/' || true)
+if [ -n "$cyr" ]; then
+  while IFS= read -r f; do bad "non-English text in $f"; done <<<"$cyr"
+else
+  ok "no non-English text in docs"
+fi
+
+# ---------------------------------------------------------------------------
+section "Examples are labelled as sketches"
+# Nothing validates the examples, so each one must say so — otherwise a reader
+# mistakes an illustration for syntax.
+for f in docs/examples/*.yaml; do
+  [ -e "$f" ] || continue
+  if head -6 "$f" | grep -qi 'sketch'; then
+    ok "$f"
+  else
+    bad "$f does not announce itself as a sketch in its first 6 lines"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+printf '\n'
+if [ "$fail" -ne 0 ]; then
+  printf 'FAIL\n'
+  exit 1
+fi
+printf 'PASS\n'

--- a/setup-speckit.sh
+++ b/setup-speckit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Install spec-kit extensions and presets for a project.
+#
+# Native extensions (agent-context, bug, git) install by name from the catalog.
+# Community ones live in a discovery-only catalog (install_allowed: false), so
+# they install via --from <github-archive-url> and trigger an "Untrusted Source"
+# confirmation, which this script auto-answers (running it = you authorizing it).
+#
+# Requires the `specify` CLI on PATH (https://github.com/github/spec-kit).
+#
+# Usage:
+#   bash setup-speckit.sh            # additive: install what's missing, skip existing
+#   bash setup-speckit.sh --force    # reinstall extensions over existing (DANGER:
+#                                     # overwrites customized files; presets have no --force)
+
+set -euo pipefail
+
+command -v specify >/dev/null 2>&1 || {
+  echo "error: 'specify' CLI not found on PATH. Install spec-kit first." >&2; exit 2; }
+
+FORCE_FLAG=""
+[[ "${1:-}" == "--force" ]] && FORCE_FLAG="--force"
+
+# Mirror all output to a log so failures can be inspected after the fact.
+# Capture tee's PID and `wait` for it on exit — process-substitution is
+# backgrounded, so without the trap the script can return before tee
+# flushes its last buffered writes and its stdout can interleave with the
+# caller's prompt after exit.
+LOG="$(cd "$(dirname "$0")" && pwd)/speckit-install.log"
+exec > >(tee "$LOG") 2>&1
+TEE_PID=$!
+trap 'exec >&- 2>&-; wait "$TEE_PID" 2>/dev/null || true' EXIT
+
+# Extensions/presets need a base spec-kit project (a .specify/ dir); without it
+# `specify extension add` fails with "Not a spec-kit project". If the base is
+# missing, lay it down first. Idempotent: skipped once .specify/ exists.
+#   --integration claude   this template targets Claude Code (.claude/, CLAUDE.md)
+#   --force                merge into the non-empty generated project, no prompt
+#   --ignore-agent-tools   init writes command/skill files even if the claude CLI
+#                          is absent (e.g. CI / copier post-gen)
+# init is additive: it preserves .claude/settings.json, hooks, and AGENTS.md, and
+# only appends a marker block to CLAUDE.md.
+if [[ ! -d .specify ]]; then
+  echo
+  echo "==> Base spec-kit not found — running 'specify init'"
+  specify init --here --integration claude --script sh --force --ignore-agent-tools
+fi
+
+# A single failed install must NOT abort the rest (set -e would otherwise kill the
+# script on the first ✗). Collect failures and report them at the end instead.
+FAILED=()
+
+run_ext() {     # id  <add-args...>
+  local id="$1"; shift
+  local out rc=0
+  # specify prompts "Untrusted Source — Continue? [y/N]" for external --from URLs.
+  # Auto-answer y so the script is non-interactive.
+  out=$(printf 'y\n' | specify extension add "$@" ${FORCE_FLAG} 2>&1) || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "  ✓  $id"
+  elif echo "$out" | grep -q "already installed"; then
+    echo "  –  $id (already installed; --force to reinstall)"
+  else
+    echo "  ✗  $id"; echo "$out" | sed 's/^/      /'; FAILED+=("$id")
+  fi
+}
+
+run_preset() {  # id  <add-args...>   (preset add has no --force)
+  local id="$1"; shift
+  local out rc=0
+  out=$(printf 'y\n' | specify preset add "$@" 2>&1) || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "  ✓  $id"
+  elif echo "$out" | grep -q "already installed"; then
+    echo "  –  $id (already installed)"
+  else
+    echo "  ✗  $id"; echo "$out" | sed 's/^/      /'; FAILED+=("$id")
+  fi
+}
+
+gh_zip() { echo "https://github.com/$1/archive/refs/tags/$2.zip"; }
+
+echo
+echo "==> Native extensions (catalog by name)"
+run_ext agent-context  agent-context
+run_ext bug            bug
+run_ext git            git
+
+echo
+echo "==> Community extensions (--from github archive)"
+run_ext worktrees  worktrees  --from "$(gh_zip dango85/spec-kit-worktree-parallel  v1.3.2)"
+run_ext harness    harness    --from "$(gh_zip formin/spec-kit-harness            v1.0.0)"
+# spectest + changelog: the original Quratulain-bilal v1.0.0 extensions are broken
+# (manifests fail `specify`'s validator, and commands read the spec from
+# .specify/spec.md instead of specs/<feature>/spec.md). We maintain fixed copies in
+# our own forks — these forks are the canonical source for this template, not a
+# temporary patch. Pinned tags below; bump when re-tagging a fork.
+#   https://github.com/jigarkhwar/spec-kit-spectest   (tag v1.1.0)
+#   https://github.com/jigarkhwar/spec-kit-changelog  (tag v1.2.0)
+run_ext spectest   spectest   --from "$(gh_zip jigarkhwar/spec-kit-spectest  v1.1.0)"
+run_ext changelog  changelog  --from "$(gh_zip jigarkhwar/spec-kit-changelog v1.2.0)"
+
+echo
+echo "==> Presets (--from github archive)"
+run_preset claude-ask-questions  claude-ask-questions \
+  --from "$(gh_zip 0xrafasec/spec-kit-preset-claude-ask-questions v1.0.0)"
+
+echo
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "Done with FAILURES: ${FAILED[*]}"
+  exit 1
+fi
+echo "Done."


### PR DESCRIPTION
Closes #1

## What changes

Applies `galax-io/spec-kit-galaxio-bootstrap` to this repository, then adds the pieces its `AGENTS.md` assumes exist but the template does not ship: a verification gate, CI, a release workflow, and a git-cliff config.

## Why

`AGENTS.md` names `.github/workflows/` as CI/release truth and git-cliff as the release-notes tool. Landing the process files without those would leave the guide describing things that do not exist.

`scripts/verify.sh` is the "green per commit" command. The repo has no code, so it checks the only things that can currently be wrong — the YAML sketches parse, internal links resolve, the docs stayed English, and every example says it is a sketch.

Two rules that were previously only discipline are now mechanical: `release.yml` refuses a tag that is not on `main` or `release/*`, and refuses a release branch whose name does not match the tag's minor version.

## Not included

Installing the spec-kit community extensions. `setup-speckit.sh` downloads and executes code from third-party repositories; the bootstrap's own README says to run it by hand rather than let an agent do it. Run it locally when you want the extensions:

```
bash setup-speckit.sh
```

## Checklist

- [x] Milestone assigned
- [x] `Closes #1` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally
- [x] No term changed
- [x] No decision changed