### PR TITLE
docs: repository architecture, layout and constitution v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 .claude/settings.local.json
 .claude/worktrees/
 
-# spec-kit scratch
+# spec-kit scratch (keep the installed config tracked; ignore per-checkout runtime state)
+.specify/feature.json
 scratchpad-*.sh
 scratchpad-*.log
 speckit-install.log

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,41 +1,54 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: (template, unversioned) → 1.0.0
-Bump rationale: MAJOR — first ratification. The file was an unfilled template; every
-placeholder is now a concrete, binding principle, which is a new governance baseline
-rather than an amendment to an existing one.
+Version change: 1.0.0 → 1.1.0
+Bump rationale: MINOR on both limbs of the versioning policy simultaneously — three
+principles are added (VI, VII, VIII), and an existing binding constraint is materially
+expanded to cover a second class of target.
 
-Principles defined (all new — no prior titles to rename):
-  I.   Vocabulary Before Features (NON-NEGOTIABLE)
-  II.  Borrow Names, Never Invent Them
-  III. No Silent Green (NON-NEGOTIABLE)
-  IV.  Honest Status
-  V.   Structure Over Grammar
+Principles added:
+  VI.   Evaluation Is Target-Blind
+  VII.  Architecture Before Implementation
+  VIII. Experiments Are Parked, Not Merged
 
-Sections added:
-  - Compatibility Constraints  (template slot SECTION_2)
-  - Development Workflow       (template slot SECTION_3)
-  - Governance
+Principles renamed or removed: none. I-V are untouched.
 
-Sections removed: none.
+Sections materially expanded:
+  - Compatibility Constraints — "Support for a load testing tool MUST be expressible as
+    data" widened to "Support for any target", naming both classes. Widened rather than
+    duplicated: a parallel bullet saying nearly the same thing is what spec 001 § FR-011
+    forbids.
+  - Governance → Compliance review — "five principles above" → "eight".
+
+Grandfather clause, stated in VIII rather than hidden: `docs/semconv/loadtest.md` and the
+`errorSignal` sketch in `docs/examples/mapping-k6.yaml` both practise labelling without
+containment and predate this amendment. VIII binds work admitted after 2026-08-18.
 
 Templates and docs reviewed:
-  ✅ .specify/templates/plan-template.md   — "Constitution Check" filled with the five
-                                             concrete gates below (was a placeholder)
-  ✅ .specify/templates/spec-template.md   — no change needed; it is stack-agnostic and
-                                             adds no constraint the constitution contradicts
-  ✅ .specify/templates/tasks-template.md  — no change needed; task categories are generic.
-                                             Revisit when an implementation exists and
-                                             Principle V starts generating schema tasks
-  ✅ AGENTS.md                             — no change needed; it is the runtime process
-                                             guide and the constitution now points at it
-                                             rather than restating it
-  ✅ README.md, docs/                      — no change needed; the principles were derived
-                                             from them, not imposed on them
+  ✅ .specify/templates/plan-template.md   — stale pointer "(v1.0.0)" corrected to
+                                             "(v1.1.0)"; three Constitution Check gates
+                                             added for VI, VII and VIII
+  ✅ .specify/templates/spec-template.md   — no change needed; the added principles impose
+                                             no new mandatory spec section, and all three
+                                             are checked at plan time
+  ✅ .specify/templates/tasks-template.md  — no change needed; task categories stay generic
+  ✅ .specify/templates/checklist-template.md — no change needed
+  ✅ AGENTS.md                             — no change needed; VII generalises its
+                                             Spec-first rule rather than restating it
+  ✅ docs/                                 — no change needed; VI cites compatibility.md
+                                             § Layering, which already says it
 
-Deferred / TODO: none. RATIFICATION_DATE is today because this is the first adoption;
-there is no earlier date to recover.
+Citations, each resolvable by file and section without reading git history:
+  VI   → docs/compatibility.md § Requirements for the Go implementation → Layering
+  VII  → AGENTS.md § Commits & PRs (Spec-first), co-cited with Principle I's ordering rule
+  VIII → Principle III's "Any artifact nothing validates MUST say so in its own text",
+         which grounds the notice half; the containment half is new, which is why the
+         grandfather clause exists.
+
+Deferred / TODO: whether the compatibility-surface list should also cover names the format
+defines under `loadtest.*` — currently it covers only names the format *borrows*. Argued in
+specs/001-nfr-format-architecture/research.md § D4b; not taken here because it may exceed
+MINOR.
 -->
 
 # OpenNFR Constitution
@@ -115,6 +128,70 @@ contributions and, worse, invites someone to build against names that will chang
 every backend that reads it — and it never is. This is precisely where the string-DSL
 formats surveyed in `docs/references.md` fail.
 
+### VI. Evaluation Is Target-Blind
+
+The component that turns measurements into verdicts is the only thing standing between one
+document and one meaning. It stays blind, or the meaning becomes the tool's.
+
+- The component that produces verdicts MUST NOT know which target produced the measurements,
+  nor how they were obtained.
+- A statistic a target computed for itself MUST NOT be consumed as a verdict. Verdicts are
+  computed from normalised series under canonical names.
+- How a target derives a percentile MUST be recorded alongside any result that rests on it.
+- A measurement taken at one vantage point MUST NOT stand in for one taken at another. A gap
+  is declared, never filled by the nearest available number.
+
+**Rationale**: `docs/compatibility.md` § Requirements for the Go implementation → Layering
+already says it — "the evaluation layer knows nothing about tools or sources" — and calls that
+"the only reason the format can promise compatibility with an arbitrary tool". But that section
+is a proposal and nothing is built against it yet, which is exactly when the rule is cheap to
+fix. The moment a verdict depends on a tool's own arithmetic, one document stops meaning one
+thing and every portability claim the format makes is void.
+
+### VII. Architecture Before Implementation
+
+- Every change that adds or alters a component MUST name the architectural role it fills, and
+  MUST stay inside it.
+- A specification that needs a role the architecture does not have MUST amend the architecture
+  first, in an earlier pull request. Diverging from it silently is FORBIDDEN.
+- Implementation MUST NOT arrive ahead of the specification that names its role.
+- Amending the architecture MUST NOT require a decision record. It is not a
+  compatibility-sensitive surface, and the sanctioned route has to stay cheaper than the
+  workaround, or people take the workaround.
+
+**Rationale**: `AGENTS.md` § Commits & PRs already orders the artifacts — "**Spec-first.**
+`specs/NNN-*/` artifacts → `docs(speckit): add NNN-<feature> spec/plan/tasks` commit BEFORE any
+`feat`/`fix`. Never folded into implementation." — and Principle I orders the vocabulary the
+same way. This generalises both from a commit rule into a design rule. Deciding the
+architecture and the implementation in one pass is how a design notebook becomes a codebase
+nobody can argue with: the architecture stops being reviewable the moment it arrives attached
+to working code.
+
+### VIII. Experiments Are Parked, Not Merged
+
+Unsettled work is contained. A notice on something load-bearing is not containment — but a
+notice on something already contained is exactly what Principle III requires, so the two rules
+meet here rather than compete.
+
+- Work whose correctness is not yet established MUST live in the experimental area and MUST
+  NOT enter a compatibility-sensitive surface.
+- Every artifact in that area MUST state, in its own text, that it is experimental, what would
+  promote it, what would retire it, and the date the statement was last true.
+- The experimental area MUST be removable in one operation without changing anything outside
+  it, and nothing outside it may link into it.
+- This principle binds work admitted **after 2026-08-18**. Two artifacts predate it and are
+  grandfathered: `docs/semconv/loadtest.md`, an unsubmitted upstream proposal that core
+  constructs already depend on, and the `errorSignal` sketch in
+  `docs/examples/mapping-k6.yaml`. Both carry the notice Principle III requires. Neither may
+  be cited as precedent for admitting new unsettled work.
+
+**Rationale**: the failure this prevents is "it mostly works, call it v1" — a four-query-language
+experiment with four different percentile implementations treated as settled because it is
+nearly right. The grandfather clause is written down rather than hidden because two committed
+artifacts already practise labelling without containment, and a principle that made them
+retroactively non-compliant on the day it shipped would be a rule the repository breaks on
+arrival.
+
 ## Compatibility Constraints
 
 Compatibility-sensitive surfaces, which MUST NOT change without an ADR:
@@ -130,9 +207,10 @@ Binding constraints:
   format silently excludes every tool that cannot assert inline.
 - Requirement documents MUST remain portable across observability stacks. The data
   source is a parameter of evaluation, never part of the requirement.
-- Support for a load testing tool MUST be expressible as data, not as code in the
-  reference implementation. A tool list that only maintainers can extend is not
-  tool-agnostic.
+- Support for any target MUST be expressible as data, not as code in the reference
+  implementation. This covers both classes: a load generator that produces the traffic, and a
+  monitoring backend that holds telemetry and answers a query. A target list that only
+  maintainers can extend is not tool-agnostic.
 
 ## Development Workflow
 
@@ -166,7 +244,7 @@ same issue/milestone/linkage rules as every other change.
 - PATCH — clarification, rewording, or a fix that changes no obligation.
 
 **Compliance review**: `/speckit-plan` MUST evaluate its Constitution Check against the
-five principles above before Phase 0 research and again after Phase 1 design. PR review
+eight principles above before Phase 0 research and again after Phase 1 design. PR review
 MUST verify compliance; a violation is either fixed or the constitution is amended, but
 never silently accepted. Complexity that appears to require a violation MUST be
 justified in writing in the plan's Complexity Tracking section.
@@ -174,4 +252,4 @@ justified in writing in the plan's Complexity Tracking section.
 **Runtime guidance**: `AGENTS.md` for process, `docs/GLOSSARY.md` for vocabulary,
 `docs/adr/` for why any of it is the way it is.
 
-**Version**: 1.0.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-10
+**Version**: 1.1.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-18

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -41,7 +41,7 @@
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 Answer each gate explicitly. A "no" is either fixed or justified in Complexity Tracking
-below — never left blank. See `.specify/memory/constitution.md` (v1.0.0).
+below — never left blank. See `.specify/memory/constitution.md` (v1.1.0).
 
 - [ ] **I. Vocabulary Before Features** — does this feature introduce or rename a term?
       If so, is `docs/GLOSSARY.md` updated in the same change, with a rejected
@@ -57,6 +57,17 @@ below — never left blank. See `.specify/memory/constitution.md` (v1.0.0).
 - [ ] **V. Structure Over Grammar** — is every new field validatable by schema without a
       bespoke parser? Are value sets closed? Does anything need custom decoding, and is
       that justified in an ADR?
+- [ ] **VI. Evaluation Is Target-Blind** — does anything here let the component that
+      produces verdicts learn which target supplied the measurements, or consume a statistic
+      a target computed for itself? Is percentile provenance recorded? Is any measurement
+      from one vantage point standing in for another?
+- [ ] **VII. Architecture Before Implementation** — does every component this adds or alters
+      name the architectural role it fills? If it needs a role the architecture lacks, does
+      an earlier PR amend the architecture rather than diverging from it?
+- [ ] **VIII. Experiments Are Parked, Not Merged** — is any unsettled work entering a
+      compatibility-sensitive surface? Does every experimental artifact state its status,
+      promotion and retirement conditions, and the date? Is the experimental area still
+      removable in one operation, with nothing outside linking into it?
 - [ ] **Compatibility** — does this touch a borrowed OTel name, a published example's
       field name, or the conformance levels? Is any construct expressible only at
       conformance level `assert` or above?

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ alternatives and the reasons.
 | | |
 |---|---|
 | [docs/GLOSSARY.md](docs/GLOSSARY.md) | candidate vocabulary, with rejected synonyms |
+| [docs/architecture.md](docs/architecture.md) | how a requirement becomes an outcome, and three worked walkthroughs |
+| [docs/layout.md](docs/layout.md) | where every kind of thing lives, and how to add a tool |
 | [docs/adr/0001-terminology.md](docs/adr/0001-terminology.md) | naming arguments, in ADR form (status: proposed) |
 | [docs/adr/0002-compatibility.md](docs/adr/0002-compatibility.md) | notes on a Go implementation and tool compatibility |
 | [docs/compatibility.md](docs/compatibility.md) | what tools actually emit — checked, factual |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -26,9 +26,13 @@ strict about — though the boundaries below are drawn by argument, not by exper
     ┌────────────────────┐      ┌──────────────┐      ┌────────────────────────┐
     │ Requirement        │──────│  Assertion   │      │ Verdict → Outcome      │
     │   └─ Criterion     │ render               evaluate                        │
-    │   └─ Guard         │──────│ (k6/Gatling) │──────│ EvaluationReport       │
+    │   └─ Guard         │──────│    Target    │──────│ EvaluationReport       │
     └────────────────────┘      └──────────────┘      └────────────────────────┘
 ```
+
+The runtime box faces a [Target](#target) — a load generator (k6, Gatling, JMeter) or a
+monitoring backend (Prometheus, Datadog). Both classes are supported the same way: by adding
+data, never code.
 
 ---
 
@@ -244,6 +248,35 @@ Gatling, a post-processor in JMeter.
 is a generated artifact, not a source of truth. The moment it enters the format, the format
 is nailed to one tool's semantics. This is the single strongest constraint the notes have
 produced so far, and the one most likely to hold.
+
+### Target
+
+The external product an adapter faces. Two classes, supported identically — by adding data,
+never by adding code:
+
+- a **load generator** produces the traffic and reports what happened (k6, Gatling, JMeter);
+- a **monitoring backend** holds telemetry, answers a query, and can host a standing monitor
+  (Prometheus, Datadog).
+
+A target never reads a requirement document. It is reached through a
+[MetricMapping](#metricmapping), and only the load-generator class is ever handed native
+assertions — at [conformance level](#conformance-level) `assert` and above.
+
+A target faces **outward**: it receives a rendered artifact or an assembled query. That is the
+opposite direction from a *data source*, which faces inward and supplies normalised series to
+evaluation, and which [ADR-0002 § D18](adr/0002-compatibility.md) keeps a parameter of
+evaluation rather than a property of a requirement. One product may play both roles in one
+run — Prometheus is the obvious case — in which case it is named by the role it is playing.
+
+`monitoring backend` is defined here rather than in an entry of its own because `backend`
+already carries a different sense in this glossary: in [enforcement](#enforcement) and in
+[EvaluationReport](#evaluationreport) it is the thing that evaluates after the run. The two
+must never be read as one.
+
+Rejected: `consumer` — [AGENTS.md](../AGENTS.md) uses it for everything downstream of the
+format, CI backends and human readers included, which is far wider than this. `tool` —
+excludes the monitoring class, and the entire point of the word is that both classes are
+supported the same way. `backend` on its own — collides, as above.
 
 ### Adapter
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,15 @@ Working notes towards a format for load testing requirements. See the
 considered and dropped. The rest of the notes assume its vocabulary, so it is the cheapest
 way in.
 
+**[architecture.md](architecture.md)** — how a requirement becomes an outcome, what each
+component on that path may not know, and the same example document walked through for k6,
+Gatling and JMeter. Every clause says whether it binds later work or merely describes
+something unbuilt.
+
+**[layout.md](layout.md)** — one home per artifact class, what changing each obliges, what is
+currently mis-filed, and the procedure for adding support for a tool without touching the
+normative core.
+
 ## What is actually verified
 
 Two documents contain checked facts rather than opinion, and they are the parts worth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,316 @@
+# Architecture
+
+How a requirement becomes an outcome, what each component on that path may not know, and how
+the format reaches a tool at all.
+
+## Status of this document
+
+This document carries **two statuses at once**, and every clause and table row below says which
+one applies to it. Nothing is unmarked.
+
+| Marker | Meaning |
+|---|---|
+| **(binding)** | Later specifications must obey it. Component roles, their forbidden dependencies, and the boundaries between follow-up specs |
+| **(proposed)** | Describes something that does not exist yet. True of every component named here — none is built |
+
+The split is not decoration. [Principle IV](../.specify/memory/constitution.md) forbids a
+document from reading as more settled than it is, while a rule nobody must follow is not worth
+writing. Roles bind; the machinery that would fill them is proposed.
+
+**Amending this document** *(binding)*: an ordinary pull request that edits it, landing
+**before** the specification that diverges from it. No decision record is required — this
+document is not a compatibility-sensitive surface. The sanctioned route is deliberately cheaper
+than the workaround, because a route more expensive than the workaround is not a route.
+
+---
+
+## 1. The path
+
+A requirement is written once, by a human, and names no tool. Everything else happens to it.
+
+```text
+requirement ── criterion ──> verdict ──> gate ──> outcome
+     │             │            ▲                    │
+     │             │            │                    └─ what a CI job prints
+     │             └─ rendered into a target's native form (R2)
+     └─ parsed into an object model (R1)
+                                │
+        a target's raw output ──┴── normalised into series (R3), evaluated (R4)
+```
+
+1. *(binding)* The path ends at **outcome**, not at verdict. A `Verdict` is the result of
+   checking one criterion or guard; an `Outcome` is the aggregated result of the whole run.
+   A trace that stops at verdict stops one component short of `gate`. See
+   [GLOSSARY.md](GLOSSARY.md).
+2. *(binding)* No role may read the requirement document to discover its data source. The
+   source is a parameter of evaluation, never a property of the requirement —
+   [ADR-0002 § D18](adr/0002-compatibility.md).
+3. *(binding)* No construct may be checkable only while a run is in progress. Anything
+   expressible must also be evaluable afterwards, or the format silently excludes every tool
+   that cannot assert inline. This is already a ratified constitutional constraint.
+
+---
+
+## 2. The four component roles
+
+Roles are contracts, not modules. Two of them — Render and Ingest — are **sub-roles of the
+glossary's `Adapter`**, not rivals to it: the glossary already defines an `Adapter` as doing
+four jobs, of which rendering assertions is one and collecting a tool's output is another.
+Introducing a competing decomposition of the same pipeline is what
+[Principle I](../.specify/memory/constitution.md) forbids.
+
+The original request called these *interpreters*. In this repository's vocabulary that word is
+`Adapter`; `interpreter` is not used.
+
+| # | Role | Input | Output | MUST NOT know | Status |
+|---|---|---|---|---|---|
+| R1 | Parse | One document | An object model, or a parse error naming the field and its line | Which target will consume the result | **binding** |
+| R2 | Render *(Adapter)* | Criteria + one tool mapping | The target's native artifact, **plus a named list of every criterion it could not render** | Whether the run will pass | **binding** |
+| R3 | Ingest *(Adapter)* | A target's raw output + one tool mapping | Normalised series under canonical names, in canonical units | What the criteria say | **binding** |
+| R4 | Evaluate | Normalised series, criteria, guards, `gate` | One verdict per criterion and guard, then one outcome | Which target produced the measurements, or how | **binding** |
+
+**R4 is [Principle VI](../.specify/memory/constitution.md)** *(binding)*, and it is the only
+reason one document can mean one thing across many targets. Its sharpest consequence: a
+statistic the target already computed — k6's own p95 — must not be consumed as a verdict. The
+moment it is, the verdict depends on that tool's percentile machinery.
+
+**R3 is where units are converted** *(binding)*. The survey records tools reporting
+milliseconds where semantic conventions require seconds. An error here is three orders of
+magnitude wide and produces a confident, wrong, green result, which is why the conversion is
+declared in the mapping rather than left to whoever implements the role.
+
+**Naming** *(binding)*: R3 is the **file adapter** where it reads files. It is not called a
+*reader* — in this project's documents `reader` means a human.
+
+### What no role may do
+
+4. *(binding)* A criterion is either rendered or reported unrenderable **by criterion
+   identity**. Dropping one silently is forbidden: a dropped criterion is a check that never
+   ran and a result that looks clean.
+5. *(binding)* When a target cannot honour a construct, the result is a **named failure** —
+   never a substitution, an approximation, or a silent omission. The gap is declared in the
+   mapping and surfaces at render time, before the run rather than after it.
+6. *(binding)* A measurement taken at one vantage point may not stand in for one taken at
+   another. A load generator measures latency as a client; a production stack usually measures
+   it as a server. The numbers are not comparable.
+7. *(binding)* Missing data produces `noData` and a violated guard produces `inconclusive`.
+   Neither is a pass. [Principle III](../.specify/memory/constitution.md).
+
+---
+
+## 3. Targets
+
+*(binding)* A **target** is the external product an adapter faces. Two classes, supported
+identically — by adding data, never by adding code:
+
+| Class | What it does | Can host assertions? | Status |
+|---|---|---|---|
+| Load generator | Produces the traffic and reports what happened | Sometimes, at conformance level `assert` and above | **binding** |
+| Monitoring backend | Holds telemetry, answers a query, can host a standing monitor | Not applicable — see § 6 | **proposed** |
+
+The full definition, including why `monitoring backend` is defined inside the `Target` entry
+rather than on its own, is in [GLOSSARY.md](GLOSSARY.md). A target faces **outward**; a
+*data source* faces inward and supplies normalised series to R4. One product may play both
+roles in one run, in which case it is named by the role it is playing. This document cites
+[ADR-0002 § D18](adr/0002-compatibility.md) for `data source` rather than redefining it.
+
+---
+
+## 4. Three walkthroughs
+
+*(proposed — none of the machinery exists; the tool facts are dated)*
+
+One document, unchanged in every character:
+[examples/checkout-perf.yaml](examples/checkout-perf.yaml). It carries five requirements, two
+guards, and a `gate`. Every tool statement below comes from this repository's own survey in
+[compatibility.md](compatibility.md), *"Verified against documentation as of August 2026"*, or
+from the mapping sketches in `examples/`. Nothing here is asserted from outside those files.
+
+### 4.1 k6 — the best case
+
+Conformance **`abort`**: OTLP output built in, native `thresholds`, `abortOnFail`.
+
+| Requirement | R2 renders | R3 ingests | Result |
+|---|---|---|---|
+| `checkout-throughput` | `rate` over the histogram count | `k6_http_req_duration` → `http.client.request.duration`, **ms → s** | works |
+| `checkout-latency` p95/p99 | `p(95)`, `p(99)` thresholds; `onViolation: abort` → `abortOnFail` | same metric | works |
+| guard `generator-not-saturated` | — (guards are evaluated post-run) | `k6_dropped_iterations` → `loadtest.dropped_iterations` | works |
+| `checkout-error-rate` | **cannot render** | `k6_http_req_failed` via `errorSignal` | **gap** |
+| `no-latency-regression` | **cannot render** | — | **gap** |
+
+**Declared gaps** *(binding that they are declared, proposed how)*:
+
+8. *(binding)* The ratio indicator cannot become a k6 threshold. `mapping-k6.yaml` renders selectors as k6
+   tags (`selectorAs: tag`), and `error.type` is not a tag — it is derived from a separate
+   metric through `errorSignal`. Evaluation post-run is unaffected; only the inline rendering
+   is impossible. Per clause 4, R2 reports it rather than dropping it.
+9. *(binding)* `http.route` is not emitted by k6. The mapping carries k6's `name` tag to
+   `loadtest.request.name`, and reconstructing a route needs `routeHints` — a field of
+   `kind: MetricMapping` sketched in `examples/mapping-jmeter.yaml`, not specific to JMeter.
+   Requirements written against `loadtest.request.name` do not travel between tools.
+
+### 4.2 Gatling — the case with a named customer and no mapping
+
+Conformance **`assert`**: native `assertions`, **no abort**, and OTLP only in the Enterprise
+Edition — the open-source build goes through `simulation.log`.
+
+10. *(binding)* **There is no `mapping-gatling.yaml`.** `examples/` holds mappings for k6 and JMeter only.
+    This walkthrough is therefore traced from the survey alone, and producing the mapping is the
+    first deliverable of the `target-gatling` follow-up specification. Until it exists, no
+    criterion in the example document can actually be rendered for Gatling.
+
+| Construct | Status against the survey |
+|---|---|
+| Latency, throughput | Response time is recorded; canonical naming needs the missing mapping |
+| `onViolation: abort` | **Impossible** — the survey records Abort: `no` for Gatling |
+| guard on `loadtest.dropped_iterations` | **No equivalent** — the mapping table in [semconv/loadtest.md](semconv/loadtest.md) records an em-dash |
+| Error signal | `KO` carries it |
+| `http.route` | Reconstructed by an adapter, per the survey — which does not exist yet |
+
+### 4.3 JMeter — the worst case, and still complete
+
+Conformance **`report`**: no OTLP output, no native assertions, no abort. The path is JTL files
+through R3.
+
+11. *(binding)* `report` is **not a degraded mode**. Every requirement in the example document
+    is evaluable after the run: R2 renders nothing, reports all criteria as unrenderable per
+    clause 4, and R4 produces the same verdicts it would for k6. `assert` and `abort` shorten
+    the feedback loop; they add no expressiveness. This is why the format may contain no
+    construct expressible only at `assert` or above.
+
+| Construct | Status |
+|---|---|
+| Latency | `elapsed` (**ms**), `Latency` ≈ TTFB only |
+| `http.request.method` | **Not in the mapping** — `mapping-jmeter.yaml` maps `label`, `responseCode` and `URL` only. `checkout-latency`'s method selector cannot be satisfied as mapped |
+| `http.route` | Via `routeHints`, manually maintained |
+| `loadtest.dropped_iterations` | **No equivalent** |
+| Native assertions, abort | **None** |
+
+### 4.4 What the walkthroughs expose about the example itself
+
+*(binding that these are declared; each needs its own issue — fixing them changes the format,
+which this feature does not do)*
+
+12. *(binding)* **`overall-availability` can produce a silent RED.** A run in which nothing fails yields no
+    series carrying `error.type`, hence `noData`, hence `onNoData: fail`. The run fails because
+    the system was perfect.
+13. *(binding)* **An unmeasurable guard fails for the wrong reason.** Gatling and JMeter cannot measure
+    `loadtest.dropped_iterations`, so the guard lands on `onNoData: fail` rather than
+    `onGuardViolation: inconclusive`, and a tool limitation reads as a system failure.
+14. *(binding)* **`skipped` has no gate key.** It appears in the status enum and in the report sketch, but
+    no `gate` key handles it. Silence is undefined behaviour in a project whose Principle III
+    forbids exactly that.
+15. *(binding)* **`indicatorRef: checkout-latency` points at a Requirement name**, while ADR-0001 § D10 and
+    the glossary describe `Indicator` as a reusable kind of its own.
+16. *(binding)* **Two constructs are satisfiable by no tool in the survey**: `window.phase` rests on
+    `loadtest.phase`, which nothing emits, and `baseline: previousPassed` needs stored history
+    no load generator provides. Both are core constructs with a published dependency.
+
+---
+
+## 5. Support is data
+
+17. *(binding)* Support for any target is added as **data** — a `kind: MetricMapping` document
+    — and requires changing no normative-core artifact and no reference implementation. This is
+    [ADR-0002 § D12](adr/0002-compatibility.md), generalised to both target classes by
+    [the constitution's Compatibility Constraints](../.specify/memory/constitution.md).
+18. *(binding)* A mapping declares what its target **cannot** do. An undeclared gap is a defect
+    of the mapping, not of the format.
+
+---
+
+## 6. The monitoring direction
+
+19. *(proposed, and explicitly unverified — dated 2026-08-18)* The same requirement document is
+    claimed to reach a monitoring backend: a query that returns the canonical measurement, and
+    that backend's native monitoring definition for the same criterion, across Datadog,
+    Prometheus, VictoriaMetrics and InfluxDB.
+
+**This claim has not been verified and nothing here demonstrates it.** No committed file in
+this repository mentions any of those four products. The claim is owned by the parked
+monitoring follow-up specification, whose status page lives at `docs/experimental/README.md`
+and carries its promotion and retirement conditions. That area is outside the
+compatibility-sensitive surface, holds markdown only, and **nothing outside it links into it** —
+which is what makes it removable in one operation.
+
+20. *(binding)* Preconditions about the load generator do not survive the crossing. A guard on
+    `loadtest.dropped_iterations` is not applicable to production telemetry and must be reported
+    as such by name, never silently dropped so the requirement can be evaluated without it.
+
+
+---
+
+## 7. The follow-up specifications
+
+*(binding — later specifications must stay inside the boundaries below; a specification that
+needs a role this document does not have amends this document first)*
+
+21. *(binding)* Entries are named by **slug, never by ordinal**. `specs/NNN-` records the order
+    specifications were *created*, not the order they must be *completed* —
+    `001-nfr-format-architecture` already sets a numbering a reader will otherwise read as a
+    schedule. Order comes from the dependency graph in § 7.2 and from nothing else.
+22. *(binding)* The unit of claim is an **individual file**, not an artifact class. Several
+    entries legitimately add to the normative core; no two claim the same file.
+
+### 7.1 The entries
+
+| Slug | Delivers | Depends on | Role | Scheduling |
+|---|---|---|---|---|
+| `core-schema` | `schema/opennfr.io/v1/common.schema.json`, `requirementset.schema.json`, `indicator.schema.json`, `evaluationreport.schema.json`, one ADR fixing the field names | — | Substrate for all four roles | scheduled |
+| `mapping-schema` | `schema/opennfr.io/v1/metricmapping.schema.json` | `core-schema` | Substrate for R2 and R3 | scheduled |
+| `object-model` | The reference parser and its type declarations; `docs/object-model.md` | `core-schema` | **R1 Parse** | scheduled |
+| `ingest` | The normalised-series contract and the file adapter | `object-model`, `mapping-schema` | **R3 Ingest** | scheduled |
+| `evaluation` | The verdict and gate engine; `docs/evaluation.md` | `object-model` | **R4 Evaluate** | scheduled |
+| `renderer` | The criterion-to-native-artifact renderer and its unrenderable report | `object-model`, `mapping-schema` | **R2 Render** | scheduled |
+| `target-gatling` | `mappings/gatling.yaml`, `docs/targets/gatling.md` | `renderer` | A target, as data | scheduled — **serves the named customer** |
+| `target-k6` | `mappings/k6.yaml`, `docs/targets/k6.md` | `renderer` | A target, as data | scheduled |
+| `target-jmeter` | `mappings/jmeter.yaml`, `docs/targets/jmeter.md` | `ingest` | A target, as data | scheduled |
+| `conformance-corpus` | `conformance/` — documents paired with the outcome any conforming consumer must reach | `core-schema`, `evaluation` | Cross-cutting; also the first artifact able to detect cross-repository drift | scheduled |
+| `monitoring-experiment` | Everything under `docs/experimental/` | `core-schema` | Second target class | **parked — no position, see § 7.4** |
+
+`docs/README.md` says the next step is *"A JSON Schema for the requirement and result
+documents"*. That names `core-schema` exactly, and it stays true: it is first in dependency
+order, and the other ten were always implied by it, because a schema with nothing reading it
+changes nothing.
+
+### 7.2 The dependency graph
+
+```text
+001 (this feature)
+ ├─> core-schema
+ │    ├─> mapping-schema ──┐
+ │    ├─> object-model ────┼─> ingest ──────> target-jmeter
+ │    │      ├─────────────┴─> renderer ────> target-gatling
+ │    │      │                          └───> target-k6
+ │    │      └─> evaluation ─┐
+ │    └────────────────────  ┴─> conformance-corpus
+ └─> monitoring-experiment   (parked)
+```
+
+Nothing in that graph is a schedule. `target-gatling` sits three edges deep and is still the
+entry that should be started first, because it is the only one with a counterparty waiting.
+
+### 7.3 The answer owed to the named customer
+
+23. *(binding)* `gatling-picatinny` is removing `assertionFromYaml` in 2.0 and has recorded
+    that a replacement decision is needed. The entry that serves it is `target-gatling`, and
+    the answer is **two-part**, because a decision that blocks a 2.0 release on work that does
+    not exist is not an answer:
+    - picatinny 2.0 removes `assertionFromYaml` **without** a one-to-one replacement, and its
+      migration note documents that assertions are written with Gatling's native DSL. That
+      unblocks 2.0 immediately.
+    - The same migration note names OpenNFR's `target-gatling` as the intended successor once
+      `renderer` lands, so the removal is a deprecation with a destination rather than a hole.
+
+    The first deliverable of `target-gatling` is the Gatling mapping that does not exist today
+    — see clause 10.
+
+### 7.4 The parked entry
+
+24. *(proposed, unverified, dated 2026-08-18)* `monitoring-experiment` carries **no schedule
+    position** — no milestone, no "after X". In its place it carries promotion conditions,
+    retirement conditions and a date, all published in its own status page at
+    `docs/experimental/README.md`. Promotion requires one unchanged requirement document
+    assembling a valid query for **all four** named backends, each check dated and sourced.
+    Three of four is not promotion; it is a narrower scope, and narrowing amends this document
+    first.

--- a/docs/experimental/README.md
+++ b/docs/experimental/README.md
@@ -1,0 +1,78 @@
+# Experimental area
+
+**Status: experimental. Last true: 2026-08-18.**
+
+Nothing here is part of the format. Nothing here is on a compatibility-sensitive surface.
+Everything here can be deleted in one operation without changing anything outside this
+directory — and if that ever stops being true, this area has failed at the one thing it exists
+to do.
+
+## Rules for this directory
+
+1. **Nothing outside this directory may link into it.** Outside references name a path in
+   prose, inside a code span, never as markdown link syntax. `scripts/verify.sh` fails the
+   build on any dangling internal link, so a single inbound link would turn the removal test
+   red.
+2. **Markdown only, no YAML.** This keeps the area clear of the sketch-label check, which is
+   hardcoded to `docs/examples/*.yaml`.
+3. **Every file states its own status**, what would promote it, what would retire it, and the
+   date the statement was last true.
+
+The removal test, which is a command rather than an aspiration:
+
+```bash
+git rm -r docs/experimental && bash scripts/verify.sh
+```
+
+Expected: `PASS`.
+
+---
+
+## What is parked here
+
+### The monitoring direction
+
+**Status**: experimental, unverified, unscheduled. **Owner**: the `monitoring-experiment`
+follow-up specification. **Last true**: 2026-08-18.
+
+The claim: one requirement document, unchanged in every character, can be turned into both a
+query that returns the canonical measurement and a native monitoring definition, for Datadog,
+Prometheus, VictoriaMetrics and InfluxDB — four query languages, one markup.
+
+**Nothing in this repository verifies any part of that.** No committed file mentions any of the
+four products. The claim is stated so it can be argued with, not because it is believed.
+
+Three unknowns are why it is parked rather than scheduled:
+
+- **Four percentile machineries.** Prometheus and VictoriaMetrics interpolate from fixed
+  histogram buckets, Datadog uses a sketch, InfluxDB depends on how the data was written. The
+  same criterion can pass on one and fail on another with identical underlying traffic.
+- **A change of vantage point.** A load generator measures latency as a client; a production
+  stack usually measures it as a server. The two numbers are not comparable, and letting one
+  stand in for the other is the failure the whole format exists to prevent.
+- **Constructs that do not cross.** A guard about the load generator has no meaning against
+  production traffic, and run phases do not exist there.
+
+**Promotion conditions** — all must hold before any part of this leaves this directory:
+
+1. One requirement document, unchanged, assembles a query the backend's own documentation
+   confirms is valid, for **all four** backends. Three of four is not promotion; it is a
+   narrower scope, and narrowing amends the architecture first.
+2. Each of those four checks is dated and sourced, per Principle IV.
+3. The query-assembly vocabulary is declared as structure, validatable without a bespoke
+   parser, and does not embed a backend's query language as free text — Principle V.
+4. Every construct that cannot cross is listed by name, with what happens when it is
+   encountered.
+5. Supporting the direction adds at most one new document kind to the format.
+
+**Retirement conditions** — any one is sufficient:
+
+- No conforming query can be assembled for two or more of the four backends without an embedded
+  query string, which Principle V forbids.
+- The vocabulary needed to serve all four turns out to be a per-backend template set, in which
+  case it is not one markup and the premise is dead.
+- Twelve months pass with no promotion condition met.
+
+Deleting this direction requires changing nothing in the normative core, nothing in any tool
+mapping, and nothing in the conformance corpus. That property is the point of the area, and it
+is checked by the command above.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,0 +1,134 @@
+# Repository layout
+
+Where every kind of thing lives, who may change it, and what changing it obliges.
+
+If you are here to add support for a load generator, you need § 5 and nothing else.
+
+## 1. The classes
+
+`specs/` is **not** an artifact class. It is the spec-kit working directory, and the flow is
+one-directional: a follow-up specification writes artifacts into the homes named below, and
+never becomes one.
+
+| Class | Home | Who may change it | Changing it obliges | On the compatibility surface |
+|---|---|---|---|---|
+| Normative core | `docs/` top level, plus `docs/semconv/` | Anyone, by pull request | A term change updates [GLOSSARY.md](GLOSSARY.md) in the same PR with a rejected alternative; a naming disagreement is argued in an issue **before** files change; a change to a compatibility-sensitive surface requires an ADR | Partly — see § 4 |
+| Decision records | `docs/adr/NNNN-slug.md` | Anyone, by pull request | A PR that contradicts an ADR amends that ADR instead; status stays `proposed` until something validates or implements it | No |
+| Tool mappings | `mappings/` | Anyone, by pull request | The claimed conformance level is evidenced and dated; every gap the target cannot honour is declared | No — but the conformance ladder itself is |
+| Conformance corpus | `docs/examples/` | Anyone, by pull request | Every file announces itself as a sketch in its first six lines, until a schema validates it | Field names in published examples are |
+| Experimental area | `docs/experimental/` | Anyone, by pull request | Self-labelling with status, promotion and retirement conditions and a date; nothing outside links in; markdown only | **No, by construction** |
+| Reference implementation | Declared, not created | Anyone, by pull request | — | No |
+
+**Why the third column is uniform.** It reads the same in every row on purpose. The
+constitution already forbids a surface only maintainers can extend — *"A target list that only
+maintainers can extend is not tool-agnostic"* — and no other class has a reason to be narrower.
+Classes differ by what a change **obliges**, not by who may propose it. No role vocabulary is
+introduced here, because [Principle I](../.specify/memory/constitution.md) prices every added
+governance word and a role taxonomy would buy nothing mechanical.
+
+**The one place "anyone" needs help.** `scripts/check-linkage.sh` gates every pull request on a
+milestone **and** a registered closing link to an issue in that milestone, and an outside
+contributor cannot normally set a milestone on a fork's pull request. A maintainer opens the
+issue and sets the milestone on the contributor's behalf, as part of first review. Without that
+sentence the uniform column is theatre.
+
+### The normative core includes an unratified proposal
+
+`docs/semconv/loadtest.md` is filed in the normative core, not in the experimental area, and
+the class definition is widened by exactly one clause to say so:
+
+> The normative core includes the `loadtest.*` registry — the only core artifact whose
+> **upstream** status is unratified. It must state that status in its own dated text, as it
+> already does.
+
+Filed in the experimental area instead, the one-operation removal test would be false on day
+one: `window.phase` rests on `loadtest.phase`, and the fallback addressing rests on
+`loadtest.request.name`. [Principle II](../.specify/memory/constitution.md) already licenses
+`loadtest.*` names as first-class; [Principle IV](../.specify/memory/constitution.md) requires
+the unsubmitted status to be stated, not the artifact to be quarantined.
+
+## 2. Governance vocabulary
+
+These words describe the repository, not the format. They are defined here rather than in the
+glossary, which is the format's three-layer vocabulary and does not gain a fourth layer. A word
+that collides with one already in the glossary is settled **there** instead, where the collision
+is visible — that is why `target` and `monitoring backend` are in [GLOSSARY.md](GLOSSARY.md)
+and not below.
+
+| Word | Meaning | Rejected |
+|---|---|---|
+| **artifact class** | A kind of thing the repository holds, with exactly one home and one rule for changing it | `artifact type` — `type` already names a parsing concern and appears in the format as `error.type` |
+| **home** | The single directory an artifact class lives in | `owner` — conflates location with permission, which is a separate column |
+| **normative core** | The class later specifications must obey | `spec` — the repository is explicit that it is not one yet |
+| **compatibility-sensitive surface** | The published set of things that cannot change without a decision record | `public API` — there is no API, and the phrase imports stability promises nothing here makes |
+| **experimental area** | The parked class, outside that surface and removable in one operation | `incubator` — implies a pipeline to graduation that nothing here operates |
+| **follow-up spec** | One concrete future task with a boundary and a dependency | `roadmap item` — implies a schedule; these carry dependencies, not dates |
+| **obligation** | What a change to a class requires of the person making it | `policy` — pulls towards OPA and rule engines |
+| **non-conformance list** | The published record of what is currently mis-filed | `tech debt` — invites deferral rather than disclosure |
+| **component role** | A named job on the path from requirement to outcome, defined by input, output and forbidden knowledge | `layer` — already used for the vocabulary's three layers, and roles are contracts rather than strata |
+| **tool mapping** | The data that binds the format to one target | `binding` — collides with `MetricMapping`, and `binding` is already load-bearing in this repository as an adjective meaning normative |
+| **file adapter** | The sub-role of `Adapter` that reads a target's output files | `reader` — in this repository's documents `reader` means a human, and two success criteria rest on that sense |
+
+## 3. What is currently mis-filed
+
+Published rather than fixed. [AGENTS.md](../AGENTS.md) forbids opportunistic refactors outside
+scope, so these move in their own pull requests — and each move carries an obligation that is
+cheaper to know now than to discover mid-rename.
+
+| Path | Belongs to | Why not moved now | The move's obligation |
+|---|---|---|---|
+| `docs/examples/mapping-k6.yaml` | Tool mappings | Linked from five other documents; a move turns `scripts/verify.sh` red across the tree | **`verify.sh`'s sketch-label check is hardcoded to `docs/examples/*.yaml`.** A mapping relocated to `mappings/` silently stops being checked until the script is extended. Extend it in the same PR |
+| `docs/examples/mapping-jmeter.yaml` | Tool mappings | Same | Same |
+| `docs/compatibility.md` | Three classes at once | Splitting it is a separate concern from publishing this layout | It spans conformance levels (normative), the dated tool survey (evidence) and the Go notes (proposal). A split must keep the survey's date attached to the survey |
+| `docs/references.md` | Evidence, which has no class | Inventing a class for one file costs a governance word | Either widen the normative core's definition or accept it as an unclassified note, stated as such |
+| `docs/units.md` | Normative core | Already correctly filed; listed because its status line predates the layout | Confirm it announces its own status |
+| `mappings/` | Tool mappings | The directory does not exist yet | Created by the first target follow-up specification, not by this document |
+
+## 4. The compatibility-sensitive surface
+
+This document does **not** republish the list. The constitution owns it, and a second copy is a
+copy that can drift — which the constitution's own supremacy clause makes wrong by definition.
+
+The authoritative list is in
+[the constitution's Compatibility Constraints](../.specify/memory/constitution.md). The
+per-class column in § 1 says whether a class touches it; the constitution says what "it" is.
+Extending the list is a constitutional amendment, not a layout change.
+
+## 5. Adding support for a target
+
+The whole point of the layout: this needs no permission and touches no normative-core file.
+
+1. Write one `kind: MetricMapping` document in `mappings/`, named for the target.
+2. Declare, at minimum: the correspondence between the target's names and canonical ones; the
+   unit conversion for each; the correspondence between the target's labelling and canonical
+   attributes; how the target signals a failed request; and how it derives percentiles.
+3. Declare the conformance level the mapping claims, and **the list of constructs the target
+   cannot honour**. An undeclared gap is a defect of the mapping, not of the format.
+4. Evidence the claimed level with a **dated manual verification against the target's own
+   documentation**, in the mapping's own annotations. This is what
+   [Principle IV](../.specify/memory/constitution.md) requires of every claim about an external
+   tool.
+5. Open a pull request. A maintainer attaches the milestone and the closing link if you cannot.
+
+**This procedure is unenforceable today, and says so.** There is no schema to validate the
+mapping against and no conformance corpus to run it through; both are follow-up specifications.
+Until they exist, review is by reading, and the dated evidence in step 4 is the only thing
+standing behind a conformance claim.
+
+Reviewing a submitted mapping means checking: every canonical name used by the reference example
+is covered or declared missing; every unit conversion is stated rather than implied; the claimed
+level matches what the evidence shows; and the gap list is not empty when the survey says it
+should not be.
+
+## 6. Cross-repository integrations
+
+A tool-native integration — a Gatling plugin, a k6 extension — lives in **that tool's own
+repository** and consumes this one. It never lives here.
+
+**This repository is authoritative** for the format, the vocabulary and the conformance levels.
+An integration that disagrees is wrong and is fixed there, not here.
+
+How drift becomes visible is deliberately unanswered: every detection mechanism is an
+executable artifact, and this feature ships none. Detection is assigned to the conformance-corpus
+follow-up specification, which is the first artifact capable of failing when an integration
+diverges.

--- a/specs/001-nfr-format-architecture/checklists/requirements.md
+++ b/specs/001-nfr-format-architecture/checklists/requirements.md
@@ -1,0 +1,90 @@
+# Specification Quality Checklist: Repository Architecture and Operating Principles
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-17
+**Last validated**: 2026-08-18, after the clarification session
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Clarification Session 2026-08-18
+
+An eight-lens ambiguity audit produced 47 raw candidates; consolidation rejected 23 as
+already answered in the constitution, `AGENTS.md`, the ADRs or the spec's own text, and
+ranked 8 survivors. Five were asked and integrated.
+
+| # | Decision | Landed in |
+|---|---|---|
+| 1 | Three load-generator walkthroughs published over one named example; monitoring half stated as an explicitly unverified dated claim owned by the parked spec | FR-001, FR-004, SC-002, US1 Independent Test, Assumptions |
+| 2 | `data source` (inbound) and `monitoring backend` (outbound) are two concepts with two words; one product may play both roles | FR-005a (new), Key Entities → Data source |
+| 3 | Vocabulary split by collision: colliding words settled in the glossary, other governance words in the layout document | FR-012, SC-013 (new) |
+| 4 | FR-008's drop test accepts a citation to committed text or to a decision already taken here; an invented utterance is not a citation | FR-008, SC-003, US2 Independent Test, Context → Candidate principles (table gains a Grounding column) |
+| 5 | The architecture document carries a split status — roles and boundaries bind, unbuilt components are proposed — and states its own cheap amendment procedure | FR-013, FR-023, SC-014 (new) |
+
+### Consequence worth carrying forward
+
+Answer 4 made the drop test real rather than decorative, and it immediately bit: of the four
+candidate principles, **Experiments Are Parked, Not Merged** can cite nothing. No committed
+file mentions Datadog, VictoriaMetrics or InfluxDB, and no recorded decision covers parking.
+The Context table now says so in place of the invented utterance it previously carried. Under
+FR-008 that candidate is dropped unless a citation is found before the amendment is written,
+which would reduce the constitution amendment from four principles to three.
+
+### Defects fixed by edit rather than by asking
+
+- **FR-022 named no unit of claim.** It said "no two follow-up specs may claim the same
+  artifact" while User Story 4's Independent Test said "no artifact class" — and at class
+  granularity the follow-up list is unwritable, since the schema, the object model and the
+  corpus all add to the normative core. FR-022, the Independent Test and SC-008 now name the
+  individual deliverable as the unit.
+- **The `loadtest.*` registry had no home.** None of the six artifact classes accommodates an
+  unsubmitted proposal to an external standards body that core constructs already depend on.
+  FR-015 now names this as a known defect the layout document must resolve, without
+  pre-deciding which class receives it.
+
+### Numbering note
+
+The answer to question 2 added an obligation between FR-005 and FR-006. It is numbered
+**FR-005a** rather than renumbering twenty requirements and every cross-reference to them.
+
+## Deferred — reached the five-question quota
+
+Three ranked survivors were not asked. All three are "where does this live" questions that
+the layout document must answer anyway, and none changes what this specification requires.
+
+| Rank | Question | Why deferring is safe |
+|---|---|---|
+| 6 | Does the experimental area exist as a real directory in this feature's output, and may normative documents link into it? | Affects whether SC-007 is literally runnable (`git rm` the directory, then `bash scripts/verify.sh` — an inbound link would turn it red). Decidable while writing the layout document. |
+| 7 | Which artifact class houses the `loadtest.*` registry? | Now recorded as a stated obligation in FR-015 rather than a silent gap. |
+| 8 | What does FR-014's "who may change it" resolve to, given no role vocabulary exists anywhere in the repository? | The constitution already forbids the failure mode that matters — "a tool list that only maintainers can extend is not tool-agnostic" — which constrains the answer. |
+
+## Notes
+
+- All items pass. The specification is ready for `/speckit-plan`.
+- Two success criteria remain soft and a reviewer will tick them by feel: SC-001 and SC-006
+  are comprehension claims about "a reader who has read nothing else" with no stated reader
+  and no answer key. Judged answerable from FR-001 and FR-002, so not spent as a question,
+  but worth converting into a structural check during planning.

--- a/specs/001-nfr-format-architecture/contracts/component-roles.md
+++ b/specs/001-nfr-format-architecture/contracts/component-roles.md
@@ -1,0 +1,145 @@
+# Contract: The four component roles
+
+**Feature**: [spec.md](../spec.md) | **Status**: proposed until the architecture document lands
+
+The interface this project exposes is not an API — it is the set of jobs an implementer may
+build, and the boundaries they may not cross. FR-002 requires each named component to state
+its input, its output, and at least one thing it is forbidden to depend on. The count of four
+is a decision of this contract, corroborated by compatibility.md § Layering — no requirement
+fixes it, and it is proposed until the architecture document lands.
+
+These contracts are **authored here**, not inherited from
+[compatibility.md](../../../docs/compatibility.md) § Layering, which gives responsibilities
+without contracts and sits in that document's proposal half. Two of the four are sub-roles of
+the glossary's `Adapter`; the architecture document must say so rather than introduce a rival
+decomposition.
+
+---
+
+## R1 · Parse
+
+**Job**: turn a document into an in-memory object model.
+
+| | |
+|---|---|
+| **Input** | One document, in the JSON-compatible YAML subset of ADR-0002 § D16 |
+| **Output** | An object model, or a parse error naming the offending field and its line |
+| **Forbidden** | Knowing which target will consume the result. Parse is target-independent or the format is not |
+
+**Guarantees the output carries** — proposed here, bound later by the `object-model`
+follow-up spec. The unknown-field rule is committed text in ADR-0002 § D17:
+
+- Unknown fields were rejected, not ignored. A typo like `agregation:` is an error, never a
+  silently skipped criterion — ADR-0002 § D17.
+- Mutually exclusive alternatives were resolved to exactly one: `distribution` xor `ratio`,
+  `indicator` xor `indicatorRef`, `threshold` xor `baseline`+`tolerance`.
+- Units are present. `unit` is mandatory, so the model has no unitless number.
+- The declared profile version is known, independently of the file's name or location.
+
+**Failure mode this exists to prevent**: lenient parsing turning a run green because a field
+name was misspelled.
+
+---
+
+## R2 · Render *(sub-role of `Adapter`)*
+
+**Job**: turn criteria into a target's native artifact.
+
+| | |
+|---|---|
+| **Input** | Criteria from the object model, plus one tool mapping |
+| **Output** | The target's native artifact, **plus a named list of every criterion it could not render** |
+| **Forbidden** | Deciding whether the run passes. Render emits; it never judges |
+
+**Hard rule** (FR-007): every criterion is either rendered or reported unrenderable
+**by criterion identity**. Dropping one silently is forbidden — a dropped criterion is a check
+that never ran and a result that looks clean.
+
+**Known asymmetry the walkthroughs must show**: the survey gives k6 native thresholds and
+abort, Gatling native assertions without abort, and JMeter neither. Render therefore returns a
+non-empty unrenderable list for JMeter by construction, and that is a correct outcome, not a
+failure of the role.
+
+---
+
+## R3 · Ingest *(sub-role of `Adapter`; called **file adapter** where it reads files)*
+
+**Job**: turn a target's raw output into comparable measurements.
+
+| | |
+|---|---|
+| **Input** | A target's raw output — an OTLP stream, a JTL file, a `simulation.log` — plus one tool mapping |
+| **Output** | Normalised series under canonical names, in canonical units, with attributes renamed |
+| **Forbidden** | Knowing what the criteria say. Ingest must not normalise differently because of what will be asked of the data |
+
+**Unit conversion is part of the contract, not a detail.** The survey records tools reporting
+milliseconds where semconv requires seconds. An error here is three orders of magnitude wide
+and produces a confident, wrong, green result, which is why the conversion is stated in the
+mapping rather than left to the implementation.
+
+**Naming note**: `reader` is **not** this role's name. In this specification `reader` means a
+human, and two success criteria rest on that sense.
+
+---
+
+## R4 · Evaluate
+
+**Job**: reduce measurements and criteria to verdicts, and verdicts to one outcome.
+
+| | |
+|---|---|
+| **Input** | Normalised series, criteria, guards, and the `gate` policy |
+| **Output** | One verdict per criterion and per guard, then one outcome through `gate` |
+| **Forbidden** | Knowing which target produced the measurements, or how they were obtained |
+
+**This is Principle VI**, and it is the only reason one document can mean one thing across
+seven targets. Its sharpest consequence: a statistic the target already computed — k6's own
+p95 — **must not be consumed as a verdict**. The moment it is, the verdict depends on the
+tool's percentile machinery, and the same document means different things in different places.
+
+**Outcomes that are not pass**, and which the role must produce rather than collapse:
+
+| State | Meaning | Never |
+|---|---|---|
+| `noData` | The selection matched nothing | a pass |
+| `inconclusive` | A guard failed — the run did not happen as intended | a pass or a fail |
+
+**Four defects in the current gate vocabulary** that the walkthroughs will expose. They are
+pre-existing, not introduced by this contract, and each needs an issue:
+
+1. `overall-availability` yields no series when nothing fails → `noData` → `onNoData: fail`.
+   The run fails because the system was perfect.
+2. A guard on a metric a target cannot measure lands on `onNoData: fail` rather than
+   `onGuardViolation: inconclusive`, so a tool limitation reads as a system failure.
+3. `skipped` appears in the status enum and in the report sketch, but **no `gate` key handles
+   it**. Silence is undefined behaviour in a project whose Principle III forbids exactly that.
+4. `indicatorRef: checkout-latency` points at a Requirement name, while ADR-0001 § D10 and the
+   glossary describe `Indicator` as a reusable kind of its own.
+
+---
+
+## The path, end to end
+
+```text
+requirement → criterion → verdict → gate → outcome
+     R1            R1        R4       R4      R4
+                   R2 renders criteria into the target
+                   R3 supplies R4 the measurements
+```
+
+The trace ends at **outcome**, not verdict. A `Verdict` is the result of checking one criterion;
+what a CI job prints is the aggregated `Outcome`. Ending at verdict stops one component short
+of `gate`.
+
+---
+
+## What no role may do
+
+- **No role may read the requirement document to find its data source.** The source is a
+  parameter of evaluation, never a property of the requirement — ADR-0002 § D18.
+- **No construct may be checkable only while a run is in progress.** Anything expressible must
+  also be evaluable afterwards, or the format silently excludes every tool that cannot assert
+  inline. This is already a ratified constitutional constraint.
+- **No role may substitute a measurement it can obtain for one it cannot.** A client-side
+  latency is not a server-side latency; a gap is declared, never filled by the nearest
+  available number.

--- a/specs/001-nfr-format-architecture/contracts/repository-shapes.md
+++ b/specs/001-nfr-format-architecture/contracts/repository-shapes.md
@@ -1,0 +1,115 @@
+# Contract: Repository shapes
+
+**Feature**: [spec.md](../spec.md) | **Status**: proposed until the layout document lands
+
+The layout document, the follow-up list and the experimental area each publish rows that later
+work reads. These are the shapes those rows must have, so a reviewer can check a draft
+mechanically instead of by feel.
+
+---
+
+## Layout table row
+
+One row per artifact class. Every column mandatory.
+
+| Column | Rule |
+|---|---|
+| Class | Unique name. Defined in the layout document with a rejected alternative — it is a governance word, not a format term |
+| Home | Exactly one directory. Two or none is a layout defect (FR-015) |
+| Who may change it | **Uniform across every row: "Anyone, by pull request."** Differences belong in the next column |
+| Obliges | What a change requires — glossary entry, ADR, dated evidence, sketch label |
+| On the compatibility surface | Yes / partly / no. The experimental area is `no` by construction (FR-018) |
+
+**Why the third column is uniform**: the constitution already forbids a surface only
+maintainers can extend, and no class has a reason to be narrower. Classes differ by what a
+change obliges, not by who may propose it. Two sentences below the table carry that argument,
+and no role vocabulary is introduced — Principle I prices every added governance word.
+
+**One sentence the table needs beside it**: `specs/` is not an artifact class. It is the
+spec-kit working directory, and flow is one-directional — a follow-up spec writes into the
+homes this table names, and never becomes one.
+
+---
+
+## Non-conformance row
+
+The layout publishes what is mis-filed rather than moving it. AGENTS.md forbids opportunistic
+refactors outside scope; FR-013 forbids the silent mismatch.
+
+| Column | Rule |
+|---|---|
+| Path | The file as it sits today |
+| Belongs to | The class the table assigns it |
+| Why not moved now | The scope argument |
+| The move's obligation | What the eventual move must **also** do, so the cost is visible before someone starts |
+
+The obligation column is the one that earns the row. Moving the two tool mappings out of
+`docs/examples/` slips them past `verify.sh`'s sketch-label check, which is hardcoded to that
+directory — a move that looks like tidying silently removes a gate.
+
+---
+
+## Follow-up entry
+
+| Column | Rule |
+|---|---|
+| Slug | Unique. **Named by slug, never by ordinal** |
+| Delivers | Concrete files. This is FR-022's unit of claim |
+| Depends on | Other slugs, stated explicitly |
+| Role | Which component role it implements |
+| Scheduling | `scheduled`, or `parked` |
+
+**Numbering is not scheduling.** `specs/NNN-` records the order specs were *created*, not the
+order they must be *completed*. The list must say so in one sentence, because
+`001-nfr-format-architecture` already sets a numbering a reader will read as a schedule.
+
+**Disjointness** (SC-008): no individual deliverable appears in two entries. The unit is the
+file, not the class — at class granularity the list is unwritable, since the schema, the object
+model and the corpus all add to the normative core.
+
+**A parked entry carries conditions instead of a position** (SC-011): promotion conditions,
+retirement conditions, a date, and nothing that looks like a schedule.
+
+---
+
+## Experimental artifact
+
+Every file in the experimental area, without exception (FR-018, SC-011).
+
+| Element | Rule |
+|---|---|
+| Status | States in its own text that it is experimental |
+| Promotion | What would move it to stable, in checkable terms |
+| Retirement | What would kill it |
+| Date | When the status was last true |
+| Owner | The follow-up spec that owns verifying it |
+
+**Two structural rules make SC-007 executable rather than aspirational**:
+
+1. **No markdown link points into the area from outside it.** Outside references name the path
+   in prose, inside a code span. `verify.sh` fails the build on any dangling internal link, so
+   one inbound link turns the one-operation deletion red.
+2. **The area holds markdown only, no YAML.** This keeps it clear of the sketch-label check.
+
+With both rules, the criterion is a command:
+
+```bash
+git rm -r docs/experimental && bash scripts/verify.sh
+```
+
+---
+
+## Statement marker
+
+SC-014 requires every statement in the architecture document to be marked binding or proposed,
+and the number of unmarked ones to be zero — which is unfalsifiable unless "statement" has a
+unit.
+
+| | |
+|---|---|
+| Unit | A numbered clause or a table row. Not a sentence, not a heading |
+| Marker | A dedicated column for tables; an explicit `(binding)` / `(proposed)` tag for clauses |
+| Counting | Mechanical: rows and clauses without a marker, counted |
+
+**Default**: nothing is binding by default. An unmarked clause is a defect, not an implicit
+`proposed` — otherwise the safest draft is the vaguest one.

--- a/specs/001-nfr-format-architecture/data-model.md
+++ b/specs/001-nfr-format-architecture/data-model.md
@@ -1,0 +1,192 @@
+# Phase 1 Data Model: Repository Architecture and Operating Principles
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Date**: 2026-08-18
+
+This feature ships no runtime data, so the model here is structural: the things the repository
+holds, the roles the architecture names, and the words that identify both. These are the
+entities the two new documents are made of.
+
+---
+
+## 1. Artifact class
+
+A kind of thing the repository holds. Exactly one home directory, one rule for changing it.
+
+| Field | Rule |
+|---|---|
+| `name` | Unique. Named in the layout table |
+| `home` | Exactly one directory path. Two homes, or none, is a defect of the layout (FR-015) |
+| `who may change it` | Uniform: "Anyone, by pull request". Differences live in obligations, never in permission ([research.md](research.md) § D4c) |
+| `obligations` | What changing it requires — the only column that varies between classes |
+| `on the compatibility surface` | Boolean. The experimental area is excluded by construction (FR-018) |
+
+### Instances
+
+| Class | Home | Obligations | Compat. surface |
+|---|---|---|---|
+| Normative core | `docs/` top level, plus `docs/semconv/` | term change updates `docs/GLOSSARY.md` in the same PR with a rejected alternative; naming disagreements argued in an issue first; compatibility-sensitive change requires an ADR | partly |
+| Decision records | `docs/adr/NNNN-slug.md` | a PR contradicting an ADR amends it instead; status stays `proposed` until something validates it | no |
+| Tool mappings | `mappings/` | claimed conformance level evidenced and dated | no (content); the level ladder itself is |
+| Conformance corpus | `docs/examples/` | every file announces itself as a sketch until a schema validates it | field names in published examples are |
+| Experimental area | `docs/experimental/` | self-labelling with promotion and retirement conditions; no inbound markdown links; markdown only | **no, by construction** |
+| Reference implementation | declared, not created | — | no |
+
+**`specs/` is not an artifact class.** It is the spec-kit working directory. The layout table
+says so explicitly in one sentence, because a newcomer scanning the tree assumes otherwise.
+
+**Known unfiled artifact** (FR-015 names it): `docs/semconv/loadtest.md` — an unsubmitted
+proposal to an external standards body that core constructs already depend on. Filed in the
+normative core with a widened class definition; see [research.md](research.md) § D4b.
+
+---
+
+## 2. Component role
+
+A named job on the path from a requirement to an outcome. Roles are contracts, not modules —
+see [contracts/component-roles.md](contracts/component-roles.md) for the full contracts.
+
+**Provenance, because this is the feature's most load-bearing table.** These roles are
+**authored here**, not inherited. [compatibility.md](../../docs/compatibility.md) § Layering
+lists four layers, but it gives four *responsibilities* and zero contracts — no inputs, no
+outputs, no forbidden dependencies — and it sits under `## Requirements for the Go
+implementation`, which that document classifies as a proposal. FR-013 makes component roles
+**binding**, so inheriting them would rest binding text on a proposal. The layering table is
+cited as corroboration; the contracts below are new.
+
+**Reconciliation with the glossary.** `Adapter` already umbrellas two of these roles — the
+glossary defines it as doing four jobs, of which rendering assertions is one and collecting a
+tool's output is another. Render and Ingest are therefore *sub-roles of `Adapter`*, not rivals
+to it, and the architecture document must say so rather than introduce a competing
+decomposition, which Principle I forbids. The count of four and the placement of `gate`
+inside Evaluate are decisions of this model, corroborated by compatibility.md § Layering. No
+requirement fixes either.
+
+| Field | Rule |
+|---|---|
+| `name` | Unique. Must not collide with a glossary word at another layer |
+| `input` | What it is handed |
+| `output` | What it returns |
+| `forbidden knowledge` | At least one thing it must not depend on (FR-002) |
+| `status` | `binding` or `proposed`. No statement may be unmarked (FR-013, SC-014) |
+
+### The four roles
+
+| Role | Input | Output | Must not know |
+|---|---|---|---|
+| Parse | A document | An object model with unknown fields already rejected, alternatives resolved to one, units present | Which target will consume it |
+| Render | Criteria + a tool mapping | The target's native artifact, plus a named list of criteria it could not render | Whether the run will pass |
+| Ingest (file adapter) | A target's raw output + a tool mapping | Normalised series under canonical names, in canonical units | What the criteria say |
+| Evaluate | Normalised series + criteria + guards | Verdicts, then an outcome through `gate` | Which target produced the measurements, or how |
+
+The fourth row is Principle VI. It is the whole reason one document can mean one thing.
+
+---
+
+## 3. The traced path
+
+The architecture document traces this, three times, over
+[docs/examples/checkout-perf.yaml](../../docs/examples/checkout-perf.yaml).
+
+```text
+requirement → criterion → verdict → gate → outcome
+```
+
+**The endpoint matters.** The specification originally ended the trace at *verdict*, but in
+[GLOSSARY.md](../../docs/GLOSSARY.md) a `Verdict` is the result of checking **one** criterion;
+what a CI job prints is an `Outcome`, the aggregated result of the whole run. Ending at
+`verdict` stops one component short of `gate` — which User Story 1's own acceptance scenario
+requires to be named. See [research.md](research.md) § D5.
+
+---
+
+## 4. Vocabulary entry
+
+Every word this feature introduces, with exactly one home (FR-012, SC-013).
+
+| Field | Rule |
+|---|---|
+| `word` | The term |
+| `home` | `glossary` if it collides with a word already in `docs/GLOSSARY.md`; `layout` otherwise. Never both |
+| `definition` | One line |
+| `rejected alternative` | Mandatory, with the reason. This is the durable part |
+
+### Words settled in the glossary — they collide
+
+| Word | Collides with | Disposition |
+|---|---|---|
+| `target` | "target load" in the Requirement entry; OpenSLO's `target` field | New `### Target` in Layer 2. Runtime, between `### Assertion` and `### Adapter`. No fourth layer |
+| `monitoring backend` | `backend`, already used for the thing that evaluates after the run | Defined **inside** the `Target` entry as its second class. Reverses the 2026-08-18 clarification, which predates the discovery of this collision |
+| `binding` | `MetricMapping`; and `binding` is already load-bearing as an adjective meaning normative | **Dropped.** The artifact class becomes `tool mapping` |
+
+### Words defined in the layout document — no collision
+
+`artifact class`, `home`, `normative core`, `compatibility-sensitive surface`,
+`experimental area`, `follow-up spec`, `obligation`, `non-conformance list`. Each carries its
+own rejected alternative.
+
+### Words fixed, not introduced
+
+| Word | Problem | Fix |
+|---|---|---|
+| `reader` | Two senses — a human (SC-001, US1, eight occurrences) and a software component | The component becomes `file adapter`; `reader` stays human |
+| `interpreter` | A straight synonym of the glossary's `Adapter` | Dropped outside the quoted user input. The architecture document states plainly that it means `Adapter`, whose sub-roles are `renderer` and `file adapter` |
+| `source` | Four committed senses | Always written `data source` in full; never the bare noun |
+| `data source` | Inherited, not introduced (ADR-0002 § D18) | Cited, never redefined |
+
+---
+
+## 5. Document status
+
+Applies to every document this feature produces (FR-013).
+
+| Value | Meaning |
+|---|---|
+| `binding` | Later specs must obey it. Component roles, forbidden dependencies, follow-up boundaries |
+| `proposed` | Describes something that does not exist yet |
+
+No statement may be unmarked (SC-014). Amending a binding statement is an ordinary PR landing
+before the diverging spec — **no decision record required**, because the architecture document
+is not on the compatibility-sensitive surface (FR-023). The sanctioned route has to stay
+cheaper than the workaround, or people take the workaround.
+
+---
+
+## 6. Follow-up entry
+
+One future spec. Named by **slug, never by ordinal** — `specs/NNN-` records creation order, not
+completion order.
+
+| Field | Rule |
+|---|---|
+| `slug` | Unique |
+| `delivers` | Concrete files. The unit of claim under FR-022 — a file, not an artifact class |
+| `depends on` | Other slugs. Stated explicitly, never implied by numbering |
+| `role` | Which component role it implements |
+| `scheduling` | `scheduled`, or `parked` with promotion and retirement conditions in place of a position (SC-011) |
+
+**Disjointness invariant**: no individual deliverable appears in two entries (SC-008). At
+artifact-class granularity the list would be unwritable — the schema, the object model and the
+corpus all add to the normative core, which is exactly why FR-022 names the file as the unit.
+
+---
+
+## 7. Non-conformance entry
+
+The layout document publishes what is currently mis-filed rather than moving it (FR-013).
+
+| Field | Rule |
+|---|---|
+| `path` | The file |
+| `class it belongs to` | Where the layout says it should live |
+| `why not moved` | AGENTS.md forbids opportunistic refactors outside scope |
+| `obligation attached to the eventual move` | What the move must also do |
+
+The two sharpest entries, and the reason the list exists rather than a rename commit:
+
+- `docs/examples/mapping-k6.yaml`, `docs/examples/mapping-jmeter.yaml` — tool mappings sitting
+  in the corpus home. Linked from five other documents, so a move turns `verify.sh` red across
+  the tree. **Hidden obligation**: `verify.sh`'s sketch-label check is hardcoded to
+  `docs/examples/*.yaml`, so mappings relocated to `mappings/` silently stop being checked
+  until the script is extended.
+- `docs/compatibility.md` — spans three classes by its own admission: conformance levels
+  (normative), the tool survey (evidence), the Go notes (proposal).

--- a/specs/001-nfr-format-architecture/plan.md
+++ b/specs/001-nfr-format-architecture/plan.md
@@ -1,0 +1,230 @@
+# Implementation Plan: Repository Architecture and Operating Principles
+
+**Branch**: `001-nfr-format-architecture` | **Date**: 2026-08-18 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/001-nfr-format-architecture/spec.md`
+
+## Summary
+
+Publish how OpenNFR works and where its parts live, and give the project the rules that decide
+the arguments the architecture creates — without writing any of it.
+
+Six pull requests in a fixed order: the spec; a glossary settlement that fixes three live word
+collisions before anything uses them; a constitution amendment to v1.1.0 adding two principles
+and widening one binding constraint; the architecture document with three worked walkthroughs
+over `docs/examples/checkout-perf.yaml`; and the layout document naming one home per artifact
+class; and the follow-up list appended to it. No schema, no validator, no code, no tool
+mapping.
+
+The order is not cosmetic. The constitution says a conflicting document "is wrong and MUST be
+fixed", so an architecture document written against unamended text is born wrong; and the
+amendment PR may contain nothing but the constitution and the templates it affects, which
+forbids it from carrying the glossary entry its own new wording needs. Settling the vocabulary
+first is what makes the amendment legal.
+
+## Technical Context
+
+**Language/Version**: None — this feature ships no code. Markdown as GitHub renders it, and
+YAML 1.2 restricted to its JSON-compatible subset ([ADR-0002 § D16](../../docs/adr/0002-compatibility.md))
+where existing sketches are quoted.
+
+**Primary Dependencies**: OpenTelemetry semantic conventions, as the source of every borrowed
+name; this repository's own dated tool survey ([compatibility.md](../../docs/compatibility.md),
+"Verified against documentation as of August 2026").
+
+**Storage**: Files in git. No database, no state.
+
+**Testing**: `bash scripts/verify.sh` — four checks: YAML sketches parse, internal markdown
+links resolve, documents contain no non-English text, examples announce themselves as
+sketches. Plus one criterion this feature makes literally executable: `git rm -r docs/experimental`
+followed by `bash scripts/verify.sh` must stay green (SC-007).
+
+**Target Platform**: A git repository rendered on GitHub; `scripts/check-linkage.sh` in CI.
+
+**Project Type**: Documentation and governance artifacts for a format specification. Not an
+application, not a library.
+
+**Performance Goals**: None applicable.
+
+**Constraints**:
+- `bash scripts/verify.sh` must pass on every commit; weakening it requires justification in
+  the PR, not in the script.
+- English only — `verify.sh` fails on any Cyrillic in `*.md` or `*.yaml`.
+- FR-025: zero executable artifacts. No schema, validator, parser, renderer or tool mapping.
+- The amendment PR contains exactly two files.
+- The link check filters `grep -v '^\./\.'`, so anything under a dot-prefixed root directory
+  has its outgoing links **unchecked**. The checked set is 12 files today.
+- The sketch-label check is hardcoded to `docs/examples/*.yaml`.
+- Every PR needs milestone `v0.2.0` and a closing link to an issue in that milestone. **No such
+  issue exists yet** — issue creation is task one, not an afterthought.
+
+**Scale/Scope**: The repository holds 168 files, of which **ten** are format artifacts. This
+feature adds two documents, one directory with one file, one glossary section, a constitution
+amendment across two files, and an eleven-entry follow-up list.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against [constitution.md](../../.specify/memory/constitution.md) v1.0.0. Re-evaluated
+after Phase 1 design — result unchanged except where noted.
+
+- [x] **I. Vocabulary Before Features** — Yes, this feature introduces terms, and it also
+      *removes* one. Settled by sequencing: the glossary PR lands before any document uses the
+      words. `target` gets an entry in Layer 2 with a rejected alternative; the noun `binding`
+      is dropped in favour of `tool mapping`; the component sense of `reader` is renamed to
+      `file adapter`. Principle I's ordering clause binds a term to reach the glossary "before
+      it appears in an example, a schema, or an implementation" — the architecture and layout
+      documents are none of those three, so landing the glossary PR first satisfies it with
+      room to spare. No ADR is contradicted: adding `Target` to Layer 2 is consistent with
+      ADR-0001 § D2, and dropping a word this repository never ratified contradicts nothing.
+
+- [x] **II. Borrow Names, Never Invent Them** — This feature adds no metric and no attribute
+      name. The `loadtest.*` registry is unchanged; it is *filed*, not edited. No aliases, no
+      derived quantities.
+
+- [x] **III. No Silent Green** — This feature adds no check that can fail to find data, so the
+      gate is trivially satisfied for what it ships. It is **not** trivially satisfied for what
+      it discovered: the three walkthroughs will expose four silent-green defects that already
+      exist in `docs/examples/checkout-perf.yaml` and the gate vocabulary
+      ([research.md](research.md) § D7). They are pre-existing, not introduced here. The plan
+      files them as issues rather than fixing them, because fixing them changes the format and
+      FR-025 forbids that — but leaving them undocumented while writing a walkthrough that
+      steps over them would itself be a silent green.
+
+- [x] **IV. Honest Status** — The architecture document carries a split status by FR-013: roles
+      and boundaries bind, unbuilt components are marked proposed. Every tool claim traces to
+      the dated survey. Two live violations in the specification were found and **fixed during
+      planning**: an unmarked elision in the AGENTS.md citation, and an ellipsis swallowing a
+      sentence boundary in the compatibility.md citation. One unlabelled knowledge claim about
+      Gatling's `simulation.log` columns was caught in research and dropped — nothing committed
+      speaks to it.
+
+- [x] **V. Structure Over Grammar** — This feature adds no format field, no value set and no
+      construct requiring custom decoding. Trivially satisfied.
+
+- [x] **Compatibility** — No borrowed OTel name is touched. No published example's field name
+      is touched: the two mis-filed tool mappings stay where they are, and the layout publishes
+      the mismatch instead of moving them. The conformance levels are unchanged. No construct
+      is added, so none can be `assert`-only. The amendment **does** widen the Compatibility
+      Constraints section — but through the constitution's own amendment procedure, which is
+      the sanctioned route for exactly that.
+
+**Which constitution version this gates against**: **v1.0.0**, deliberately. This feature's own
+amendment lands mid-sequence as PR 3, so gating against v1.1.0 would check the plan against
+text that does not exist. The constitution already requires the check to run "again after
+Phase 1 design"; the re-run above used v1.0.0 for the same reason. The first plan to gate
+against v1.1.0 is the one after this feature ships.
+
+**One decision the check cannot clear alone** — the fourth candidate principle. Recorded in
+Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-nfr-format-architecture/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output — artifact classes, component roles, vocabulary homes
+├── quickstart.md        # Phase 1 output — how to verify this feature landed correctly
+├── contracts/           # Phase 1 output — the four component-role contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Repository artifacts (what this feature actually changes)
+
+```text
+docs/
+├── architecture.md      # NEW — how a requirement becomes an outcome; three worked walkthroughs
+├── layout.md            # NEW — one home per artifact class, obligations, non-conformance list
+├── GLOSSARY.md          # EDITED — adds § Target to Layer 2; drops the noun `binding`
+├── experimental/        # NEW directory
+│   └── README.md        # NEW — the parked monitoring direction's status page
+├── adr/                 # unchanged — decision records
+├── examples/            # unchanged — corpus home; also holds two mis-filed tool mappings
+├── semconv/             # unchanged — filed into the normative core by layout.md
+├── compatibility.md     # unchanged — named in the non-conformance list (spans three classes)
+├── units.md             # unchanged
+├── references.md        # unchanged
+└── README.md            # EDITED — indexes the two new documents
+
+.specify/
+├── memory/constitution.md          # EDITED — v1.0.0 → v1.1.0
+└── templates/plan-template.md      # EDITED — stale version pointer; new principle gates
+
+README.md                # EDITED — Documents table gains two rows
+```
+
+**Structure Decision**: Keep the existing tree and move nothing. AGENTS.md forbids
+opportunistic refactors outside scope, and the two tool mappings in `docs/examples/` are linked
+from five other documents — moving them turns `verify.sh` red across the tree, and would
+additionally slip them out of the sketch-label check, which is hardcoded to that directory.
+The layout document publishes six non-conforming entries under FR-013 instead, each with the
+obligation its eventual move carries. `mappings/` is declared as the tool-mapping home and
+created empty of content by the first target follow-up spec, not here.
+
+`specs/` is explicitly **not** an artifact class and the layout table says so in one sentence —
+a newcomer scanning the tree would otherwise read it as holding format artifacts. Flow is
+one-directional: a follow-up spec writes into the homes the layout names; it never becomes one.
+
+## Delivery sequence
+
+Six PRs, each with its own issue on milestone `v0.2.0`. The ordering constraint is real, not
+stylistic — see Summary.
+
+| # | PR | Contents | Why here |
+|---|---|---|---|
+| 1 | spec | `specs/001-*/` only | AGENTS.md spec-first; never folded into implementation |
+| 2 | glossary | `docs/GLOSSARY.md`, plus the spec's own uses of the settled words | Settles `target` before the amendment needs the word; drops `binding` before the layout uses it |
+| 3 | amendment | `constitution.md` + `plan-template.md`, nothing else | The constitution's own procedure. Must precede any document written against it |
+| 4 | architecture | `docs/architecture.md`, `docs/experimental/README.md`, index rows | Needs the amended constitution and the settled words |
+| 5 | layout | `docs/layout.md`, index rows | Names homes the architecture document already refers to |
+| 6 | follow-up list | the follow-up section appended to `docs/architecture.md` | The decomposition is a separate concern from how it works |
+
+## Preconditions — the check that fails first
+
+`.github/workflows/verify.yml` runs `scripts/check-linkage.sh --pr` on every pull request,
+gating on milestone `v0.2.0` **and** a registered closing link to an issue in that milestone.
+Three issues exist in this repository; all are closed and none covers this work.
+
+Under AGENTS.md's "1 issue = 1 commit", the six-PR sequence needs **six issues opened before
+the first PR**, one per row of the table above. This is task one in `tasks.md`, not a
+formality — without it CI rejects PR 1 on its face.
+
+Two questions the plan could not decide were answered on 2026-08-18:
+
+- **Milestone fit.** `v0.1.0` covered only the first cut of the notes, so it was tagged,
+  released and closed rather than stretched. `v0.2.0` is cut for this feature and is created
+  by T001. No open milestone exists until then, which is why `scripts/check-linkage.sh` exits
+  2 on every PR.
+- **`.specify/feature.json`** is spec-kit runtime state and is now ignored via `.gitignore`,
+  so it no longer rides along in the spec commit. The `.gitignore` change travels in PR 1 as
+  the enabling edit for that commit.
+
+## Open decisions carried into tasks
+
+Surfaced by the completeness critic, each blocking a specific requirement rather than the plan
+as a whole.
+
+| Requirement | What is undecided | Note |
+|---|---|---|
+| FR-016 | Which side is authoritative when a tool-native integration in another repository drifts from the format | `grep -r authoritative` over `docs/`, `README.md`, `AGENTS.md` and the constitution returns nothing. No committed text answers it. FR-016's own wording asks only for authority to be *stated*, so the layout document must state it — and every detection mechanism is an executable artifact FR-025 forbids, which leaves detection to the conformance-corpus follow-up |
+| FR-017 | Whether the layout document republishes the compatibility-sensitive list or points at the constitution's | Republishing creates a second copy that can drift, which the constitution's supremacy clause makes wrong by definition. Pointing is the only safe form; the layout carries a pointer plus the per-class yes/partly/no column |
+| SC-014 | What counts as a "statement" | Settled in [contracts/repository-shapes.md](contracts/repository-shapes.md): the unit is a numbered clause or a table row, the marker is a dedicated column or an explicit tag, and unmarked is a defect rather than an implicit `proposed` |
+| SC-012 | The construct set it is verified over | This feature admits no new construct, so the criterion is satisfied over an empty set — which is true but hollow. Read it as a standing obligation on later specs rather than a check this feature passes |
+
+## Complexity Tracking
+
+> Filled because one Constitution Check item cannot be cleared without a decision that changes
+> the constitution's content.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| Principle VIII "Experiments Are Parked, Not Merged" as drafted would make two committed artifacts retroactively non-compliant, and its own text contradicts the only constitutional bullet that supports it | The author asked for the monitoring direction to be "parked in some form", and FR-018/SC-011 need a rule above them | Shipping as drafted — rejected: the draft says "Unsettled work is contained, not labelled. A warning notice on something load-bearing is not containment", while the nearest committed grounding, Principle III's "Any artifact nothing validates MUST say so in its own text", blesses labelling. `docs/semconv/loadtest.md` and the `errorSignal` sketch in `mapping-k6.yaml` both practise labelling over containment today. Dropping it entirely — viable and costs nothing mechanically, since FR-018 and SC-011 still bind this feature's own artifacts. **Recommended: narrow it to *new* unsettled work and name the two existing artifacts as grandfathered with a dated note** |
+| The three walkthroughs cannot be symmetric: `docs/examples/` has `mapping-k6.yaml` and `mapping-jmeter.yaml` and **no Gatling mapping** | SC-002 names three load generators, and Gatling is the internal consumer's tool | Writing a Gatling mapping here — rejected by FR-025, which forbids this feature from shipping a tool mapping. Dropping Gatling from the three — rejected: it is the tool with the named counterparty. The Gatling walkthrough therefore traces from the dated survey alone and declares every gap, and creating the mapping becomes the first deliverable of the `target-gatling` follow-up spec |
+| `monitoring backend` was sent to the architecture document by the 2026-08-18 clarification, but collides with `backend`, already used in the glossary in a different sense | FR-012's collision test is mechanical and says the glossary | Honouring the clarification as given — the clarification predates the discovery of the collision, and FR-012's own test overrides it. **Resolution: define it inside the `Target` glossary entry**, where the collision is visible, and have the architecture document cite rather than redefine it. This reverses a stated answer and is flagged for the author |

--- a/specs/001-nfr-format-architecture/quickstart.md
+++ b/specs/001-nfr-format-architecture/quickstart.md
@@ -1,0 +1,136 @@
+# Quickstart: verifying this feature landed correctly
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Date**: 2026-08-18
+
+This feature ships documents, so most of its success criteria are read rather than run. Four
+are genuinely executable, and they are the ones worth wiring into review. Everything below
+runs from the repository root.
+
+## Prerequisites
+
+- `python3` with PyYAML, or `verify.sh` skips its YAML check and says so
+- `gh`, authenticated, for the milestone and linkage checks
+- A clean working tree — several checks below delete files
+
+---
+
+## 1 · The standing gate
+
+```bash
+bash scripts/verify.sh
+```
+
+Expected: `PASS`. Four checks — YAML sketches parse, internal markdown links resolve, no
+non-English text in `*.md` or `*.yaml`, every example announces itself as a sketch.
+
+**Two blind spots to know before trusting it.** The link check filters `grep -v '^\./\.'`, so
+anything under a dot-prefixed root directory — `.specify/`, `.claude/`, `.github/` — has its
+outgoing links unchecked; the checked set is twelve files. And the sketch-label check is
+hardcoded to `docs/examples/*.yaml`, so a tool mapping moved to `mappings/` silently stops
+being checked.
+
+---
+
+## 2 · SC-007 — the experimental area really is removable
+
+The only criterion in this feature that is a command rather than a reading.
+
+```bash
+git rm -r docs/experimental && bash scripts/verify.sh
+```
+
+Expected: `PASS`. Then `git restore --staged docs/experimental && git checkout docs/experimental`.
+
+A `FAIL` naming a dangling link means some document linked into the parked area, and "parked"
+was never true — the fix is in the referring document, not in the criterion.
+
+---
+
+## 3 · SC-004 — the constitution and its templates agree
+
+```bash
+grep -n 'Version.*:' .specify/memory/constitution.md | tail -1
+grep -n 'constitution.md.*v[0-9]' .specify/templates/plan-template.md
+grep -c '^### [IVX]*\.' .specify/memory/constitution.md
+grep -n 'principles above' .specify/memory/constitution.md
+```
+
+Expected, after the amendment PR: the footer reads `1.1.0`; the template's pointer reads
+`v1.1.0` and not `v1.0.0`; the principle count matches the number the Compliance review
+sentence claims. A stale version pointer in the template is exactly the drift this amendment
+exists to prevent, so it fails the check rather than being tidied later.
+
+---
+
+## 4 · SC-013 — every introduced word has exactly one home
+
+```bash
+for w in target "artifact class" "component role" "compatibility-sensitive surface" \
+         "experimental area" "follow-up spec" "monitoring backend"; do
+  printf '%-34s glossary:%s layout:%s\n' "$w" \
+    "$(grep -ci "$w" docs/GLOSSARY.md)" "$(grep -ci "$w" docs/layout.md)"
+done
+```
+
+Expected: each word is defined in exactly one of the two. Colliding words — `target`,
+`monitoring backend` — in the glossary; governance words in the layout document. A word
+defined in both is a defect, not a convenience.
+
+Also check the dropped word did not survive:
+
+```bash
+grep -rn '\bbindings\?\b' docs/ --include='*.md' | grep -v 'binding constraint'
+```
+
+Expected: no hits naming an artifact class. The noun was dropped for `tool mapping`.
+
+---
+
+## 5 · SC-010 — nothing executable shipped
+
+```bash
+git diff --name-only main...HEAD | grep -vE '\.(md)$|^specs/|^\.gitignore$'
+```
+
+Expected: empty. This feature produces markdown and nothing else — no schema, no validator, no
+parser, no renderer, no tool mapping.
+
+---
+
+## 6 · Linkage — the check that fails first if preconditions were skipped
+
+```bash
+bash scripts/check-linkage.sh --pr
+gh api repos/galax-io/opennfr/milestones --jq '.[] | "\(.number) \(.title) [\(.state)]"'
+```
+
+Every PR needs milestone `v0.2.0` and a registered closing link to an issue in that milestone.
+**No issue exists for any part of this feature yet**, so this is the check that fails on the
+first PR if the issues were not created first.
+
+---
+
+## Read, not run
+
+These carry the feature's actual value and no script can judge them.
+
+| Criterion | How to judge |
+|---|---|
+| SC-001 | Hand `docs/architecture.md` to someone who has read nothing else. Ask them to trace one requirement to an outcome, naming every component. A step they cannot name is a defect |
+| SC-002 | Three walkthroughs over `docs/examples/checkout-perf.yaml`, one per load generator, present and followable. The four monitoring backends are a dated unverified claim — check it says so |
+| SC-003 | Every principle in the amendment resolves to a file and section without git history |
+| SC-005 | Every artifact class has one home; count classes with none or two |
+| SC-006 | Hand `docs/layout.md` to a newcomer; ask which files they would create to add a tool |
+| SC-008 | Enumerate the follow-up list's deliverables; count files claimed twice |
+| SC-014 | Count clauses and table rows in `docs/architecture.md` carrying no binding/proposed marker |
+
+---
+
+## Known-failing on purpose
+
+The walkthroughs will document four defects that already exist in the reference example and
+the gate vocabulary — a perfect run that reports `noData` and fails; an unmeasurable guard that
+fails for the wrong reason; a `skipped` status no gate key handles; an `indicatorRef` pointing
+at the wrong kind. They are **declared, not fixed**: fixing them changes the format, which
+FR-025 puts out of scope. Each needs its own issue. A walkthrough that steps over them silently
+would be the very failure Principle III exists to prevent.

--- a/specs/001-nfr-format-architecture/research.md
+++ b/specs/001-nfr-format-architecture/research.md
@@ -1,0 +1,447 @@
+# Phase 0 Research: Repository Architecture and Operating Principles
+
+**Feature**: [spec.md](spec.md) | **Date**: 2026-08-18 | **Branch**: `001-nfr-format-architecture`
+
+Seven parallel investigations over the repository, then two adversarial verification passes —
+one on every citation, one on every claim about an external tool, since Principle IV makes an
+unlabelled tool claim a defect. The verifiers were instructed to default to REFUTED when they
+could not confirm from a file in this repository. They refuted a great deal, including two
+statements in the specification itself.
+
+Every quote below was independently re-checked. Line numbers cited by the first pass were
+wrong four times in a row (off by one or by a range end); the numbers here are the verified
+ones.
+
+---
+
+## D1. Which candidate principles survive, and what the constitution actually gains
+
+**Decision**: The amendment adds **two** numbered principles, **widens one** existing binding
+constraint, and carries a **third principle only in a narrowed form** — or drops it.
+
+| Candidate | Outcome | Grounding, verified |
+|---|---|---|
+| Targets Are Data | **Not a new principle.** Widen the existing constraint, per FR-011 | `constitution.md` § Compatibility Constraints — "Support for a load testing tool MUST be expressible as data, not as code in the reference implementation." Confirmed verbatim. The words "monitor"/"monitoring" appear nowhere in `docs/`, `README.md`, `AGENTS.md` or the constitution — the gap is real |
+| Evaluation Is Target-Blind | **New Principle VI** | `compatibility.md` § Requirements for the Go implementation → Layering — "the evaluation layer knows nothing about tools or sources" |
+| Architecture Before Implementation | **New Principle VII** | `AGENTS.md` § Commits & PRs → Spec-first |
+| Experiments Are Parked, Not Merged | **Conditional — see D2** | Contested |
+
+**Rationale**: FR-011 forbids adding a parallel principle that nearly duplicates an existing
+constraint, and the load-testing-tool constraint is exactly the one being generalised.
+Numbering the conditional principle **VIII**, last, means dropping it renumbers nothing.
+
+**Alternatives considered**:
+
+- Adding *Targets Are Data* as a numbered principle — rejected by FR-011: the constitution
+  already says it, narrowly.
+- Citing `README.md` § "Tool support as data, not code" as primary grounding — rejected: the
+  README hedges it as "Unproven", which weakens a principle citation.
+- Citing ADR-0002 § D18 for target-blindness — rejected: D18 is about the data source being
+  absent from the document, which FR-005 already spends.
+
+**Two honesty caveats the amendment must carry**:
+
+1. `compatibility.md` § Layering sits under `## Requirements for the Go implementation`, which
+   that document's own opening classifies as a *proposal*, not a verified fact, and which
+   states "nothing is implemented yet". Cite it by its full path and do not let Principle VI's
+   wording imply the layering exists.
+2. `AGENTS.md` declares everything below its `---` to be "the **stack-agnostic development
+   process** … meant to be reused verbatim across all projects". The Spec-first bullet is
+   therefore inherited boilerplate, not an argument this repository had. Co-cite
+   `constitution.md` Principle I's ordering rule, which is ratified and repository-specific.
+
+**Defect found in the specification itself**: [spec.md](spec.md) quotes the Spec-first bullet
+as "`specs/NNN-*/` artifacts → commit BEFORE any `feat`/`fix`", eliding
+`docs(speckit): add NNN-<feature> spec/plan/tasks` **without marking the elision**. In a
+document whose own FR-008 says "an invented utterance is not a citation", that is
+self-inflicted. The `compatibility.md` quote has the same problem: its ellipsis swallows a
+sentence boundary. Both must be re-quoted in full.
+
+---
+
+## D2. "Experiments Are Parked" — the drafted principle contradicts its own evidence
+
+**Decision**: Do not ship the principle as drafted. Either narrow it to the half that is
+grounded, naming the two existing counter-examples as grandfathered, or drop it and rely on
+the spec's FR-018 and SC-011, which already bind this feature's own artifacts.
+
+**Rationale**: three findings, all confirmed.
+
+1. **The offered citation was refuted.** The hunt proposed ADR-0001 § D7 (`workload` reserved,
+   unused). The verifier rejected it: D7 records an *abstention* — nothing was built, tried,
+   labelled or held anywhere; the ADR says the question "is still open" and the name "is left
+   free". The drafted principle governs work that **exists and is nearly right**. Different
+   thing.
+
+2. **A closer citation exists that the hunt missed** — and it says the opposite of the draft.
+   `constitution.md` Principle III carries the bullet "Any artifact nothing validates MUST say
+   so in its own text." That is ratified and repository-specific, and it grounds the
+   *self-labelling* half of parking. But the drafted text opens "Unsettled work is contained,
+   not labelled. A warning notice on something load-bearing is not containment" — which
+   contradicts the only constitutional text that supports it.
+
+3. **The repository has practised the opposite, twice, in published artifacts.**
+   - `docs/semconv/loadtest.md` announces itself as "a proposal written in semconv style,
+     nothing more … has not been submitted anywhere, and nothing emits these names today" —
+     and core constructs depend on it anyway.
+   - `docs/examples/mapping-k6.yaml` marks its `errorSignal` block "a draft: the expressiveness
+     of conditional rules must stay bounded, or it becomes the very DSL we rejected" — in a
+     published example.
+
+   Both are unsettled work admitted with a label instead of held back. A principle forbidding
+   that would make two committed artifacts retroactively non-compliant on the day it lands.
+
+**Alternatives considered**:
+
+- Ship as drafted — rejected: it contradicts `constitution.md` Principle III's labelling
+  bullet and two committed artifacts.
+- Drop entirely — viable, and the spec already anticipates it. Costs nothing mechanically:
+  FR-018 and SC-011 still bind this feature's own experimental area.
+- **Recommended**: narrow to *new* unsettled work, keep labelling as the mechanism the
+  constitution already blesses, and name `docs/semconv/loadtest.md` and the `errorSignal`
+  sketch as grandfathered with a dated note. This preserves the author's stated intent
+  ("parked, in some form") without a rule the repository itself violates.
+
+**This is the one decision in Phase 0 that the plan cannot take alone** — it changes what the
+constitution says. Carried into Complexity Tracking.
+
+---
+
+## D3. Two better-grounded principles that are not among the candidates
+
+**Decision**: Record them, do not add them in this amendment.
+
+- **A generated artifact never enters the source of truth.** Grounded twice — ADR-0001 § D2
+  ("the word `assertion` does not appear in the OpenNFR schema") and `docs/GLOSSARY.md`
+  § Layer 2 → Assertion, which ranks it: "the single strongest constraint the notes have
+  produced so far, and the one most likely to hold". Not in the constitution.
+- **One concept, one layer; a word is never reused across layers.** Grounded in
+  `docs/GLOSSARY.md` § Layers and ADR-0001 § D2, both naming it as the exact point where the
+  surveyed formats break. Principle I requires a glossary entry and a rejected alternative but
+  says nothing about layer separation.
+
+**Rationale**: both are stronger candidates than one of the four in the spec, but neither is
+*this feature's* subject — this feature is about repository architecture. Principle I treats
+every added rule as a permanent cost, and an amendment that quietly grows from three items to
+five is the kind of scope drift AGENTS.md's one-concern rule exists to stop.
+
+**Alternatives considered**: adding them now — rejected as scope creep into a PR the
+constitution requires to travel alone. They belong in a later amendment with their own
+argument.
+
+---
+
+## D4. The three deferred clarifications
+
+### (a) The experimental area is a real directory with two link rules
+
+**Decision**: Create `docs/experimental/` holding exactly one markdown file, `README.md` — the
+parked monitoring direction's status page (status, promotion condition, retirement condition,
+date, and the follow-up spec that owns it). Add two binding rules to the layout document:
+
+- **No markdown link may point into the experimental area from outside it.** Outside
+  references name the path in prose, inside a code span, never as markdown link syntax.
+- **The area holds markdown only, no YAML.**
+
+**Rationale**: `scripts/verify.sh` fails the build on any dangling internal markdown link, so a
+single inbound link makes SC-007's one-operation deletion turn the gate red. With these two
+rules SC-007 becomes literally executable: `git rm -r docs/experimental && bash scripts/verify.sh`
+stays green. The no-YAML rule keeps the area clear of the sketch-label check, which is
+hardcoded to `docs/examples/*.yaml`.
+
+**Alternatives considered**: prose-only, no directory — rejected: SC-007 and SC-011 become
+unfalsifiable, and this feature's only literally runnable criterion is lost. Inbound links
+permitted with SC-007 reworded — rejected: AGENTS.md makes `verify.sh` the gate and the
+constitution forbids weakening it quietly.
+
+### (b) The `loadtest.*` registry is normative core, at its existing home
+
+**Decision**: File `docs/semconv/` in the normative core. Do not invent a seventh artifact
+class. Discharge FR-015 by widening the normative core's definition in the layout document
+with one clause: it includes the `loadtest.*` registry, the only core artifact whose
+**upstream** status is unratified, which it must state in its own dated text — as it already
+does.
+
+**Rationale**: filed in the experimental area, SC-007's removability claim is false on day one,
+because deleting it breaks `window.phase` and the `loadtest.request.name` addressing fallback
+(ADR-0002 § D14). Principle II already licenses `loadtest.*` names as first-class; Principle IV
+requires the unsubmitted status to be stated, not the artifact to be quarantined.
+
+**Alternatives considered**: a seventh artifact class "proposed upstream contribution" —
+rejected: one artifact does not justify a class, and Principle I prices the new word. The
+experimental area — rejected: makes SC-007 false immediately.
+
+**Consequence**: the constitution's compatibility-surface bullet "any OpenTelemetry name the
+format borrows" does not cover names the format *defines*. Widening it is a candidate edit —
+but see the open question in D6, since it may push the bump past MINOR.
+
+### (c) "Who may change it" is uniform: anyone, by pull request
+
+**Decision**: FR-014's middle column reads the same in every row — **"Anyone, by pull
+request"**. Every difference between classes lives in the third column, "what changing it
+obliges", which FR-014 already mandates. Introduce no role vocabulary at all.
+
+**Rationale**: the constitution's own binding constraint says "A tool list that only
+maintainers can extend is not tool-agnostic", which rules out a role taxonomy for the mappings
+class at least; and Principle I prices every added governance word. Two sentences below the
+table carry the whole answer.
+
+**Alternatives considered**: a prose taxonomy (maintainer / contributor) — rejected: two new
+governance words for no mechanical effect. CODEOWNERS plus branch protection — rejected:
+machinery this repository does not have, for a rule the constitution already fixes.
+
+**Operational catch**: `scripts/check-linkage.sh` gates every PR on a milestone and a
+registered closing link, and outside contributors cannot normally set a milestone on a fork
+PR. The layout document must say who does that on an outsider's behalf, or the "anyone" is
+theatre.
+
+---
+
+## D5. Vocabulary: four defects, one of them in the specification's own trace
+
+**Decision**: settle `target` in the glossary; **drop the noun `binding`**; rename the
+component sense of `reader`; drop `interpreter`; and **fix the endpoint of the traced path**.
+
+| Word | Decision |
+|---|---|
+| `target` | `### Target` in `docs/GLOSSARY.md` § Layer 2. Runtime, between `### Assertion` and `### Adapter`. No fourth layer is created — FR-012 holds literally |
+| `binding` | **Drop the noun.** It collides with `MetricMapping`, and worse, `binding` is already load-bearing in this repository as an *adjective* meaning normative. The artifact class becomes **tool mapping**, home `mappings/` |
+| `monitoring backend` | Collides with `backend`, already used in the glossary in a different sense (the thing that evaluates after the run). By FR-012's own collision test it belongs in the glossary — which contradicts the 2026-08-18 clarification that sent it to the architecture document. **Resolution: define it inside the `Target` entry**, where the collision is visible, and have the architecture document cite rather than redefine it |
+| `reader` | Used in two senses — a human (SC-001, US1, eight more occurrences) and a software component. The human sense is load-bearing for two success criteria. Rename the component to **file adapter** |
+| `interpreter` | A straight synonym of the glossary's `Adapter`. Drop outside the quoted user input; `renderer` and `file adapter` are its legitimate sub-roles |
+| `source` | Four committed senses already. Always write `data source` in full; never the bare noun |
+
+**The trace ends on the wrong word.** FR-001, SC-001 and User Story 1 all end at **verdict** —
+"the verdict a CI job prints". In `docs/GLOSSARY.md` a `Verdict` is "The result of checking
+**one** criterion or guard"; what a CI job prints is an `Outcome`, "The aggregated result of
+the whole run". Ending at `verdict` stops the trace one component short of `gate`, which US1's
+own Acceptance Scenario 1 requires to be named. The three walkthroughs must run
+**requirement → criterion → verdict → gate → outcome**, and FR-001/SC-001 need the word fixed.
+
+**Rationale**: Principle I makes one-concept-one-word the product. Each of these is a live
+collision in a document that has not been written yet, which is the cheapest possible moment.
+
+**Alternatives considered**: keeping `binding` and disambiguating by context — rejected: three
+senses in one repository is exactly what the glossary exists to prevent. Keeping `interpreter`
+because the user's request used it — rejected: the request is input, not vocabulary; the
+architecture document should say plainly that `interpreter` means the glossary's `Adapter`.
+
+**Process**: Principle I requires naming disagreements to be argued in an issue **before files
+change**, and no vocabulary issue exists (`gh issue list` returns #1, #3, #5, all closed, none
+about vocabulary).
+
+---
+
+## D6. The constitution amendment, edit by edit
+
+**Decision**: `1.0.0 → 1.1.0`, MINOR, on both limbs of the policy simultaneously — principles
+are added, and an existing binding constraint is materially expanded.
+
+**Files in the amendment PR — exactly two**:
+
+1. `.specify/memory/constitution.md`
+   - Add `### VI. Evaluation Is Target-Blind` and `### VII. Architecture Before Implementation`
+     after Principle V, before `## Compatibility Constraints`.
+   - Add conditional `### VIII` last (see D2).
+   - Widen the Compatibility Constraints bullet: "Support for a load testing tool" → wording
+     that covers any target.
+   - Governance → Compliance review: "five principles above" → "seven".
+   - Version footer: `1.0.0` → `1.1.0`, `Last Amended` updated.
+   - Rewrite the SYNC IMPACT REPORT comment block in place — it is a current-state report, not
+     a changelog.
+2. `.specify/templates/plan-template.md`
+   - Line 44 hard-codes "See `.specify/memory/constitution.md` (v1.0.0)" — a stale version
+     pointer of exactly the kind this amendment exists to prevent.
+   - Add gate bullets for the new principles, before the Compatibility gate.
+
+**Not touched**: `spec-template.md`, `tasks-template.md`, `checklist-template.md`. The added
+principles impose no new mandatory section; both are checked at plan time.
+
+**A real, unresolved tension in committed text**: if the widened bullet or Principle VI uses
+the noun `target`, the amendment PR introduces a governance word, and the constitution's
+Development Workflow says "A PR that changes a term MUST update `docs/GLOSSARY.md` in the same
+PR" — which the amendment procedure's "and nothing else" forbids.
+
+**Resolution**: settle `target` in the glossary in an **earlier** PR, so that by the time the
+amendment lands the word is not new. This is why the ordering below is not arbitrary.
+
+**PR ordering** — the amendment must land before the architecture and layout documents,
+because the constitution says a conflicting document "is wrong and MUST be fixed", so an
+architecture document written against unamended text is born wrong:
+
+1. spec PR — `specs/` artifacts only
+2. glossary PR — settles `target`, drops `binding`, renames the component sense of `reader`
+3. **constitution amendment PR** — two files, nothing else
+4. architecture document — `docs/architecture.md`
+5. layout document — `docs/layout.md`
+
+**Open**: whether adding `loadtest.*` to the compatibility-surface bullet (D4b) is MINOR or
+PATCH. The policy's MINOR limb covers "existing guidance is materially expanded"; a reviewer
+could read the addition as a clarification instead. Decide when drafting.
+
+---
+
+## D7. Are the three walkthroughs actually writable? Partly — and they expose real defects
+
+**Decision**: SC-002 is achievable for k6 and JMeter from committed evidence. **Gatling is the
+problem**: `docs/examples/` contains `mapping-k6.yaml` and `mapping-jmeter.yaml` and **no
+`mapping-gatling.yaml`**. The Gatling walkthrough must trace from the tool survey alone and
+declare every gap, or the feature must produce a Gatling mapping — which is a tool-mapping
+artifact, and FR-025 forbids this feature from shipping one.
+
+**Rationale and corrections.** The first research pass made several claims the verifier
+overturned; these are the corrected findings:
+
+- **`routeHints` exists and is not JMeter-specific.** It is a field of `kind: MetricMapping`,
+  sketched in `docs/examples/mapping-jmeter.yaml`. `http.route` is therefore addressable for
+  any tool with a mapping — the earlier "not addressable by any construct the repository has
+  sketched" was wrong.
+- **k6's native thresholds are properly sourced.** `docs/compatibility.md` states its facts as
+  "Verified against documentation as of August 2026" and gives k6 `thresholds` and
+  `abortOnFail`, level `abort`. The earlier rejection of that claim misapplied Principle IV.
+- **`http.route` appears in three requirements** of `checkout-perf.yaml` (four times), not four.
+- **"k6: fully honourable" is false.** The ratio indicator cannot render as a k6 threshold:
+  `mapping-k6.yaml` renders selectors as k6 tags, and `error.type` is not a tag — it is derived
+  from a different metric via `errorSignal`.
+- **"Gatling's inline half is honourable" is false.** `docs/GLOSSARY.md` says "`inline` is an
+  adapter capability: k6 and Taurus have it, Gatling and JMeter only partly", and no Gatling
+  mapping exists at all.
+- **Confirmed impossibilities**: Gatling `onViolation: abort` (survey records Abort: no);
+  JMeter both halves (level `report`, "no native assertions rendered").
+- **Unlabelled knowledge claim caught**: an assertion about Gatling's `simulation.log` columns
+  came from the agent's own knowledge, not this repository. Nothing committed speaks to it.
+  Under Principle IV it must be labelled or dropped.
+
+**Four defects in the reference example the walkthroughs will expose.** These are findings
+about `docs/examples/checkout-perf.yaml`, not about the architecture, and they belong in the
+walkthrough as declared gaps and in issues of their own:
+
+1. **`overall-availability` can produce a silent RED.** A run in which nothing fails yields no
+   series carrying `error.type`, hence `noData`, hence `onNoData: fail` — the run fails because
+   the system was perfect.
+2. **An unmeasurable guard fails the run for the wrong reason.** If a tool cannot measure
+   `loadtest.dropped_iterations`, the guard lands on `onNoData: fail` rather than on
+   `onGuardViolation: inconclusive`, so a tool limitation reads as a system failure.
+3. **`skipped` has no gate key.** It appears in the glossary's status enum and as `skipped: 0`
+   in the report sketch, but no `gate` key handles it. Silence is undefined behaviour in a
+   project whose Principle III forbids exactly that.
+4. **`indicatorRef: checkout-latency` points at a Requirement name**, while ADR-0001 § D10 and
+   the glossary describe `Indicator` as a reusable kind of its own.
+
+**Alternatives considered**: dropping Gatling from the three — rejected: it is the internal
+consumer's tool, which is why it ranks alongside k6. Writing a Gatling mapping inside this
+feature — rejected by FR-025, but it becomes the first thing the `target-gatling` follow-up
+spec delivers.
+
+---
+
+## D8. Repository layout
+
+**Decision**: keep the existing tree, add two documents and one directory, move nothing.
+
+| Artifact class | Home | Changing it obliges |
+|---|---|---|
+| Normative core | `docs/` top level, plus `docs/semconv/` | term change updates `docs/GLOSSARY.md` in the same PR with a rejected alternative; naming disagreements argued in an issue first; compatibility-sensitive change requires an ADR |
+| Decision records | `docs/adr/NNNN-slug.md` | a PR contradicting an ADR amends it instead; status stays `proposed` until something validates it |
+| Tool mappings | `mappings/` (was "bindings" — see D5) | claimed conformance level evidenced and dated |
+| Conformance corpus | `docs/examples/` | every file announces itself as a sketch until a schema validates it |
+| Experimental area | `docs/experimental/` | self-labelling; no inbound links; markdown only |
+| Reference implementation | declared, not created | — |
+
+**New documents**: `docs/architecture.md` and `docs/layout.md`, flat in `docs/`, matching the
+existing naming convention. All three walkthroughs stay **inside** `architecture.md`: SC-001
+requires the trace to be followable "using the architecture document alone".
+
+**Rationale**: AGENTS.md forbids opportunistic refactors outside scope, and the two mapping
+files are linked from at least five other documents, so moving them would turn `verify.sh` red
+across the tree. Publish the layout, name the mismatches under FR-013, schedule the moves
+separately.
+
+**Six currently non-conforming entries** to publish as a named list, of which the two sharpest:
+
+- `docs/examples/mapping-k6.yaml` and `mapping-jmeter.yaml` are tool-mapping artifacts sitting
+  in the corpus home. **Moving them has a hidden cost**: `verify.sh`'s sketch-label check is
+  hardcoded to `for f in docs/examples/*.yaml`, so mappings relocated to `mappings/` silently
+  stop being checked until `verify.sh` is extended.
+- `docs/compatibility.md` spans three classes by its own admission — conformance levels
+  (normative), the tool survey (evidence), and the Go notes (proposal).
+
+**Two `verify.sh` behaviours the plan depends on**, both verified by reading the script:
+
+- The link check greps `--include='*.md'` then filters `grep -v '^\./\.'`, so **anything under
+  a dot-prefixed root directory has its outgoing links unchecked** — `.specify/`, `.claude/`,
+  `.github/`. The checked set is 12 files today.
+- The sketch-label check is hardcoded to `docs/examples/*.yaml`.
+
+**`specs/` is not an artifact class** and must be excluded from the layout table explicitly,
+with a sentence saying so — a newcomer scanning the tree will otherwise assume it holds format
+artifacts. Flow is one-directional: a follow-up spec produces artifacts into the homes the
+layout names; it never becomes one.
+
+---
+
+## D9. The follow-up spec list
+
+**Decision**: eleven entries, named by **slug, never by ordinal**, with the dependency graph
+stated explicitly. `specs/NNN-` records the order specs were *created*, not the order they
+must be *completed* — the architecture document must say so in one sentence, because
+`001-nfr-format-architecture` already sets a numbering a reader will read as a schedule.
+
+Entries span: the normative core schema; the tool-mapping schema; the object model; the file
+adapter; evaluation; the renderer; per-target mappings for Gatling, k6 and JMeter; the
+conformance corpus; and the parked monitoring experiment.
+
+**No individual deliverable appears in two entries** — verified by enumerating every claimed
+file. FR-022's unit is the file, which is what makes the check possible; at artifact-class
+granularity it would be unwritable, since the schema, the object model and the corpus all add
+to the normative core.
+
+**`docs/README.md`'s stated next step — "A JSON Schema for the requirement and result
+documents" — names the core-schema entry exactly and stays true.** It is first in dependency
+order.
+
+**The answer to `gatling-picatinny#236`** (FR-024, SC-009), served by the `target-gatling`
+entry: picatinny 2.0 removes `assertionFromYaml` without a one-to-one replacement and
+documents that assertions are written with Gatling's native DSL; the migration note names
+OpenNFR's Gatling target as the intended successor once the renderer lands. That answers the
+issue's "replacement decision needed" without blocking 2.0 on work that does not exist.
+
+**The parked entry carries promotion and retirement conditions instead of a schedule
+position** (SC-011). Promotion requires one unchanged requirement document assembling a valid
+query for **all four** backends, each check dated and sourced. Three of four is not promotion —
+it is a narrower scope, and narrowing requires amending the architecture.
+
+**Open**: every directory name used above is a proposal. None exists today.
+
+---
+
+## D10. Operational preconditions
+
+**Decision**: create GitHub issues before the first PR.
+
+`scripts/check-linkage.sh` gates every PR on carrying milestone `v0.1.0` **and** a registered
+closing link to an issue in that milestone. Milestone `v0.1.0` is the only open one and is
+therefore active under AGENTS.md. It currently reports 0 open and 6 closed items; the three
+issues that exist (#1, #3, #5) are all closed and none covers this work.
+
+**Consequence**: no PR in the sequence of D6 can merge until its issue exists. Issue creation
+is the first task, not an afterthought.
+
+**Superseded 2026-08-18**: `v0.1.0` was tagged, released and closed after this was written.
+`v0.2.0` is the active milestone and is created by T001.
+
+---
+
+## Residual unknowns carried into Phase 1
+
+1. **Whether Principle VIII ships, and in what form** (D2). Changes the constitution's content;
+   recorded in Complexity Tracking.
+2. **Whether `monitoring backend` is settled in the glossary or the architecture document**
+   (D5). FR-012's collision test says glossary; the 2026-08-18 clarification said architecture
+   document. The test is mechanical and the clarification predates the discovery of the
+   `backend` collision, so the test should win — but it reverses a stated answer.
+3. **Whether widening the compatibility-surface bullet to cover `loadtest.*` is MINOR or
+   PATCH** (D4b, D6).
+4. **How the Gatling walkthrough discharges SC-002 without a Gatling mapping** (D7).
+5. **Whether `conformance corpus` survives as a name** — `conformance` already has a closed
+   committed meaning (a level a tool reaches) and is a field name in two published examples.

--- a/specs/001-nfr-format-architecture/spec.md
+++ b/specs/001-nfr-format-architecture/spec.md
@@ -1,0 +1,484 @@
+# Feature Specification: Repository Architecture and Operating Principles
+
+**Feature Branch**: `001-nfr-format-architecture`
+
+**Created**: 2026-08-17
+
+**Status**: Draft
+
+**Input**: User description (translated from Russian; the repository is English-only per
+[ADR-0001](../../docs/adr/0001-terminology.md)):
+
+> Source: the `galax-io/ideas` note *An open format for performance requirements*
+> (`ideas/observability/open-nfr-format.md`) — what can we take from it? We need a minimal
+> requirements format that depends on nothing and is tool-agnostic. Let us think about the
+> repository architecture. It seems there should be a single format with interpreters — for
+> example a Go parser producing objects, a Gatling interpreter that converts requirements
+> into assertions, likewise for k6 — plus formats describing how metrics can be converted
+> for observability through Datadog or other APM tools, so that NFR metrics can be monitored
+> from the application's APM. In other words, we need metrics bound both to load testing
+> tools and to monitoring tools.
+>
+> Do not try to think through the implementation now — rather just the repository layout and
+> how it should all work. Invent principles; the constitution may need amending, but not the
+> implementation. The implementation itself should be done in separate specs, each for a
+> concrete task.
+
+Scope decisions taken during drafting:
+
+> The core keeps the vocabulary that already exists; "minimal" means adding no new construct
+> to it. The monitoring direction is attempted in both directions — query and monitor — but
+> as an **experiment that must be parked**, aimed at a markup rich enough to assemble a query
+> for Datadog, Prometheus, VictoriaMetrics and InfluxDB. One repository holds everything,
+> with support for a target expressed as data.
+
+## Context
+
+This repository is a design notebook ([README](../../README.md)). It has a candidate
+vocabulary ([GLOSSARY](../../docs/GLOSSARY.md)), two proposed ADRs, a verified tool survey
+([compatibility](../../docs/compatibility.md)), unvalidated example documents, and a
+ratified [constitution](../../.specify/memory/constitution.md) with five principles.
+
+What it does not have is a statement of **how the parts fit together**, **where each part
+lives**, and **which rules decide the arguments the architecture is about to create**. Those
+three gaps are what this feature closes.
+
+### What this feature is, and is not
+
+| | |
+|---|---|
+| **Is** | The operating model — one format, several adapters, two classes of target — written down end to end; the repository layout that houses it; the principles that govern it, including an amendment to the constitution; and the list of follow-up specs the implementation must travel through |
+| **Is not** | A schema, a validator, a parser, a renderer, a tool mapping, or any change to the format's field-level design. Every one of those belongs to a separate, later spec with its own concrete task |
+
+The boundary is deliberate. Deciding the architecture and the implementation in one pass is
+how a design notebook becomes a codebase nobody can argue with: the architecture stops being
+reviewable the moment it arrives attached to working code.
+
+### What is taken from the source idea
+
+| From the idea note | Taken as | Why |
+|---|---|---|
+| Every tool has its own assertion syntax, rewritten on every tool change | The motivation for the architecture | Unchanged and still true |
+| Priority tools: JMeter, Gatling, k6 | The three load generators the architecture must be able to serve | They span the whole difficulty range: k6 is the best case, JMeter the worst |
+| "One description works on three tools without edits" | SC-002 | The only criterion that actually tests tool-agnosticism |
+| "At least one real project migrated" | SC-009, via the internal consumer below | Turns an aspiration into a named counterparty |
+| `gatling-picatinny` removes `assertionFromYaml`, recording "replacement decision needed" | A named consumer, and the reason one follow-up spec outranks the others | A real deadline beats a hypothetical user |
+| "Is it YAML, JSON or a DSL?" | Already answered by ADR-0002 § D16; restated, not reopened | The decision exists; reopening it costs more than it buys |
+| "Who is the target user?" | The Assumptions section | Needed to judge what the architecture may assume of its reader |
+| Sibling idea: the three tools disagree on load profile semantics | A reason to keep load profiles out of the format entirely | A construct whose cross-tool meaning is unknown cannot sit in a tool-agnostic format |
+| Sibling idea: generating requirements from human-language text | A constraint on the format, not a deliverable | The format must be a good generation target: closed value sets, no free-form strings |
+
+### Candidate principles
+
+The request asks for principles, so here are the ones the architecture actually needs. Each
+carries the argument it settles **and a citation that grounds it** — committed text named by
+file and section, or a decision already taken here that the principle generalises. A
+principle that can produce neither is decoration, and FR-008 drops it.
+
+| Candidate | What it forbids | The argument it settles | Grounding |
+|---|---|---|---|
+| **Targets Are Data** | Any target — load generator or monitoring backend — requiring code in the format's own implementation before it can be supported | "Let us just special-case JMeter in the reader; it is only one `if`." | [ADR-0002 § D12](../../docs/adr/0002-compatibility.md) — "supporting a new tool means adding a YAML file, not forking the Go code" — plus the constitution's Compatibility Constraints, which say it for load testing tools only. The principle generalises both to monitoring backends |
+| **Evaluation Is Target-Blind** | The component that turns measurements into verdicts knowing which target produced them, or how | "k6 already computed p95 — let us trust its number." Then the verdict depends on the tool, and one document stops meaning one thing | [compatibility.md](../../docs/compatibility.md) § Requirements for the Go implementation → Layering — "The crucial part: the evaluation layer knows nothing about tools or sources. It operates on canonical names — and that is the only reason the format can promise compatibility with an arbitrary tool." Note: that section is in the document's *proposal* half and says nothing is implemented yet |
+| **Experiments Are Parked, Not Merged** | Unsettled work entering the compatibility surface because it is nearly right | "The Datadog mapping mostly works; call it v1." Four query languages and four percentile implementations are not nearly-right material | **Contested — see [research.md](research.md) § D2.** The nearest committed text is constitution Principle III's "Any artifact nothing validates MUST say so in its own text", which grounds *labelling* — the opposite of what the draft says. Two published artifacts already practise labelling over containment. Ships only in a narrowed form, or is dropped |
+| **Architecture Before Implementation** | Code arriving without a spec naming the architectural role it fills; a spec changing the architecture implicitly | "Let us write the parser and see what shape falls out." | [AGENTS.md](../../AGENTS.md) § Commits & PRs — "**Spec-first.** `specs/NNN-*/` artifacts → `docs(speckit): add NNN-&lt;feature&gt; spec/plan/tasks` commit BEFORE any `feat`/`fix`. Never folded into implementation." Co-cited with constitution Principle I's ordering rule, because AGENTS.md declares everything below its `---` to be boilerplate reused across projects rather than an argument this repository had |
+
+The amendment is MINOR under the constitution's own versioning policy: the existing
+constraint "support for a load testing tool must be expressible as data" is widened rather
+than duplicated, and the surviving candidates are new obligations. How many survive is
+decided by FR-008's drop test at writing time, not asserted here.
+
+### Decisions carried forward
+
+- **Core = the existing vocabulary, frozen.** "Minimal" is a zero budget for new constructs,
+  not a demolition of the glossary. The honest consequence — some core constructs depend on
+  an unratified attribute, on stored run history, or on a tool capability — is a fact the
+  architecture must expose, not hide.
+- **The monitoring direction is experimental and parked.** Both directions are attempted:
+  assembling a query, and emitting a native monitor. The target vocabulary must serve
+  Datadog, Prometheus, VictoriaMetrics and InfluxDB.
+- **One repository.** Core, tool mappings, corpus, experimental area, decision records and the
+  eventual reference implementation live here. Tool-native integrations live in the tool's
+  own repository and consume this one.
+
+## Clarifications
+
+### Session 2026-08-18
+
+- Q: How much of the four-backend monitoring work is discharged inside this feature, and what does SC-002's "walking each path on paper" produce? → A: Publish three load-generator walkthroughs in full over one named example document; state the monitoring half as an explicitly unverified, dated claim owned by the parked follow-up spec, and narrow SC-002's verified half to three targets.
+- Q: Are "monitoring backend" and "data source" one concept or two, and which word does the architecture use for Prometheus? → A: Two concepts, two words — `data source` is inbound (supplies normalised series to evaluation, a parameter per ADR-0002 § D18), `monitoring backend` is outbound (receives an assembled query or a standing monitor). One product may play both roles, and each glossary entry names the other.
+- Q: Which of this feature's new words are "terms" under FR-012, and does docs/GLOSSARY.md host them? → A: Split by collision — only words colliding with one already in the glossary (`target`, and `binding` if kept) are settled there, where the collision is visible; the remaining governance words are defined in the layout document, each with its own rejected alternative. The glossary keeps its three-layer structure.
+- Q: What counts as "at least one argument already recorded in this repository" for FR-008's drop test? → A: A citation to committed text named by file and section, OR to a decision already taken here with the decision the principle generalises named. An invented utterance is not a citation. Three candidates cite committed text; "Experiments Are Parked" currently cites nothing and is dropped unless it finds a citation.
+- Q: What status does the architecture document carry, and what makes FR-023's "amend the architecture first" enforceable? → A: A split status inside one document — component roles, their forbidden dependencies and the follow-up boundaries bind later specs; every description of a component that does not yet exist is marked proposed. The document states its own amendment procedure: an ordinary PR editing it, landing before the diverging spec, with no decision record required.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Someone new understands how the whole thing works (Priority: P1)
+
+A reader who has never seen this project opens one document and can follow a requirement
+from the engineer who writes it to the verdict a CI job prints: what reads it, what turns it
+into something a load generator understands, what reads the run back, what decides pass or
+fail, and where a monitoring backend enters the picture. At every step they can see what that
+step is handed, what it returns, and what it is forbidden to know.
+
+**Why this priority**: "how it should all work" is the request, and nothing else in this
+feature can be reviewed without it. It delivers value with no code and no format change: an
+architecture document is immediately usable as the thing every later spec is checked against.
+
+**Independent Test**: hand the architecture document to someone who has read nothing else and
+ask them to trace one example requirement end to end, naming each component. Any step they
+cannot name, or any point where they must guess what a component knows, is a defect. The
+document must carry that trace worked through for each of k6, Gatling and JMeter over
+[docs/examples/checkout-perf.yaml](../../docs/examples/checkout-perf.yaml); a missing or
+unfollowable walkthrough is the same defect.
+
+**Acceptance Scenarios**:
+
+1. **Given** the architecture document, **When** a reader traces a requirement from authoring
+   to outcome, **Then** every component on the path — including `gate` — is named and no step requires information
+   the previous step did not provide.
+2. **Given** any named component, **When** a reader asks what it must not depend on, **Then**
+   the answer is written down.
+3. **Given** the component that decides pass or fail, **When** a reader asks whether it knows
+   which tool produced the measurements, **Then** the answer is no, and the reason is recorded.
+4. **Given** the two classes of target — load generators and monitoring backends — **When** a
+   reader asks how each is supported, **Then** the answer is "by adding data", identically for
+   both.
+5. **Given** the monitoring direction, **When** a reader opens any part of it, **Then** its own
+   text says it is experimental, what would promote it, and what would retire it.
+6. **Given** a criterion a target cannot honour, **When** the architecture describes what
+   happens, **Then** the answer is a named failure, never a silent substitution.
+
+---
+
+### User Story 2 - The project has principles that end arguments (Priority: P2)
+
+A maintainer facing a recurring design argument — should this tool get a special case, may we
+trust a tool's own percentile, is this experiment ready — finds the argument already decided
+in writing, with the reasoning and the rejected alternative attached. Where a new principle
+extends or contradicts the ratified constitution, the constitution is amended through its own
+procedure rather than quietly outvoted by a newer document.
+
+**Why this priority**: the architecture creates exactly the kind of recurring decision that
+erodes under deadline pressure, and the constitution as ratified predates it. Principles are
+independently valuable — they govern work that has not been specified yet.
+
+**Independent Test**: for each principle, produce its citation — committed text named by file
+and section, or a decision already taken here that the principle generalises. A principle that
+can produce neither is removed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a proposed principle, **When** it is reviewed, **Then** it names what it forbids,
+   the failure it prevents, and at least one real argument it settles.
+2. **Given** a principle that extends the constitution, **When** it is adopted, **Then** the
+   constitution is amended and its version is bumped under its own policy.
+3. **Given** the constitution's amendment procedure, **When** the amendment is proposed,
+   **Then** it travels as a change to the constitution and affected templates and nothing
+   else.
+4. **Given** any later change that contradicts a principle, **When** it is reviewed, **Then**
+   it is either rejected or accompanied by an amendment — never silently accepted.
+
+---
+
+### User Story 3 - A contributor can find and change exactly one thing (Priority: P3)
+
+A contributor wants to add support for their load generator, or fix a term, or record a
+decision. They open the layout document, find the one place that artifact class lives, learn
+who may change it and what changing it obliges, and make a change that touches nothing else.
+Adding a target never requires touching the format's normative text.
+
+**Why this priority**: the layout is what makes "support is data, not code" true in practice
+rather than in principle. It ranks below the architecture because it is the architecture's
+filing system.
+
+**Independent Test**: hand the layout document to someone who has not read the rest and ask
+them to list every file they would create to add a new load generator, and every file they
+would need permission to touch. Compare against what the architecture actually requires.
+
+**Acceptance Scenarios**:
+
+1. **Given** the layout document, **When** a contributor adds a target, **Then** the normative
+   core is untouched.
+2. **Given** any artifact in the repository, **When** a contributor asks where its class
+   belongs, **Then** exactly one location answers.
+3. **Given** a change to a compatibility-sensitive surface, **When** it is proposed, **Then**
+   the layout document already told the contributor an ADR is required.
+4. **Given** the experimental area, **When** a contributor changes it, **Then** no ADR and no
+   core version bump is required, because that area is outside the compatibility surface by
+   construction.
+5. **Given** the experimental area, **When** it is deleted in one operation, **Then** nothing
+   outside it changes.
+
+---
+
+### User Story 4 - The work ahead is cut into separate, non-overlapping specs (Priority: P4)
+
+A maintainer planning the next quarter reads a list of the specs the implementation must
+travel through — the schema, the object model, each renderer, the file adapter for file-based
+tools, the conformance corpus, the parked monitoring experiment — each with a stated
+boundary and a stated dependency on the others. No two overlap, none re-derives the
+architecture, and each can be picked up on its own.
+
+**Why this priority**: it is the request's explicit instruction, and it is the mechanism that
+keeps this feature from silently becoming an implementation project. It comes last because
+the boundaries follow from the architecture.
+
+**Independent Test**: check every named follow-up spec for a boundary, a dependency, and an
+architectural role it fills. Check that no individual deliverable appears in two of them.
+
+**Acceptance Scenarios**:
+
+1. **Given** the follow-up list, **When** a maintainer picks any entry, **Then** it states
+   what it delivers, what it depends on, and which architectural role it implements.
+2. **Given** two follow-up entries, **When** they are compared, **Then** no artifact is
+   claimed by both.
+3. **Given** a follow-up spec that would change the architecture, **When** it is written,
+   **Then** it amends the architecture first rather than diverging from it.
+4. **Given** this feature's own output, **When** it is inspected, **Then** it contains no
+   schema, no validator and no executable artifact.
+
+---
+
+### Edge Cases
+
+- **A later spec needs something the architecture forbids.** There must be a stated route —
+  amend the architecture — and it must be cheaper than the workaround, or people will take
+  the workaround.
+- **A principle contradicts the ratified constitution.** The constitution wins until amended;
+  a newer document silently overriding it is the failure mode the constitution exists to
+  prevent.
+- **The architecture document goes stale.** It describes components that do not exist yet, so
+  drift is guaranteed unless its status is honest about what is described versus what is
+  built.
+- **A target class needs a role the architecture does not have.** A monitoring backend can
+  host a standing monitor that must be reconciled over time; no load generator does anything
+  like that. The architecture must either name that role or state that it is out of scope.
+- **The experiment is abandoned.** Withdrawing it must cost nothing outside its own area —
+  otherwise "parked" was never true.
+- **A tool-native integration in another repository drifts from the format.** The architecture
+  must say which side is authoritative and how the drift becomes visible.
+- **Two artifact classes want the same home**, or an artifact belongs to none. Both make the
+  layout unusable for the newcomer it exists to serve.
+- **A follow-up spec is completed out of order**, before the one it depends on. The
+  dependencies must be stated, not implied by numbering.
+- **A core construct's own dependency is unavailable** — no recorded run phase, no stored
+  previous run. The architecture must forbid degrading into "evaluate everything instead" or
+  "pass by default".
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### The operating model
+
+- **FR-001**: The repository MUST publish an architecture document that traces a requirement
+  from authoring to outcome — `requirement → criterion → verdict → gate → outcome` — naming
+  every component on the path. The trace MUST be worked
+  through concretely over one named example document, once per load generator, rather than
+  described in the abstract.
+- **FR-002**: For each named component the document MUST state its input, its output, and at
+  least one thing it is forbidden to depend on.
+- **FR-003**: The component that produces verdicts MUST be defined as independent of which
+  target produced the measurements and of how they were obtained.
+- **FR-004**: The architecture MUST define two classes of target — load generators and
+  monitoring backends — and MUST state, for each, that support is added as data. Any claim
+  about a monitoring backend that this feature does not work through MUST be published as
+  explicitly unverified, carry the date it was made, and name the parked follow-up spec that
+  owns verifying it.
+- **FR-005**: The data source MUST remain a parameter of evaluation and MUST NOT appear in a
+  requirement document, preserving [ADR-0002 § D18](../../docs/adr/0002-compatibility.md).
+- **FR-005a**: The architecture MUST keep two distinct concepts with two distinct words for
+  the two directions a metrics product can face: the **data source**, inbound, which supplies
+  normalised series to evaluation and stays a parameter of it; and the **monitoring backend**,
+  outbound, which receives an assembled query or a standing monitor. It MUST state that one
+  product — Prometheus is the obvious case — may play both roles in one run, and each
+  definition MUST name the other so the two are never read as synonyms.
+- **FR-006**: The architecture MUST NOT admit any construct that is checkable only while a run
+  is in progress. Anything expressible MUST also be evaluable after the fact.
+- **FR-007**: The architecture MUST state what happens when a target cannot honour a
+  construct: a named failure, never a substitution, an approximation, or a silent omission.
+
+#### Principles and governance
+
+- **FR-008**: Every principle adopted by this feature MUST state what it forbids, the failure
+  it prevents, and a citation that grounds it: either committed text in this repository, named
+  by file and section, or a decision already taken here, naming the decision the principle
+  generalises. An invented utterance is not a citation. A principle that can produce neither
+  MUST be dropped.
+- **FR-009**: Principles that extend or contradict the ratified constitution MUST be adopted
+  by amending the constitution, with a version bump under its own versioning policy.
+- **FR-010**: The constitution amendment MUST travel as its own change, containing the
+  constitution and any templates it affects and nothing else, as the constitution's amendment
+  procedure requires.
+- **FR-011**: Where a new principle widens an existing constitutional constraint, it MUST
+  widen that constraint rather than add a parallel one saying nearly the same thing.
+- **FR-012**: Every word this feature introduces MUST carry at least one rejected alternative
+  before it appears anywhere else, in exactly one of two homes:
+  - a word that collides with one already used in [GLOSSARY.md](../../docs/GLOSSARY.md) —
+    `target` against "target load" in the Requirement entry, and `binding` if that word is
+    kept — MUST be settled in the glossary, where the collision is visible;
+  - every other governance word — `artifact class`, `component role`,
+    `compatibility-sensitive surface`, `experimental area`, `follow-up spec` and the like —
+    MUST be defined in the layout document with its own rejected alternative.
+
+  The glossary's three-layer structure MUST NOT gain a fourth layer, and no word may be
+  defined in both homes.
+- **FR-013**: Every document this feature produces MUST state its own status honestly —
+  what is described, what is decided, and what is merely proposed. The architecture document
+  MUST carry a **split status**: its component roles, their forbidden dependencies and its
+  follow-up boundaries bind later specs, while every description of a component that does not
+  yet exist is marked proposed. No statement in it may be left unmarked.
+
+#### Repository layout
+
+- **FR-014**: The repository MUST publish a layout document naming, for each artifact class,
+  where it lives, who may change it, and what changing it obliges.
+- **FR-015**: Every artifact class MUST have exactly one home. An artifact belonging to no
+  class, or to two, MUST be treated as a defect of the layout. One such defect is already
+  known and MUST be resolved by the layout document rather than left implicit: the unratified
+  [`loadtest.*` registry](../../docs/semconv/loadtest.md) is an unsubmitted proposal to an
+  external standards body that core constructs already depend on, and none of the artifact
+  classes named in Key Entities currently accommodates it.
+- **FR-016**: All artifact classes MUST live in this single repository. Tool-native
+  integrations MUST live in the tool's own repository and consume this one rather than copy
+  it, and the layout document MUST state which side is authoritative.
+- **FR-017**: The list of compatibility-sensitive surfaces MUST be published, and every change
+  to one MUST require a decision record.
+- **FR-018**: The experimental area MUST be excluded from the compatibility-sensitive surface
+  by construction, MUST be changeable without a decision record or a core version bump, and
+  MUST be removable in one operation without changing anything outside it.
+- **FR-019**: Adding support for a target MUST require changing no normative-core artifact and
+  no reference-implementation artifact.
+- **FR-020**: A published procedure MUST exist for contributing support for a target,
+  including what to write, what conformance level it claims, and how that claim is evidenced.
+
+#### Decomposition into follow-up work
+
+- **FR-021**: The architecture MUST name the follow-up specs the implementation travels
+  through, each with what it delivers, what it depends on, and the architectural role it
+  fills.
+- **FR-022**: No two follow-up specs may claim the same deliverable. The unit of claim is an
+  individual document or file, not an artifact class: several follow-up specs will
+  legitimately add to the normative core, and a class-level test would make the list
+  unwritable.
+- **FR-023**: A follow-up spec that would change the architecture MUST amend the architecture
+  first; diverging from it silently is FORBIDDEN. The architecture document MUST state its own
+  amendment procedure: an ordinary pull request editing it, landing before the diverging spec.
+  Amending it MUST NOT require a decision record — it is not on the compatibility-sensitive
+  surface — so the sanctioned route stays cheaper than the workaround.
+- **FR-024**: The follow-up list MUST identify which entry serves the internal consumer whose
+  YAML-driven assertion mechanism is being removed, so that its open decision receives a
+  concrete answer.
+- **FR-025**: This feature MUST produce no schema, no validator, no parser, no renderer, no
+  tool mapping and no executable artifact. Its output is documentation and governance only.
+
+### Key Entities
+
+- **Architecture document**: the end-to-end account of how a requirement becomes a verdict,
+  and the reference every later spec is checked against.
+- **Component role**: a named job in that account, defined by what it is handed, what it
+  returns, and what it may not know. Roles are contracts, not modules.
+- **Target class**: load generators, which produce traffic and can sometimes assert during a
+  run; monitoring backends, which hold telemetry, answer queries and can host standing
+  monitors. Different capabilities, identical support mechanism.
+- **Data source**: whatever supplies normalised series to evaluation for one run — an OTLP
+  stream, a Prometheus instance, a JTL file. Inbound, and a parameter of evaluation rather
+  than a property of a requirement. Distinct from a monitoring backend, which faces outbound;
+  one product may be both, in which case it is named by the role it is playing.
+- **Artifact class**: a kind of thing the repository holds — normative core, decision records,
+  tool mappings, conformance corpus, experimental area, reference implementation — each with one
+  home and one rule for changing it.
+- **Compatibility-sensitive surface**: the published set of things that cannot change without
+  a decision record.
+- **Experimental area**: the parked part of the repository. Outside that surface,
+  self-labelling, and removable in one piece.
+- **Follow-up spec**: one concrete implementation task with a stated boundary, a stated
+  dependency, and the architectural role it fills.
+- **Principle**: a written rule that decides a recurring argument, carrying what it forbids,
+  the failure it prevents, and the case it settles.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader who has read nothing else can trace one example requirement from
+  authoring to outcome, naming every component, using the architecture document alone.
+- **SC-002**: One named requirement document —
+  [docs/examples/checkout-perf.yaml](../../docs/examples/checkout-perf.yaml) — unchanged in
+  every character, is walked end to end for each of the three load generators, and all three
+  walkthroughs are published. The four monitoring backends are not walked here: the claim
+  that the same document reaches them is published as explicitly unverified and dated, and is
+  owned by the parked follow-up spec.
+- **SC-003**: Every principle adopted carries a citation to committed text or to a decision
+  already taken here, resolvable by file and section without reading git history; principles
+  carrying none are zero.
+- **SC-004**: The constitution's version reflects the amendment, or the specification states
+  explicitly that no amendment was needed — silence about it is a failure.
+- **SC-005**: Every artifact class has exactly one home; the number of artifact classes with
+  no home or two homes is zero.
+- **SC-006**: A newcomer given only the layout document correctly names every file needed to
+  add a new target.
+- **SC-007**: Deleting the experimental area in one operation changes zero files outside it.
+- **SC-008**: Every follow-up spec named has a boundary, a dependency and an architectural
+  role; the number of individual deliverables claimed by two of them is zero.
+- **SC-009**: The internal consumer's open question about replacing its YAML-driven assertion
+  mechanism is answered by a named follow-up spec rather than left pending.
+- **SC-010**: This feature adds zero executable artifacts and zero constructs to the
+  requirement vocabulary.
+- **SC-011**: Every artifact in the experimental area states its own status and its promotion
+  and retirement conditions — 100%, verifiable by inspection.
+- **SC-012**: No construct the architecture admits is expressible only while a run is in
+  progress — verified construct by construct.
+- **SC-013**: Every word this feature introduces carries a rejected alternative in exactly one
+  home; the number of introduced words with no rejected alternative, or with one in both
+  homes, is zero.
+- **SC-014**: Every statement in the architecture document is marked either binding or
+  proposed; the number of unmarked statements is zero.
+
+## Assumptions
+
+- **Deliverable class.** This feature produces documentation and governance: the architecture
+  document including three worked walkthroughs over one named example, the layout document,
+  the constitution amendment, glossary entries for any new term, and the follow-up list. No
+  schema, no validator, no code, no tool mappings. This is
+  the request's explicit instruction and it matches the constitution's ordering, in which a
+  term is fixed in the glossary before anything encodes it.
+- **Everything already decided stays decided.** The surface syntax (a JSON-compatible subset
+  of YAML, strict parsing, camelCase), the borrowing of OpenTelemetry names, the three-layer
+  vocabulary and the conformance levels are inputs to this feature, not subjects of it.
+- **The core vocabulary is frozen, not audited.** Constructs that depend on an unratified
+  attribute, on stored run history, or on a tool capability keep their place; the architecture
+  is obliged to expose those dependencies, not to remove them.
+- **Target users.** The author is a performance or QA engineer stating requirements; the
+  consumers are load testing adapters, CI backends and monitoring integrations. Requirements
+  outlive the tests that check them, which is why a requirement document may not name a tool.
+- **Priority targets.** k6, Gatling and JMeter for load generation — the three this feature
+  actually works through. Datadog, Prometheus, VictoriaMetrics and InfluxDB name the parked
+  monitoring experiment's intended scope, chosen to span one commercial sketch-based stack,
+  two label-and-bucket stacks and one with a different data model, so the vocabulary is
+  stressed rather than fitted to one backend. Naming them here is a statement of intent, not
+  a demonstration.
+- **Named consumer.** The organisation's Gatling wrapper is removing its YAML-driven assertion
+  mechanism and has recorded that a replacement decision is needed. That is why a renderer for
+  it ranks first among the follow-up specs.
+- **Governance.** The constitution v1.0.0 applies in full; where this specification and the
+  constitution disagree, the constitution wins until amended. Work belongs to the active
+  milestone `v0.2.0`. (`v0.1.0` was tagged, released and closed on 2026-08-18.)
+- **Verification.** `bash scripts/verify.sh` remains the gate: sketches parse, internal links
+  resolve, documents stay English, examples announce themselves as unvalidated. Extending it
+  is out of scope here, because this feature adds nothing it could validate.
+
+## Dependencies
+
+- **The ratified constitution** ([constitution.md](../../.specify/memory/constitution.md)) —
+  amended by this feature, and binding on it in the meantime.
+- **The existing vocabulary and decision records** ([GLOSSARY.md](../../docs/GLOSSARY.md),
+  [ADR-0001](../../docs/adr/0001-terminology.md),
+  [ADR-0002](../../docs/adr/0002-compatibility.md)) — inputs, not subjects.
+- **The verified tool survey** ([compatibility.md](../../docs/compatibility.md)) — what each
+  tool actually emits as of August 2026. Any new claim about a tool or a monitoring backend
+  must be checked the same way and dated.
+- **Four monitoring backends' query semantics** — Datadog, Prometheus, VictoriaMetrics and
+  InfluxDB. Outside this project's control, and the reason that direction is parked.
+- **The internal Gatling wrapper's pending replacement decision** — the counterparty for
+  SC-009. Outside this repository, and its schedule is not controlled here.

--- a/specs/001-nfr-format-architecture/tasks.md
+++ b/specs/001-nfr-format-architecture/tasks.md
@@ -1,0 +1,243 @@
+---
+
+description: "Task list for 001-nfr-format-architecture"
+---
+
+# Tasks: Repository Architecture and Operating Principles
+
+**Input**: Design documents from `/specs/001-nfr-format-architecture/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: No test tasks. This feature ships documentation and governance only (FR-025); there
+is nothing to unit-test. Verification is `bash scripts/verify.sh` plus the six executable
+checks in [quickstart.md](quickstart.md), which appear as verification tasks in their phases.
+
+**Organization**: Grouped by user story. One phase per story, each independently reviewable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US4, matching [spec.md](spec.md)
+- Exact file paths in every description
+
+## Path Conventions
+
+Repository root. Format artifacts live in `docs/`; governance in `.specify/`. There is no
+`src/` and no `tests/` — this feature writes markdown.
+
+---
+
+## ⚠️ Phase order is not priority order
+
+US1 (architecture) is **P1** and the MVP, but its phase sits **after** US2's. This is
+deliberate and load-bearing:
+
+> The constitution says a conflicting document "is wrong and MUST be fixed". An architecture
+> document written against unamended text is born wrong. And the amendment PR may contain
+> nothing but the constitution and the templates it affects — which forbids it from carrying
+> the glossary entry its own new wording needs.
+
+So the sequence is **glossary → amendment → architecture → layout → follow-up list**. Priority
+still decides what matters most; the constitution decides what lands first. Where they
+disagree, the constitution wins.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Unblock CI. No PR in this feature can merge until these exist.
+
+- [ ] T001 Create milestone `v0.2.0` in `galax-io/opennfr` via `gh api repos/galax-io/opennfr/milestones -X POST -f title=v0.2.0 -f description="Repository architecture and operating principles…"` — no open milestone exists, so `scripts/check-linkage.sh` exits 2 on every PR until this lands
+- [ ] T002 Create issue "Settle the vocabulary this architecture introduces" on milestone `v0.2.0`, per Principle I's rule that naming disagreements are argued in an issue before files change
+- [ ] T003 [P] Create issue "Amend the constitution to v1.1.0" on milestone `v0.2.0`
+- [ ] T004 [P] Create issue "Publish the architecture document" on milestone `v0.2.0`
+- [ ] T005 [P] Create issue "Publish the repository layout document" on milestone `v0.2.0`
+- [ ] T006 [P] Create issue "Name the follow-up specs the implementation travels through" on milestone `v0.2.0`
+- [ ] T006a [P] Create issue "Publish the 001 architecture spec, plan and tasks" on milestone `v0.2.0` — T007 requires a closing link, and every other Phase 1 issue is already claimed by a later PR
+- [ ] T007 Commit the spec artifacts as `docs(speckit): add 001-nfr-format-architecture spec/plan/tasks` covering `specs/001-nfr-format-architecture/` and the `.gitignore` entry for `.specify/feature.json`, assigned to `v0.2.0` with a closing link
+- [ ] T008 [P] Delete the merged leftovers `origin/chore/speckit-extensions` and `origin/docs/constitution`, both empty against `main` after squash-merge
+
+**Checkpoint**: `bash scripts/check-linkage.sh` resolves an open milestone; PRs can merge.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Settle every contested word before any document uses it. Both new documents are
+made of these words, so nothing downstream can start.
+
+**⚠️ CRITICAL**: No user story work begins until this phase is complete.
+
+- [X] T009 Add `### Target` to `docs/GLOSSARY.md` inside `## Layer 2. Runtime`, between `### Assertion` and `### Adapter`, defining both target classes with at least one rejected alternative — no fourth layer is created (FR-012)
+- [X] T010 Define `monitoring backend` inside that same `### Target` entry in `docs/GLOSSARY.md` as the second class, because `backend` already carries a different sense in the `enforcement` table and the `EvaluationReport` entry — this reverses the 2026-08-18 clarification, which predates the collision
+- [X] T011 Drop the noun `binding` project-wide in favour of `tool mapping`: it collides with `MetricMapping` and with `binding` used as an adjective meaning normative. Edit `specs/001-nfr-format-architecture/spec.md` (the Key Entities artifact-class list and FR-012's parenthetical)
+- [X] T012 [P] Extend the ASCII layer diagram in `docs/GLOSSARY.md` so the monitoring class is visible — today it shows only `(k6/Gatling)`, leaving the second target class absent from the only picture the glossary has
+- [X] T013 Fix the traced path's endpoint in `specs/001-nfr-format-architecture/spec.md`: FR-001, SC-001 and User Story 1 end at *verdict*, but a `Verdict` is the result of checking one criterion — what a CI job prints is an `Outcome`. The path is `requirement → criterion → verdict → gate → outcome`
+- [ ] T014 Open the glossary PR with issue T002's closing link and milestone `v0.2.0`; confirm `bash scripts/verify.sh` passes
+
+**Checkpoint**: Every contested word has exactly one home and one meaning.
+
+---
+
+## Phase 3: User Story 2 — Principles that end arguments (Priority: P2)
+
+**Goal**: The project gains ratified rules that decide the recurring arguments the
+architecture creates, through the constitution's own amendment procedure.
+
+**Independent Test**: For each principle, produce its citation — committed text named by file
+and section, or a decision already taken here. A principle that can produce neither is
+removed.
+
+**Lands before US1** — see the phase-order note above.
+
+- [X] T015 [US2] Decide the fate of "Experiments Are Parked, Not Merged" — **needs the author**. Its offered citation (ADR-0001 § D7) was refuted as an abstention, not a parking; the nearest committed text, Principle III's "Any artifact nothing validates MUST say so in its own text", blesses labelling, which the draft rejects; and `docs/semconv/loadtest.md` plus the `errorSignal` block in `docs/examples/mapping-k6.yaml` already practise labelling over containment. See [research.md](research.md) § D2
+- [X] T016 [US2] Draft `### VI. Evaluation Is Target-Blind` in `.specify/memory/constitution.md`, after Principle V and before `## Compatibility Constraints`, citing `docs/compatibility.md` § Requirements for the Go implementation → Layering — and noting that section is in the document's proposal half
+- [X] T017 [US2] Draft `### VII. Architecture Before Implementation` in `.specify/memory/constitution.md`, immediately after VI, co-citing `AGENTS.md` § Commits & PRs and constitution Principle I's ordering rule, because AGENTS.md declares its lower half boilerplate reused across projects
+- [X] T018 [US2] Draft `### VIII` last in `.specify/memory/constitution.md` if T015 keeps it, so dropping it renumbers nothing
+- [X] T019 [US2] Widen the Compatibility Constraints bullet in `.specify/memory/constitution.md` from "Support for a load testing tool MUST be expressible as data" to cover any target — a widening, not a parallel bullet (FR-011)
+- [X] T020 [US2] Update Governance → Compliance review in `.specify/memory/constitution.md`: "five principles above" → the surviving count
+- [X] T021 [US2] Update the version footer in `.specify/memory/constitution.md` to `1.1.0` with today's Last Amended date
+- [X] T022 [US2] Rewrite the SYNC IMPACT REPORT comment block at the top of `.specify/memory/constitution.md` in place — it is a current-state report, not a changelog
+- [X] T023 [US2] Fix the stale pointer in `.specify/templates/plan-template.md`: "See `.specify/memory/constitution.md` (v1.0.0)" → `(v1.1.0)`. This is exactly the drift the amendment exists to prevent
+- [X] T024 [US2] Add Constitution Check gate bullets for the new principles to `.specify/templates/plan-template.md`, before the Compatibility gate
+- [X] T025 [US2] Verify `.specify/templates/spec-template.md`, `tasks-template.md` and `checklist-template.md` need no edit, and that the amendment PR touches **exactly two files**
+- [ ] T026 [US2] Open the amendment PR — `.specify/memory/constitution.md` and `.specify/templates/plan-template.md` and nothing else — with issue T003's closing link
+- [X] T027 [US2] Run the SC-004 checks from [quickstart.md](quickstart.md) § 3: version footer, template pointer, principle count, Compliance review sentence all agree
+
+**Checkpoint**: The constitution is v1.1.0 and every later document can be written against it.
+
+---
+
+## Phase 4: User Story 1 — Someone new understands how it works (Priority: P1) 🎯 MVP
+
+**Goal**: One document traces a requirement from authoring to outcome, naming every component
+and what each may not know, worked through concretely for three load generators.
+
+**Independent Test**: Hand `docs/architecture.md` to someone who has read nothing else and ask
+them to trace one requirement end to end, naming each component. A step they cannot name, or a
+point where they must guess what a component knows, is a defect.
+
+- [X] T028 [US1] Create `docs/architecture.md` with its own split-status declaration: component roles, their forbidden dependencies and the follow-up boundaries bind later specs; every description of a component that does not exist is marked proposed; no statement is unmarked (FR-013, SC-014)
+- [X] T029 [US1] Write the component-role table in `docs/architecture.md` from [contracts/component-roles.md](contracts/component-roles.md) — four roles, each with input, output and at least one forbidden dependency (FR-002). State that these contracts are authored here, not inherited from `docs/compatibility.md` § Layering, which gives responsibilities without contracts and sits in that document's proposal half
+- [X] T030 [US1] State in `docs/architecture.md` that Render and Ingest are sub-roles of the glossary's `Adapter`, not a rival decomposition — Principle I forbids a second decomposition of one pipeline. Note that `interpreter` in the original request means `Adapter`
+- [X] T030a [US1] State in `docs/architecture.md` what happens when a target cannot honour a construct (FR-007): a named failure, never a substitution, an approximation or a silent omission — US1 Acceptance Scenario 6 requires this of the MVP
+- [X] T031 [US1] Write the k6 walkthrough in `docs/architecture.md` over `docs/examples/checkout-perf.yaml`, tracing requirement → criterion → verdict → gate → outcome. Declare the gap: the ratio indicator cannot render as a k6 threshold, because selectors become k6 tags and `error.type` is derived from a separate metric via `errorSignal`
+- [X] T032 [US1] Write the JMeter walkthrough in `docs/architecture.md` over the same document. Declare conformance `report`, addressing via `routeHints`, and that no criterion renders natively
+- [X] T033 [US1] Write the Gatling walkthrough in `docs/architecture.md` over the same document, **from the dated survey alone** — `docs/examples/` has no Gatling mapping and FR-025 forbids creating one here. Declare every gap, including `onViolation: abort` being impossible, and name `target-gatling` as the follow-up that will supply the mapping
+- [X] T034 [US1] Define the two target classes in `docs/architecture.md` and state that support for each is added as data. Mark the four monitoring backends as an **explicitly unverified, dated claim** owned by the parked follow-up spec (FR-004)
+- [X] T035 [US1] Cite `data source` from ADR-0002 § D18 in `docs/architecture.md` rather than redefining it, and cite `monitoring backend` from the glossary entry created in T010. Always write `data source` in full — the bare noun already carries four committed senses
+- [X] T036 [US1] State the architecture document's own amendment procedure in `docs/architecture.md`: an ordinary PR editing it, landing before the diverging spec, **no decision record required** — the sanctioned route must stay cheaper than the workaround (FR-023)
+- [X] T037 [US1] Create `docs/experimental/README.md` as the parked monitoring direction's status page: experimental status, promotion conditions, retirement conditions, the date, and the follow-up spec that owns it (FR-018, SC-011)
+- [X] T038 [US1] Add the two containment rules to `docs/experimental/README.md` and to the architecture document: no markdown link points into the area from outside it, and the area holds markdown only. Without both, SC-007's one-operation deletion turns `scripts/verify.sh` red
+- [X] T039 [US1] [P] Add `docs/architecture.md` to the Documents tables in `README.md` and `docs/README.md` — a document nothing links to is not published, and nothing in `verify.sh` catches the omission
+- [X] T040 [US1] Run the SC-007 check from [quickstart.md](quickstart.md) § 2: `git rm -r docs/experimental && bash scripts/verify.sh` must stay green, then restore
+- [ ] T041 [US1] Open the architecture PR with issue T004's closing link
+
+**Checkpoint**: MVP. A newcomer can trace a requirement to an outcome from one document.
+
+---
+
+## Phase 5: User Story 3 — A contributor changes exactly one thing (Priority: P3)
+
+**Goal**: Every artifact class has one home, one rule for changing it, and a published list of
+what is currently mis-filed.
+
+**Independent Test**: Hand `docs/layout.md` to someone who has not read the rest and ask them
+to list every file they would create to add a new load generator, and every file they would
+need permission to touch.
+
+- [X] T042 [US3] Create `docs/layout.md` with the artifact-class table from [data-model.md](data-model.md) § 1 — six classes, one home each, following the row shape in [contracts/repository-shapes.md](contracts/repository-shapes.md)
+- [X] T043 [US3] Make the "who may change it" column uniform in `docs/layout.md` — "Anyone, by pull request" in every row — and add the two sentences that carry the argument: classes differ by what a change obliges, not by who may propose it. Introduce no role vocabulary (FR-014)
+- [X] T044 [US3] State in `docs/layout.md` who assigns the milestone and closing link on an outside contributor's behalf, since `scripts/check-linkage.sh` gates on both and a fork PR normally cannot set a milestone — without this the uniform column is theatre
+- [X] T045 [US3] File `docs/semconv/` into the normative core in `docs/layout.md` by widening that class's definition: it includes the `loadtest.*` registry, the only core artifact whose upstream status is unratified, which states so in its own dated text (FR-015)
+- [X] T046 [US3] Define the governance words in `docs/layout.md` — `artifact class`, `home`, `normative core`, `compatibility-sensitive surface`, `experimental area`, `follow-up spec`, `obligation`, `non-conformance list`, `component role`, and the two words this feature invents, `tool mapping` and `file adapter` — each with one rejected alternative, and none of them also in the glossary (FR-012, SC-013)
+- [X] T047 [US3] Publish the non-conformance list in `docs/layout.md` — six entries, each with the obligation its eventual move carries. Record that moving the two tool mappings out of `docs/examples/` slips them past the sketch-label check, which is hardcoded to that directory (FR-013)
+- [X] T047a [US3] Publish the target-contribution procedure in `docs/layout.md` (FR-020): what artifact to write, what conformance level it claims, and how that claim is evidenced — a dated manual verification against the tool's documentation, declared unenforceable until the conformance corpus lands
+- [X] T048 [US3] Add the sentence excluding `specs/` from the layout table in `docs/layout.md`, plus the one-directional flow rule: a follow-up spec writes into the homes this table names and never becomes one
+- [X] T049 [US3] Discharge FR-017 in `docs/layout.md` with a **pointer** to the constitution's compatibility-surface list plus the per-class yes/partly/no column — republishing would create a second copy that can drift, which the constitution's supremacy clause makes wrong by definition
+- [X] T050 [US3] Answer FR-016 in `docs/layout.md`: which side is authoritative when a tool-native integration in another repository drifts. No committed text answers this today — `grep -r authoritative` returns nothing. Assign detection to the conformance-corpus follow-up, since every mechanism is an artifact FR-025 forbids
+- [X] T051 [US3] [P] Add `docs/layout.md` to the Documents tables in `README.md` and `docs/README.md`
+- [X] T052 [US3] Run the SC-013 check from [quickstart.md](quickstart.md) § 4: every introduced word defined in exactly one home, and no artifact class still called a "binding"
+- [ ] T053 [US3] Open the layout PR with issue T005's closing link
+
+**Checkpoint**: A contributor can find one home for any change.
+
+---
+
+## Phase 6: User Story 4 — The work ahead is cut into separate specs (Priority: P4)
+
+**Goal**: A named, non-overlapping list of the follow-up specs, with dependencies stated rather
+than implied by numbering.
+
+**Independent Test**: Check every entry for a boundary, a dependency and an architectural role.
+Check that no individual deliverable appears in two entries.
+
+- [X] T054 [US4] Add the follow-up list to `docs/architecture.md` — eleven entries, each with what it delivers (concrete files), what it depends on, and the component role it fills, in the row shape from [contracts/repository-shapes.md](contracts/repository-shapes.md)
+- [X] T055 [US4] Name entries by slug, never by ordinal, and add the sentence saying `specs/NNN-` records creation order and not completion order — `001-nfr-format-architecture` already sets a numbering a reader will read as a schedule
+- [X] T056 [US4] State the dependency graph explicitly in `docs/architecture.md` as edges between slugs
+- [X] T057 [US4] Give the parked monitoring entry promotion and retirement conditions instead of a schedule position (SC-011): promotion requires one unchanged requirement document assembling a valid query for **all four** backends, each check dated and sourced. Three of four is a narrower scope, and narrowing amends the architecture
+- [X] T058 [US4] Identify `target-gatling` as the entry serving `gatling-picatinny#236` and record the concrete answer (FR-024, SC-009): picatinny 2.0 removes `assertionFromYaml` without a one-to-one replacement and documents the native Gatling DSL, while the migration note names OpenNFR's Gatling target as the intended successor
+- [X] T059 [US4] Reconcile `docs/README.md`'s stated next step — "A JSON Schema for the requirement and result documents" — with the list, naming the core-schema entry as exactly that and first in dependency order
+- [X] T060 [US4] Verify SC-008 by enumerating every claimed file across all eleven entries and counting deliverables claimed twice; the expected count is zero
+- [ ] T061 [US4] Open the follow-up-list PR with issue T006's closing link
+
+**Checkpoint**: Every later spec has a boundary and knows what it depends on.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T062 [P] Open an issue for the `overall-availability` silent RED: a run where nothing fails produces no series carrying `error.type` → `noData` → `onNoData: fail`, so the run fails because the system was perfect
+- [ ] T063 [P] Open an issue for the unmeasurable-guard misrouting: a guard on a metric a target cannot measure lands on `onNoData: fail` rather than `onGuardViolation: inconclusive`, so a tool limitation reads as a system failure
+- [ ] T064 [P] Open an issue for the `skipped` verdict status having no `gate` key in `docs/GLOSSARY.md` — it appears in the status enum and in `docs/examples/checkout-perf.report.yaml`, but no gate key handles it, and silence is undefined behaviour under Principle III
+- [ ] T065 [P] Open an issue for `indicatorRef: checkout-latency` in `docs/examples/checkout-perf.yaml` pointing at a Requirement name while ADR-0001 § D10 describes `Indicator` as a reusable kind of its own
+- [X] T066 Run the full [quickstart.md](quickstart.md) sweep — all six executable checks — and record the seven read-only criteria as reviewed
+- [X] T067 Verify SC-010 with `git diff --name-only main...HEAD | grep -vE '\.(md)$|^specs/|^\.gitignore$'` returning empty: nothing executable shipped
+- [ ] T068 Confirm every PR in this feature carries milestone `v0.2.0` and a closing link, then close each issue as its PR lands on `main`
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (setup)
+   └─> Phase 2 (glossary)          ← blocks everything; both documents are made of these words
+          └─> Phase 3 / US2 (amendment)   ← must land before any document written against it
+                 └─> Phase 4 / US1 (architecture)  🎯 MVP
+                        ├─> Phase 5 / US3 (layout)
+                        └─> Phase 6 / US4 (follow-up list, appends to architecture.md)
+                               └─> Phase 7 (polish)
+```
+
+**Story dependencies**, which are unusually tight for this template because the constitution
+imposes an order priority does not:
+
+- **US2 → US1**: the architecture document must be written against the amended constitution.
+- **US1 → US3**: the layout document names homes the architecture document already refers to.
+- **US1 → US4**: the follow-up list is a section of `docs/architecture.md`, so it needs the
+  file to exist. It ships as its own PR because the decomposition is a separate concern.
+- **US3 and US4 are independent of each other** and can run in parallel once US1 lands.
+
+## Parallel opportunities
+
+- **Phase 1**: T003–T006 are four independent issue creations. T008 is unrelated cleanup.
+- **Phase 2**: T012 touches only the diagram; the rest touch entries.
+- **Phase 4**: T039 (index rows) is independent of the walkthrough tasks. The three
+  walkthroughs T031–T033 touch one file and must be serialised.
+- **Phase 5 and Phase 6** run in parallel once Phase 4 lands.
+- **Phase 7**: T062–T065 are four independent issue creations.
+
+## Implementation strategy
+
+**MVP is Phase 4 (US1)** — but it cannot ship alone. Phases 1–3 are its price of entry: without
+the milestone CI rejects the PR, without the glossary the document uses unsettled words, and
+without the amendment it is written against text the constitution will overrule.
+
+The smallest thing worth showing anyone is therefore **Phases 1 → 4**: a newcomer can trace a
+requirement to an outcome, three walkthroughs prove the format reaches three tools, and the
+parked experiment is honestly labelled and provably removable.
+
+**One decision blocks Phase 3 and needs the author, not an implementer**: T015, the fate of
+"Experiments Are Parked, Not Merged". Everything else in this list can be executed as written.


### PR DESCRIPTION
Closes #8

## What changes

Three commits, deliberately separable:

1. **`docs(speckit)`** — the design artifacts under `specs/001-nfr-format-architecture/`, plus a
   `.gitignore` entry for `.specify/feature.json`, which is per-checkout spec-kit runtime state.
2. **`docs: amend the constitution to v1.1.0`** — three new principles and one widened
   constraint, with `plan-template.md` synced.
3. **`docs: add the architecture and layout documents`** — the actual deliverable.

The constitution's amendment procedure says an amendment travels as a change to the
constitution and affected templates *"and nothing else"*. Here it rides in the same pull
request as the documents written against it. That is a deliberate deviation, taken because
splitting one documentation change into three pull requests bought ceremony rather than review
quality. **Commit 2 is self-contained** if a reviewer wants to judge the amendment alone.

### The architecture, in one paragraph

A requirement is written once and names no tool. Four component roles carry it to an outcome —
parse, render, ingest, evaluate — and each has a published contract stating its input, its
output, and at least one thing it is **forbidden** to know. The load-bearing one: the component
that produces verdicts must not know which target produced the measurements. Support for any
target is data (a YAML mapping), never code.

## Why

**The problem the whole feature exists to prevent.** k6 computes a percentile from raw samples,
Prometheus interpolates from histogram buckets, Datadog uses a sketch. If a verdict may consume
a statistic the tool computed for itself, then one document produces different answers on
identical traffic, and "tool-agnostic" is a claim the format cannot keep. Principle VI forbids
it, and the four-role split is what makes the prohibition enforceable rather than aspirational.

**Why the constitution needed amending.** Its existing constraint — *"Support for a load
testing tool MUST be expressible as data"* — covers only load generators. The architecture adds
a second class of target, and the words "monitor" and "monitoring" appear nowhere in `docs/`,
`README.md`, `AGENTS.md` or the constitution. The bullet is widened rather than duplicated,
because a parallel bullet saying nearly the same thing is what drifts.

**Why Principle VIII carries a grandfather clause.** It would otherwise make two committed
artifacts retroactively non-compliant on the day it shipped: `docs/semconv/loadtest.md`
announces itself as an unsubmitted proposal while core constructs depend on it, and the
`errorSignal` block in `mapping-k6.yaml` is marked a draft inside a published example. Both
practise labelling without containment. The exemption is named and dated rather than hidden,
and it explicitly may not be cited as precedent.

## What a reviewer should know

**The walkthroughs are uncomfortable on purpose.** Tracing `checkout-perf.yaml` through three
tools surfaced things worth knowing before anyone builds against this:

- **There is no `mapping-gatling.yaml`.** `docs/examples/` holds mappings for k6 and JMeter
  only — and Gatling is the tool with a waiting counterparty (`gatling-picatinny#236`).
- **`overall-availability` can produce a silent RED.** A run where nothing fails yields no
  series carrying `error.type`, hence `noData`, hence `onNoData: fail`. The run fails because
  the system was perfect.
- **An unmeasurable guard fails for the wrong reason** — a tool limitation lands on
  `onNoData: fail` rather than `onGuardViolation: inconclusive`.
- **`skipped` appears in the status enum and in the report sketch, but no `gate` key handles
  it.**
- **`window.phase` and `baseline: previousPassed` are satisfiable by no tool in the survey.**

These are declared, not fixed. Fixing them changes the format, which this change does not do.

**Two things that are checkable rather than asserted:**

```bash
git rm -r docs/experimental && bash scripts/verify.sh   # must stay green; then restore
```

```bash
grep -c '^### [IVX]*\.' .specify/memory/constitution.md  # 8, matching "eight principles above"
```

## Checklist

- [ ] Milestone assigned — **no open milestone exists**; blocked on creating `v0.2.0`
- [ ] `Closes #<issue>` above points at an issue in the same milestone — **no issue exists yet**
- [x] `bash scripts/verify.sh` passes locally
- [x] If a term changed: `docs/GLOSSARY.md` updated, including the *Rejected* note — a `Target`
      entry is added in Layer 2 with rejected alternatives, and the noun `binding` is dropped in
      favour of `tool mapping`
- [x] If a decision changed: the relevant ADR updated rather than contradicted elsewhere — no
      ADR is contradicted; ADR-0002 § D12 and § D18 are cited, not amended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

