### PR TITLE
Rethink the format as assertion-first: spec and plan for 003

### DIFF
--- a/specs/003-assertion-first-format/checklists/requirements.md
+++ b/specs/003-assertion-first-format/checklists/requirements.md
@@ -1,0 +1,89 @@
+# Specification Quality Checklist: An Assertion-First Requirement Format
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+**Iteration 1 — 2026-08-19.** Three `[NEEDS CLARIFICATION]` markers, all open by design.
+
+**Iteration 2 — 2026-08-19.** All three resolved into § *Decisions taken during specification*, each
+with its rejected alternatives:
+
+| Question | Decision |
+|---|---|
+| Preconditions, when no target has an `inconclusive` outcome | D1 — render like a criterion, carry a name into the target's own report |
+| "Each request individually" versus "the aggregate" | D2 — the format gains the distinction |
+| What admits a construct, now that post-run evaluation is out of scope | D3 — at least one surveyed target must assert it exactly |
+
+**Iteration 3 — 2026-08-19.** Three changes of scope, all requested:
+
+1. **Decoupled from the downstream issue.** The specification no longer carries a deliverable in, or
+   a prerequisite for, any other project. FR-023 became "publish the six statements as worked
+   examples **in this repository**"; SC-010 became the deletion sweep; the cross-repository
+   dependency row was removed. A duplicated ADR row was removed in the same pass. The prior format
+   remains, framed as evidence.
+2. **Tests added.** New User Story 5, requirement block *What must be tested* (FR-028…FR-037), and
+   SC-014…SC-017, SC-019. Appendix C states what the corpus will **not** establish, as FR-037
+   requires of the corpus itself.
+3. **Deletion sweep specified.** Requirement block *What must leave the notebook* (FR-038…FR-042),
+   the tiered section *What leaves the notebook, and in what order*, and SC-018.
+
+### One correction to the specification's own claims
+
+Iteration 2 recorded constitution Principle III as surviving **intact**. That was wrong. Its spirit
+survives and does most of the work in this feature, but its letter mandates that a run which did not
+meet its conditions "MUST be reported as inconclusive", and decision D1 removes that outcome. The
+*Dependencies and Constraints* table now records Principle III as **requiring an amendment in an
+earlier pull request**, and Tier 1 of the deletion sweep is blocked on it.
+
+### Why most of the deletion sweep is not in this feature
+
+The sweep was audited file by file and every proposed deletion was then argued against. The majority
+did not survive, always for one reason: a rule is written in as many as four places, one of which
+binds, and the constitution's Governance section says the binding copy wins. Deleting the notebook
+copy first would leave the repository formally requiring what this feature forbids. That produced
+FR-039 and the four tiers, and it is a finding about sequencing rather than a reduction in scope.
+
+### Carried forward, not checklist failures
+
+- **Appendices A and B name external and internal implementation detail.** Both are marked as dated,
+  sourced evidence and explicitly not part of the format. Principle IV forbids an unsourced claim
+  about an external tool, so removing them would be the worse defect.
+- **Three prerequisite amendments** are recorded in § *Dependencies and Constraints*: constitution
+  Principle III, constitution Principle VI, and `ARCHITECTURE.md`. Principle VII requires all three
+  to land in **earlier** pull requests.
+- **`docs/compatibility.md` and ADR-0002 hold the rule FR-020 inverts.** All four copies are removed
+  in one change, after the binding copies are amended — Tier 2.
+
+### Defects found in the gate while validating this specification
+
+Four sites in `scripts/verify.sh` where a check cannot fail, or fails without turning the build red.
+Each was read and confirmed by hand; all four are recorded in Appendix B, and they are the evidence
+behind FR-034 and FR-035. They are one concern and belong in their own change, not this feature.

--- a/specs/003-assertion-first-format/contracts/corpus-runner.md
+++ b/specs/003-assertion-first-format/contracts/corpus-runner.md
@@ -1,0 +1,106 @@
+# Contract — the corpus runner
+
+**Feature**: [003-assertion-first-format](../spec.md) | **Date**: 2026-08-20
+
+How the conformance corpus executes, what it reports, and — the part that matters — how it fails.
+`bash scripts/verify.sh` is the gate (AGENTS.md and the constitution's Development Workflow), so the
+corpus is reachable from it and its exit code propagates.
+
+---
+
+## E1. The exit contract
+
+| Code | Meaning |
+|---|---|
+| `0` | every case ran and every case passed |
+| `1` | the suite ran; at least one case failed |
+| `2` | **the suite could not run** — a missing dependency, an unreadable schema, an empty corpus, a case with no expectation |
+
+Code `2` is the whole point. FR-035: *no part of the suite may skip.* The distinction between "ran
+and passed" and "could not run" must survive into the exit code, or a broken environment reads as a
+clean build — which is Principle III applied to the project's own tooling.
+
+**There is no `skip` branch.** Not for a missing interpreter, not for a missing library, not for an
+empty directory. The gate now gets this right everywhere — four sections were repaired to match the
+one that always had it (spec Appendix B) — and the corpus is written the same way from the start.
+
+---
+
+## E2. Check codes
+
+Every check reports a short code so a failure names itself rather than describing itself.
+
+| Code | Checks |
+|---|---|
+| `SCHEMA` | every document validates against its kind's schema |
+| `IDENTITY` | within one requirement, no two predicates share an identity — `criteria` and `guards` counted **together** |
+| `SUM` | every predicate falls in exactly one bucket. No third bucket, no remainder (FR-033, SC-017) |
+| `ORDER` | entries follow document order; selectors and native parts follow their declared orders (FR-015) |
+| `CONVERT` | the threshold, recomputed in exact rational arithmetic from the description's units, equals the rendering's value **and** is exactly representable in the declared domain (FR-013) |
+| `GAP` | every unrenderable reason cites a gap the description actually declares; and no predicate is called unrenderable for a capability the description **does** declare (FR-017, both directions) |
+| `PARTITION` | capabilities and gaps partition each axis — a combination in neither is a defect of the description |
+| `EVIDENCE` | every capability, gap and pinned literal carries a citation and a date (FR-026, SC-007) |
+| `COLLIDE` | reports predicate pairs whose `report.derivedFrom` projections are equal — indistinguishable in that target's report (SC-012) |
+| `NOTOOL` | no tool name appears in any `document.yaml`, comments included (SC-004) |
+
+`GAP` checking **both directions** is what catches laziness: declaring something unrenderable that
+the target can in fact assert is as much a defect as the reverse, and only one of the two is
+uncomfortable to report.
+
+`COLLIDE` **reports rather than fails**. Two predicates that collide in a target's report are a fact
+about the target, not an error in the corpus. Failing on it would push authors to hide collisions;
+reporting it makes them visible, which is what SC-012 now asks for.
+
+---
+
+## E3. One rule, one implementation
+
+FR-036. Where the gate and the corpus check the same rule, they call the same code.
+
+The gate today carries its checks as copy-pasted heredocs inside `scripts/verify.sh`. The corpus must
+not re-implement them: a corpus asserting against its own copy proves nothing about the gate that
+actually runs, and two copies drift — the failure this repository exists to prevent, reproduced
+inside its own test suite.
+
+So the shared checks are extracted once and called twice. If that extraction is judged out of scope,
+the affected cases are **dropped and the rule recorded as untested** — never duplicated.
+
+---
+
+## E4. The gate mutation suite
+
+`conformance/gate/`. Each case plants a defect in a copy of the tree and requires the gate to go red
+(FR-034).
+
+**A control case is mandatory**: an unmutated copy must exit `0`. Without it the whole suite can pass
+because the gate is red for an unrelated reason.
+
+Cases fall into two groups, and the distinction is worth keeping in the output:
+
+- **Pins** — the check works; the case stops a future refactor from losing it.
+- **Known-red** — the check is broken; the case is the specification of the fix, and must be visibly
+  distinguished from a pin so nobody "fixes" it by deleting it.
+
+Four of the pins guard checks that were repaired while this feature was being specified (spec
+Appendix B). They are the most valuable cases in the suite: each covers a section that reported `ok`
+on every commit, on both platforms, for the life of the project — one of them without ever having
+executed.
+
+**One honest limitation, and it is why the pin matters.** CI runs on Linux. The Cyrillic case would
+have passed there and always would have; the defect only ever bit on a developer's macOS, and only
+if they ran the gate. So no mutation case could have *found* it — the repair had to be removing the
+platform-dependent construct, which is what landed. The case guards that repair, and is worthless as
+a detector of the next defect of the same shape. A mutation suite pins what is known; it does not
+discover.
+
+---
+
+## E5. What the runner cannot establish
+
+Repeated from spec Appendix C because a runner contract is where someone will look for it.
+
+- Nothing here renders. Every check is a consistency check between files this repository writes.
+- A target description and a case can be **uniformly wrong** about a tool and the build stays green.
+  `EVIDENCE` can verify a date exists; it cannot verify the claim is true.
+- The sum rule closes over the document, not over intent. It catches a dropped predicate. It cannot
+  catch the requirement nobody wrote.

--- a/specs/003-assertion-first-format/contracts/document-kinds.md
+++ b/specs/003-assertion-first-format/contracts/document-kinds.md
@@ -1,0 +1,100 @@
+# Contract — the three document kinds
+
+**Feature**: [003-assertion-first-format](../spec.md) | **Date**: 2026-08-20
+
+What this repository publishes, and what a consumer anywhere must do with it. This is the
+compatibility surface: the constitution puts "any field name that appears in a published example" on
+it, so everything named here needs an ADR to change.
+
+The consumer is a renderer living in the tool's own repository. This repository ships no renderer
+(spec Assumptions), so this contract is written to be implementable without reference to any code
+here.
+
+---
+
+## C1. `kind: RequirementSet` — the input
+
+**A conforming consumer MUST:**
+
+1. **Reject an unknown field, anywhere, at any depth.** Not warn, not ignore. A typo like
+   `agregation:` would otherwise silently disable a criterion and turn a run green (FR-006).
+2. **Reject a document it cannot fully decode**, rather than decoding the part it understands.
+3. **Ignore `displayName` entirely when rendering.** It is free text for a person, it is optional,
+   and it never affects what is selected, measured, compared or produced (FR-007). A consumer that
+   reads it for anything but display is wrong.
+4. **Compute predicate identity** as `name` if present, else `aggregation`, and reject a document in
+   which two predicates of one requirement — counting `criteria` and `guards` together — share one.
+5. **Never resolve a data source from the document.** The document names no tool, no endpoint, no
+   backend (FR-001).
+
+**A conforming consumer MUST NOT:**
+
+- treat a selector matching many requests as anything but one aggregate — there is one reading, and
+  the format has no second one to choose between;
+- accept a threshold without a unit;
+- accept YAML anchors, aliases or merge keys, or any value with no JSON equivalent.
+
+---
+
+## C2. `kind: TargetDescription` — the capability declaration
+
+**A conforming consumer MUST:**
+
+1. **Treat the capability table as exhaustive.** A combination of *(shape, metric, side, scope,
+   selection, aggregation, comparison)* that the table does not declare as supported is
+   **unrenderable**. There is no inference, no nearest match, no fallback.
+2. **Treat capabilities and gaps as a partition.** A combination in neither half is a **defect of the
+   description**, reported as such — not silently resolved either way (FR-017).
+3. **Convert units using the declared rationals, in exact arithmetic.** A threshold that is not
+   exactly representable in the declared numeric domain is **unrenderable, never rounded** (FR-013).
+4. **Refuse to render a claim with no evidence.** Every capability and every gap cites at least one
+   evidence entry; a description that fails this is invalid, not merely undocumented.
+
+**A conforming consumer MUST NOT:**
+
+- extend the table by rule, pattern or heuristic;
+- substitute an available comparison for an unavailable one, however close;
+- treat `report.carriesAuthorName: false` as an invitation to synthesise a name by other means — see
+  spec Appendix D for what that costs.
+
+---
+
+## C3. `kind: Rendering` — the output, and the oracle
+
+**A conforming consumer MUST produce, for one document and one description:**
+
+1. **Exactly one entry per predicate**, in document order: per requirement in order, its `guards`
+   then its `criteria`.
+2. **Exactly one of `rendered` or `unrenderable` per entry.** There is no third state and no absent
+   state. A predicate that produced nothing and was not declared unrenderable is the failure this
+   whole feature exists to prevent (FR-010, FR-025).
+3. **`role`** on every entry, distinguishing a criterion from a precondition.
+4. **At least one assertion** in every `rendered` entry.
+5. **At least one reason** in every `unrenderable` entry, each citing a gap the description actually
+   declares.
+
+**Determinism** (FR-015): the same document and the same description produce the same entries, in the
+same order, with selectors serialised in lexicographic key order and native parts in the order
+`native.fields` declares.
+
+**The sum rule** (FR-033): predicate → exactly one **bucket**. Not predicate → exactly one assertion.
+One criterion may render to several native assertions where the target can only express it as a
+conjunction, and one native assertion may expand into many results at run time. Neither breaks the
+rule.
+
+---
+
+## C4. What this repository does not promise
+
+Stated because a contract that overclaims is worse than none.
+
+- **No renderer.** Nothing here turns a document into assertions. The corpus is an oracle: it says
+  what a correct rendering looks like, and is unfalsified until an implementation elsewhere runs
+  against it (spec Appendix C).
+- **No guarantee the target accepts the assertion.** The corpus pins the arguments, never the API. A
+  statistic name the tool does not have passes every check here.
+- **No coverage of run time.** Everything above is checkable before a run; what the target then does
+  is the target's. One target has a per-request assertion scope that exits **successfully** when it
+  matches nothing — a silent green inside the tool. The format does not reach for that scope
+  (spec D2, withdrawn), so nothing here renders into it; it is recorded because a reader comparing
+  the format to the tool will find the capability and ask why it is unused.

--- a/specs/003-assertion-first-format/data-model.md
+++ b/specs/003-assertion-first-format/data-model.md
@@ -1,0 +1,279 @@
+# Phase 1 — Data Model
+
+**Feature**: [003-assertion-first-format](spec.md) | **Date**: 2026-08-20 | **Research**: [research.md](research.md)
+
+Three document kinds and one corpus. Every field below is validatable by JSON Schema draft 2020-12
+with no bespoke parser, no open grammar and no string that must be parsed to be understood —
+Principle V. Where that was hard to hold, it is called out.
+
+`additionalProperties: false` everywhere, at every level. An unknown field is an error (FR-006).
+
+---
+
+## 1. `RequirementSet` — edited
+
+`schema/opennfr.io/v1/requirementset.schema.json`. Two additions, nothing removed.
+
+### 1.1 `displayName` — the human half of a name
+
+| Field | Type | Required | Where |
+|---|---|---|---|
+| `displayName` | string, `minLength: 1` | no | `metadata`, each requirement, each predicate |
+
+Free text, any script, none of the identifier's constraints. `name` is restricted to lowercase
+letters, digits and hyphens because a rendering has to point at it; a person writing a requirement
+wants a sentence, and today has nowhere to put one.
+
+**Inert, and provably so.** It changes nothing selected, measured, compared or rendered. SC-013 makes
+that a check rather than a promise: strip every display name from a document and every rendering must
+come out byte-identical. An inert field that is not *provably* inert is one that quietly acquires
+meaning.
+
+**It does not reach the target's report.** No surveyed target has a field for an author-chosen string
+(spec Appendix D). This must be said wherever the field is documented, because a format that lets an
+author believe otherwise repeats decision D1's mistake — and this time with a field named
+`displayName`, which invites exactly that belief.
+
+**Additive, not breaking.** Optional everywhere, so every existing document stays valid. This is the
+only change of the two originally planned for the container; the aggregate-versus-each distinction
+was withdrawn (spec D2).
+
+**It must not restate a structured value** (FR-007a). `displayName: 99th percentile under 500 ms`
+beside `threshold: 500` is a second source for one number and will diverge the first time the
+threshold moves. Write `99th percentile` — the quantity, not the answer.
+
+**Not mechanically checkable, and said out loud rather than assumed.** SC-013 proves a display name
+is *inert*; nothing proves it is *accurate* or that it does not duplicate a threshold. A digit-match
+heuristic was considered and rejected: `p99` legitimately contains `99`, and a check with a false
+positive on the most common percentile in the corpus would be turned off within a week.
+
+**Rejected spellings**, for the glossary entry FR-042 owes: `label` — in one surveyed tool a *label*
+is the sampler name, i.e. a selector value, so the word already means an address here;
+`title` — collides with the document's own title and with JSON Schema's `title`;
+`description` — invites paragraphs where a phrase is wanted.
+
+### 1.2 Predicate identity
+
+Not a new field — a rule made explicit and now load-bearing, because the sum rule counts identities.
+
+```
+identity(predicate) = predicate.name  if present
+                    = predicate.aggregation  otherwise
+```
+
+| Rule | Where enforced |
+|---|---|
+| Unique within a requirement across `criteria` **and** `guards` **together** | Corpus runner, not the schema — JSON Schema cannot express a cross-array uniqueness over a computed key |
+| May be a name, matching the format's own `name` pattern, **or** an aggregation — `p99.9` contains a dot and is therefore not a valid name | Wherever an identity is referenced, the type is `anyOf: [name, aggregation]` |
+
+The current gate checks uniqueness **per section**, so a criterion and a guard may collide today.
+That is a defect this feature closes, and it needs a corpus case.
+
+### 1.3 Preconditions
+
+`guards` keeps its name in the schema. The rendering carries `role: guard` per entry, which is where
+FR-009's repair lives (R1). Nothing about a name in a report survives into the format.
+
+---
+
+## 2. `TargetDescription` — new
+
+`schema/opennfr.io/v1/targetdescription.schema.json`, instances in `mappings/<target>.yaml`.
+Supersedes the incumbent `MetricMapping` kind (R9).
+
+### 2.1 Top level
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `apiVersion` | const `opennfr.io/v1` | yes | |
+| `kind` | const `TargetDescription` | yes | |
+| `metadata.name` | name | yes | **The only place a tool name legitimately appears.** SC-004 counts tool names in the format and in requirement documents; this file is neither |
+| `spec.evidence` | array, minItems 1 | yes | See 2.2 |
+| `spec.native` | object | yes | What a native assertion is made of, here |
+| `spec.report` | object | yes | How this target's own report line is derived |
+| `spec.units` | array | yes | Conversions, as exact rationals |
+| `spec.names` | object | yes | Canonical ↔ native, with the complement declared |
+| `spec.assertable` | array, minItems 1 | yes | The capability table |
+
+### 2.2 `evidence` — SC-007 by schema rather than by review
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | name, unique | Cited by every claim |
+| `source` | string | Repository path and tag, or URL |
+| `checked` | date | `^\d{4}-\d{2}-\d{2}$` |
+| `states` | string | **What the source says**, not what was concluded from it |
+
+Every capability claim and every gap carries `evidence: [<id>, …]`, `minItems: 1`. A claim with no
+citation is a schema error, which is what turns FR-026 from a habit into a rule.
+
+### 2.3 `native` and `report`
+
+```yaml
+native:
+  fields: [scope, path, statistic, reduce, percentile, condition, value]  # ordered
+  evidence: [assertion-builders]
+report:
+  derivedFrom: [scope, selection, metric, aggregation, comparison, threshold]
+  carriesAuthorName: false        # false on both surveyed targets — R1
+  evidence: [assertion-builders, run-result-processor]
+```
+
+`native.fields` is declared **per file** so a third target with an unanticipated assertion shape
+needs no schema edit (FR-016). The declared order is also the serialisation order, which is half of
+FR-015's determinism.
+
+`report.derivedFrom` is load-bearing: **two predicates whose projections onto it are equal are
+indistinguishable in that target's report.** That is what makes SC-012 checkable — and what makes it
+honest, because the corpus can then say "these two collide" instead of claiming a distinction that
+does not exist.
+
+### 2.4 `units` — exact rationals, never floats
+
+```yaml
+units:
+  - {from: s, to: ms, multiplyBy: {numerator: 1000, denominator: 1}}
+```
+
+Integers, `denominator >= 1`. FR-013 requires deciding whether a threshold is *exactly*
+representable in the target's own numeric type; floating-point conversion cannot answer that. This
+is the field that keeps the three-orders-of-magnitude error from becoming a rounding opinion.
+
+### 2.5 `names`, and the declared complement
+
+`metrics` and `attributes` map canonical → native, each with evidence. `names.unlisted` is
+**required**: it says what happens to a canonical name not in the list, per axis, with a reason and
+evidence. Without it the infinite complement is undefined, and an unlisted metric would fall through
+as *supported* — the wrong default under Principle III.
+
+### 2.6 `assertable` — the capability table
+
+Exact-match lookup on `(shape, metric, side, scope, selections)`, then `aggregations[agg]`, then
+`comparisons[op]`. **Nothing is expanded by rule**; there is no inference step for a reader to
+simulate.
+
+Two partitions make FR-017 structural rather than aspirational:
+
+- `aggregations` and `aggregationGaps` together partition the aggregation axis;
+- `comparisons` and `comparisonGaps` together partition the comparison axis.
+
+A combination in neither half is a **defect of the description**, detectable by the corpus runner —
+which is FR-017 stated as an executable rule.
+
+Each aggregation entry carries `parts`, the emitted native assertion identity, built from the
+declared `native.fields`. `statistic` may differ per aggregation, which is what the second target's
+shape requires.
+
+---
+
+## 3. `Rendering` — new
+
+`schema/opennfr.io/v1/rendering.schema.json`, instances in `conformance/render/<case>/rendering.<target>.yaml`.
+
+### 3.1 Top level
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `spec.document` | name | yes | `metadata.name` of the RequirementSet. Resolves **inside the case directory**; never a path |
+| `spec.target.description` | name | yes | `metadata.name` of the TargetDescription |
+| `spec.target.version` | string | yes | The target's version the literals were read against. MUST equal the description's — a staleness check |
+| `spec.target.checked` | date | yes | A pinned literal without a date is an unsourced claim about a third party |
+| `spec.predicates` | array, minItems 1 | yes | See below |
+
+### 3.2 `predicates` — one ordered list, not two
+
+**Exactly one entry per predicate, in document order**: for each requirement in order, its `guards`
+in order, then its `criteria` in order. `rendered` and `unrenderable` are *projections* of this list,
+not separate arrays.
+
+This is the design decision that makes FR-033 hold by construction rather than by arithmetic: there
+is no way to spell a predicate that appears twice, and no way to spell one that appears in neither
+bucket.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `predicate.requirement` | name | |
+| `predicate.role` | enum `criterion` \| `guard` | **FR-009's repair.** The only place either target can carry the distinction |
+| `predicate.id` | `anyOf: [name, aggregation]` | The identity from 1.2 |
+| `rendered` \| `unrenderable` | exactly one, `oneOf` | |
+
+### 3.3 `rendered`
+
+`assertions`, `minItems: 1` — *a rendered entry with no assertion is unspellable*. Success by
+omission has no syntax here, which is Principle III expressed as a schema constraint.
+
+More than one assertion per predicate is admissible **only** as a conjunction that strictly narrows
+the pass condition, and only where the description mandates it (R6).
+
+Each assertion carries the criterion restated in the target's tokens — `metric`, `selector`,
+`aggregation`, `percentile`, `op`, `threshold`, `unit` — all normative and all checked. No display
+name appears here: the rendering points at a predicate by identity, and a display name is not one. `percentile`
+is a number, never the string `"percentile(95)"`.
+
+Then `native.text`: a string, `minLength: 1`, and **no `pattern`, ever**. A pattern is the first line
+of a decoder. This half is dated evidence, not an authority — when it disagrees with the tokens
+above, the literal is the finding and the tokens are the bug.
+
+### 3.4 `unrenderable`
+
+`reasons`, `minItems: 1`, `uniqueItems`, ordered by `gap`. Each reason cites the gap in the target
+description that produced it, so an unrenderable claim is traceable to a declared capability rather
+than asserted. The spec's edge cases require the three kinds — missing statistic, missing comparison,
+threshold that does not convert exactly — to be distinguishable, and they are distinguishable by
+*which axis the gap partitions*, not by a free-text note.
+
+**Cost, recorded**: the reason vocabulary is a closed enum, so a target that fails in a way no code
+describes needs a schema change plus a re-review of every existing entry. The alternative — free text
+— would lose the traceability check entirely. The enum is the right trade and the churn is real.
+
+---
+
+## 4. The corpus
+
+`conformance/`, three parts, each with a different notion of a case.
+
+| Part | A case is | Expectation lives |
+|---|---|---|
+| `parse/` | one document that must be accepted or rejected | a sidecar file naming every finding: gate, path, keyword |
+| `render/` | a directory holding `document.yaml`, and one `rendering.<target>.yaml` per target | the rendering **is** the expectation |
+| `gate/` | a described mutation of a tracked file | the exit code and the line the gate must print |
+
+Two rules that make `parse/` cases readable:
+
+- **one mutation per rejection** — a case differs from a valid document by exactly one change, so
+  exactly one rule can be responsible (FR-030);
+- **the expectation is a sidecar, never inside the case** — an `expect:` key in the document would
+  itself be an unknown field and would mask the finding (FR-031).
+
+`reject/` cases may not live in `examples/`: the gate requires everything there to validate, and the
+constitution puts "any field name that appears in a published example" on the compatibility-sensitive
+surface.
+
+### 4.1 What the corpus checks that no schema can
+
+| Check | Why it is not a schema constraint |
+|---|---|
+| Predicate identity unique across `criteria` and `guards` together | Cross-array uniqueness over a computed key |
+| The sum rule: every predicate in exactly one bucket | Needs both documents at once |
+| Order: rendered entries follow document order | Needs both documents at once |
+| Conversion: the threshold recomputed in exact rational arithmetic | Needs the description's `units` and the document's value |
+| Gap traceability: an unrenderable reason cites a gap the description actually declares | Needs both documents at once |
+| Collision: two predicates with equal `report.derivedFrom` projections | This is SC-012, and it reports a collision rather than failing on one |
+
+---
+
+## Relationships
+
+```text
+RequirementSet ──identity──> predicate
+      │                          │
+      │                          └──> exactly one Rendering entry  (FR-033, structural)
+      │
+      └──rendered against──> TargetDescription ──declares──> capabilities ∪ gaps  (a partition)
+                                     │                              │
+                                     └──units (exact rationals)     └──cited by unrenderable reasons
+```
+
+One `RequirementSet` has one `Rendering` **per target**. A `Rendering` names its document and its
+description by `metadata.name`, resolved inside its own case directory — never by path, so a case can
+be moved without editing its contents.

--- a/specs/003-assertion-first-format/plan.md
+++ b/specs/003-assertion-first-format/plan.md
@@ -1,0 +1,279 @@
+# Implementation Plan: An Assertion-First Requirement Format
+
+**Branch**: `003-assertion-first-format` | **Date**: 2026-08-19 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/003-assertion-first-format/spec.md`
+
+## Summary
+
+The format stops being the input to an evaluation engine this project has not built and becomes the
+input to the load tool's own assertions. Concretely, this feature delivers four things and blocks on
+three amendments it may not make itself.
+
+**Delivers**
+
+1. One change to the container, and it is additive: an optional **display name** on the document,
+   each requirement and each predicate (FR-007) — free human text beside the machine identifier,
+   inert by construction. A precondition is identified through the rendering rather than through the
+   target's report (FR-009).
+2. Two new document kinds: the **target description** in `mappings/` — what a target names things,
+   what it can and cannot assert, how units convert — and the **rendering**, the expected native
+   assertions plus the named list of criteria that could not be produced.
+3. A **conformance corpus** in `conformance/`, in three parts: documents that must be rejected and
+   where, rendering triples any implementation must reproduce, and mutations of the gate itself that
+   must turn the build red.
+4. A **sequenced deletion sweep** of `docs/`, of which only Tier 0 is inside this feature.
+
+**Blocks on** three amendments that must land in earlier pull requests, per Principle VII: two to the
+constitution and one to `ARCHITECTURE.md`. They are not optional and they are not this feature's to
+make in passing — see [Constitution Check](#constitution-check).
+
+**Approach.** The container already fits Gatling's assertion surface almost exactly (spec Appendix
+A), so the work is not a redesign. It is: two small format changes, two new schemas, a corpus that
+makes every claim falsifiable, and a documentation sweep whose ordering matters more than its
+content.
+
+## Technical Context
+
+**Language/Version**: None. This repository ships JSON Schema and Markdown; it has no product code
+and this feature adds none. Python 3 is the gate's tooling, not the deliverable.
+
+**Primary Dependencies**: JSON Schema draft 2020-12 (the format's definition); OpenTelemetry
+semantic conventions (borrowed names, never invented — Principle II); PyYAML and `jsonschema` for
+`scripts/verify.sh`. No new dependency is introduced — both are already required and already
+installed by CI.
+
+**Storage**: N/A. Files in a git repository.
+
+**Testing**: `bash scripts/verify.sh` is the gate (AGENTS.md, and the constitution's Development
+Workflow). This feature extends it with the conformance corpus and requires that every check it
+performs be provably able to fail (FR-034).
+
+**Target Platform**: N/A for the format. **Non-trivial for the gate**: it must behave identically on
+macOS (BSD userland) and Linux (GNU userland). Spec Appendix B records four places where it did not
+— one of which had never executed on macOS — all repaired on `main` while this feature was being
+specified. The lesson survives the repair: none was caught by a test.
+
+**Project Type**: Specification and schema repository. Not a library, service, or application.
+
+**Performance Goals**: N/A.
+
+**Constraints**:
+
+- The container stays one file and small. Feature 002 set the bar at under 6 KB; two added fields
+  must not become an excuse to relax it.
+- Unknown fields are rejected everywhere (FR-006).
+- **FR-020 is the admission gate for every construct below**: nothing enters the format unless at
+  least one surveyed target can assert it *exactly*. This is the constraint that shapes the design,
+  and it is also the one that contradicts the constitution as currently written.
+- At most three new glossary terms for the whole feature (SC-011), and all three are committed: the
+  display name, the target description, the unrenderable criterion. A fourth entry, *rendering*, is
+  owed but is not a fourth concept — it names the output of an act already called *render*.
+
+**Scale/Scope**: 42 functional requirements, 19 success criteria, 5 user stories. Two targets
+(Gatling, k6). Roughly 80 corpus cases across the three parts. Seventeen files in `docs/` audited;
+four deletion tiers.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.1.0.
+
+- [x] **I. Vocabulary Before Features** — three terms are introduced and all three are recorded as
+      owed by FR-042, each requiring a rejected alternative before it reaches the schema or an
+      example. The Development Workflow's rule that a PR changing a term updates `docs/GLOSSARY.md`
+      in the same PR is what FR-042 discharges. **One live tension**: the glossary's `Assertion`
+      entry argues the word must stay out of the document, calling it "the single strongest
+      constraint". This feature upholds it — no target syntax enters a requirement document
+      (FR-001, SC-004) — but the entry needs the FR-020 tension recorded as an argument, not
+      silently left to contradict it.
+- [x] **II. Borrow Names, Never Invent Them** — no metric or attribute name is invented. **One
+      declared cost**: hierarchical addressing (FR-008) rests on `loadtest.group.name`, which lives
+      in `docs/semconv/loadtest.md` — an unsubmitted upstream proposal that Principle VIII
+      grandfathers *with the explicit warning that it may not be cited as precedent for admitting
+      new unsettled work*. This feature does not admit new unsettled names; it depends on an
+      existing grandfathered one. That dependency is stated in the spec rather than hidden, and it
+      is a reason the addressing question is not fully closed.
+- [ ] **III. No Silent Green** — **FAILS as written, and the failure is the point.** The principle's
+      spirit is upheld and does most of the work in this feature: FR-010 through FR-013 make every
+      criterion either rendered or named, FR-024 forbids success by omission at render time, and
+      FR-034 through FR-036 turn the same rule on the project's own gate. But its *letter* mandates
+      that a run which did not meet its assumed conditions "MUST be reported as inconclusive", and
+      decision D1 removes that outcome because no surveyed target has one. **Prerequisite amendment
+      A.**
+- [x] **IV. Honest Status** — Appendix A is dated and sourced to Gatling's own source; Appendix B was
+      confirmed by hand against `scripts/verify.sh`; Appendix C states what the corpus will not
+      establish. FR-026 and SC-007 carry the obligation into every target description.
+- [ ] **V. Structure Over Grammar** — *deferred to the post-design re-check.* Two new document kinds
+      are the largest surface this project has added at once, and the question "can every field be
+      validated by JSON Schema with no bespoke parser and no open grammar" cannot be answered before
+      the design exists. Recorded here as open rather than assumed.
+- [ ] **VI. Evaluation Is Target-Blind** — **requires settlement, and possibly removal.** The
+      principle forbids consuming "a statistic a target computed for itself" as a verdict. Under an
+      assertion-first format the target computes everything and decides. The principle is not
+      *violated*, because nothing in scope produces a verdict — but a principle that is vacuous
+      rather than satisfied is a trap for the next reader. Note that removal, or redefinition that
+      permits what it previously forbade, is **MAJOR** under the constitution's own versioning
+      policy. **Prerequisite amendment B.**
+- [ ] **VII. Architecture Before Implementation** — **fails until `ARCHITECTURE.md` is amended.** It
+      binds four component roles and a follow-up plan built on post-run evaluation; this feature
+      keeps R1 and R2 and takes R3 and R4 out of scope. Principle VII requires the architecture to be
+      amended in an **earlier** pull request, never diverged from silently. **Prerequisite
+      amendment C.**
+- [x] **VIII. Experiments Are Parked, Not Merged** — FR-041 requires a parked construct to arrive in
+      the experimental area carrying its argument, its rejected alternatives and a date, which is
+      what VIII demands. **One structural problem found:** `docs/experimental/` is **markdown only**
+      by LAYOUT.md, so `docs/examples/checkout-perf.report.yaml` — a result-document sketch that
+      FR-018 settles — has nowhere compliant to be parked. It is deleted with its argument carried
+      into a markdown note, or the layout is amended. Resolved in Phase 0.
+- [ ] **Compatibility** — **fails on two counts, both requiring more than an amendment.** First, the
+      binding constraint *"The format MUST NOT contain a construct expressible only at conformance
+      level `assert` or above"* is exactly what FR-020 inverts. Second, *"the conformance levels and
+      what each one guarantees"* is listed as a **compatibility-sensitive surface, which MUST NOT
+      change without an ADR** — and with post-run evaluation out of scope, `report` is no longer a
+      level at all. So this feature needs a constitution amendment **and** an ADR amending ADR-0002
+      § D13. **Prerequisite amendment B (constitution) plus a decision record.**
+
+### Gate result
+
+**Four gates do not pass**, and three of the four are the same three prerequisites the specification
+already named. They are recorded in Complexity Tracking below rather than treated as blockers to
+planning, because Principle VII's remedy is explicit: amend first, in an earlier pull request. This
+plan's Phase 0 writes those amendments; it does not land them.
+
+Principle V is deliberately left open until the post-design re-check.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-assertion-first-format/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source (repository root)
+
+```text
+schema/opennfr.io/v1/
+├── requirementset.schema.json     EDITED — the scope distinction (FR-007),
+│                                  precondition identity (FR-009)
+├── targetdescription.schema.json  NEW — what a target can and cannot assert
+└── rendering.schema.json          NEW — expected assertions + named unrenderables
+
+mappings/                          NEW directory, name already reserved by LAYOUT.md § 1
+├── gatling.yaml
+└── k6.yaml
+
+conformance/                       NEW directory, name already reserved by LAYOUT.md § 1
+├── README.md                      what the corpus binds, and what it does NOT establish (FR-037)
+├── parse/                         documents that must be accepted / rejected, and where
+├── render/                        (document, target description, rendering) triples
+└── gate/                          mutations of scripts/verify.sh that must turn the build red
+
+examples/                          the six worked statements (FR-023)
+scripts/verify.sh                  EDITED — corpus sections; every check provably able to fail
+```
+
+**Structure Decision.** No new artifact class is invented. `LAYOUT.md` § 1 already reserves
+`mappings/` ("Tool mappings … once it exists") and `conformance/` ("Conformance corpus … once it
+exists, binds later work: **Yes**"); both rows simply lose the words "once it exists". Choosing
+`mappings/` over a new `targets/` directory costs one incumbent name — the existing `MetricMapping`
+kind — and saves a LAYOUT.md amendment plus a fourth glossary term the budget cannot afford.
+
+`LAYOUT.md` § 6 already records the trap this creates and it must be honoured in the same change:
+*"`verify.sh`'s sketch-label check is hardcoded to `docs/examples/*.yaml`. A mapping relocated to
+`mappings/` silently stops being checked until the script is extended."* That is a fifth silent-green
+site waiting to happen, and FR-034 exists to catch exactly it.
+
+## Constitution Check — post-design re-evaluation
+
+Re-run after Phase 1, as the constitution's Compliance review requires. Only what changed is
+restated.
+
+- [x] **V. Structure Over Grammar** — **now passes**, deferred at the pre-design check. Every field
+      in all three kinds is validatable by JSON Schema draft 2020-12 with closed enumerations and no
+      bespoke parser. Three specifics were the risk and each is resolved:
+      - the pinned native literal is a string with **no `pattern`**, and nothing decodes it — it is
+        dated evidence, never an input. A pattern would have been the first line of a decoder;
+      - unit conversion is integer numerator/denominator pairs, so exact representability is decided
+        by arithmetic rather than by a float comparison;
+      - the checks JSON Schema genuinely cannot express — identity uniqueness across two arrays, the
+        sum rule, conversion, gap traceability — are corpus-runner checks over *two* documents, not
+        grammar inside one. The format still decodes without custom code.
+
+      **One borderline call, recorded rather than buried**: `native.fields` is declared per target
+      description, so the meaning of an assertion's `parts` array is file-dependent. It is a declared
+      ordered enumeration validated by schema, not a grammar — but it is the closest this design
+      comes to one, and it exists so that a third target with an unanticipated assertion shape needs
+      no schema edit (FR-016).
+
+- [ ] **III / VI / VII / Compatibility** — still fail, unchanged in substance, but the amendments now
+      exist as **written text** rather than as an intention. See [research.md § R10](research.md).
+      The constitution goes **1.1.0 → 2.0.0 (MAJOR)** under its own versioning policy — three
+      principles are redefined in a way that permits what they previously forbade — plus a PATCH limb
+      correction so the stamp can be applied honestly. `ARCHITECTURE.md` takes six section amendments.
+
+- [x] **I. Vocabulary** — **settled during Phase 0.** Three concepts, plus a fourth glossary entry
+      that is not a fourth concept: *rendering* names the artifact of an act already called *render*
+      in the glossary's own diagram, in `ARCHITECTURE.md`'s R2 and in the spec's Key Entities. SC-011
+      now says this explicitly, and the entry must record the judgement rather than let a later
+      reader assume it.
+
+- [x] **III, applied to the feature's own output** — worth stating separately from the amendment. The
+      design makes success-by-omission **unspellable**: one entry per predicate in one ordered list,
+      exactly one of two buckets per entry, `minItems: 1` on both. There is no way to write a
+      rendering in which a predicate quietly disappears. That is stronger than checking for it
+      afterwards.
+
+### One thing the design cannot deliver, found in Phase 0
+
+A per-request assertion that matches nothing **exits successfully** on one surveyed target — zero
+results, no failure. It is a silent green inside the tool, after the rendering is finished, and
+nothing in this feature can reach it. It is declared in the specification, in the target description
+and in the corpus as a known limitation, which is the only honest response available. Recorded here
+because a Constitution Check reporting Principle III as satisfied without naming this would be the
+kind of quiet pass the principle forbids.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| **Principle III's letter** — `inconclusive` ceases to be a mandated outcome | No surveyed target has a third outcome. Mandating one forces every rendering either to fabricate it or to drop preconditions entirely | *Keep `inconclusive` and make preconditions unrenderable everywhere* — a construct whose only behaviour is to be reported unsupported. *Drop preconditions* — abandons the under-delivered-load failure mode this project was founded on |
+| **Principle VI** — may need narrowing or removal | Nothing in scope produces a verdict, so the principle is vacuous rather than satisfied. A vacuous principle reads as a live constraint to the next person | *Leave it alone* — the spec's own Dependencies table already warns that "the ambiguity must be settled before this ships, not discovered afterwards". Silence is the expensive option |
+| **The Compatibility constraint** — inverted by FR-020 | With `report` no longer a complete path, the old rule forbids exactly what the feature exists to do | *Keep both rules* — the repository would formally forbid what it requires. This is not a trade-off, it is a contradiction |
+| **Two new document kinds at once** | The target description and the rendering are useless separately: a description nothing consumes proves nothing, and a rendering without a description has no oracle | *Ship the target description first* — leaves FR-010's sum rule, the feature's central honesty claim, untested for a whole release |
+| **`checkout-perf.report.yaml` has nowhere compliant to be parked** | `docs/experimental/` is markdown-only by LAYOUT.md; the sketch is YAML | **Resolved in Phase 0 (R7)**: delete the YAML, move its argument into a markdown parked note. Amending LAYOUT.md to admit YAML was rejected — weakening a containment rule to preserve one unvalidated file is a bad trade |
+| **The target description does not scale** | Roughly 330 lines for a target with one metric family; rows grow as *metrics × path-kinds* | **No alternative found.** Twenty metrics is thousands of lines nobody hand-authors correctly, and generating it makes the file's honesty a generator's honesty — code, which is what FR-016 pushed out of this repository. The first two descriptions are deliberately narrow, and this is why |
+| **The corpus cannot falsify itself** | Nothing here renders, so every check is a consistency check between files written here | *Ship a reference renderer* — rejected by the spec: rendering lives where the target lives. The corpus is an oracle and says so in its own text (FR-037) |
+
+---
+
+## Artifacts
+
+| Phase | Artifact | What it settles |
+|---|---|---|
+| 0 | [research.md](research.md) | Ten research items. **Three contradicted the specification**, which has been amended |
+| 1 | [data-model.md](data-model.md) | Three document kinds, the corpus, and what no schema can check |
+| 1 | [contracts/document-kinds.md](contracts/document-kinds.md) | What a consumer anywhere MUST and MUST NOT do |
+| 1 | [contracts/corpus-runner.md](contracts/corpus-runner.md) | Exit contract, ten check codes, the mutation suite |
+| 1 | [quickstart.md](quickstart.md) | Seven runnable scenarios, each mapped to a success criterion |
+
+### What Phase 0 changed in the specification
+
+Recorded here because a plan that quietly repairs its own spec is not reviewable.
+
+| Finding | Spec change |
+|---|---|
+| No surveyed target can carry an author-chosen name into its report — verified in source | FR-009 and SC-012 restated; decision **D1 revised**, its original rationale withdrawn as factually wrong; Appendix D added |
+| The per-request scope ranges over every request *observed*, not over a selection, exists on one target of two, and passes silently on an empty match | **D2 withdrawn** on review: FR-020's own second half forbids admitting a construct solely to reach one target's feature. FR-007's slot now carries the display name; Appendix A's scope row corrected |
+| One criterion may legitimately produce several assertions, and one assertion may expand at run time | **FR-033 restated**: predicate → exactly one *bucket*, not one assertion |
+| *Rendering* is a fourth glossary entry but not a fourth concept | SC-011 restated to say so, and to require the entry to record the judgement |
+
+*Phase 2 (`tasks.md`) is produced by `/speckit-tasks`, not by this command.*

--- a/specs/003-assertion-first-format/quickstart.md
+++ b/specs/003-assertion-first-format/quickstart.md
@@ -1,0 +1,174 @@
+# Quickstart — validating this feature
+
+**Feature**: [003-assertion-first-format](spec.md) | **Date**: 2026-08-20
+
+How to check that the feature does what it claims. Every scenario below is runnable and each one maps
+to a success criterion, so a green run is evidence rather than a feeling.
+
+## Prerequisites
+
+```bash
+pip install pyyaml jsonschema
+```
+
+Both are already required by the gate and already installed by CI. Nothing else is needed — this
+repository ships no code to build.
+
+```bash
+bash scripts/verify.sh
+```
+
+Expected on a clean tree: `PASS`. If it reports `jsonschema not installed`, the line above was
+skipped — and note that this is the gate behaving **correctly**: a check that cannot run fails, and
+never reports `ok`. Every section behaves that way now; four of them did not until recently, and
+scenario 5 is what stops that returning.
+
+---
+
+## Scenario 1 — a valid document is accepted, an invalid one is named (SC-003, FR-029)
+
+```bash
+python3 scripts/check-conformance.py conformance/parse/
+```
+
+Expected: every case in `accept/` validates, every case in `reject/` is rejected, and each rejection
+matches its sidecar expectation **at the exact path**.
+
+The check that matters is the second half. Break it deliberately:
+
+```bash
+cp conformance/parse/reject/missing-unit.yaml /tmp/probe.yaml
+python3 scripts/check-conformance.py --one /tmp/probe.yaml
+```
+
+A rejection that names the wrong path is a failure, not a pass. "It got rejected somehow" is the
+weaker claim the corpus exists to stop anyone making.
+
+---
+
+## Scenario 2 — the sum rule holds, exactly (SC-017, FR-033)
+
+```bash
+python3 scripts/check-conformance.py conformance/render/
+```
+
+For every case, `SUM` reports `rendered + unrenderable = predicates in document`. Not "approximately",
+not "all accounted for" — the arithmetic, per case.
+
+To see it bite, delete one entry from any `rendering.gatling.yaml` and re-run. The suite must go red
+naming the missing predicate by identity. **A silently dropped criterion is a check that never ran
+and a run that looks clean**, and this is the scenario that proves the corpus catches it.
+
+---
+
+## Scenario 3 — one document, two targets, different results (SC-002, FR-016)
+
+```bash
+ls conformance/render/ratio-not-assertable/
+# document.yaml  rendering.gatling.yaml  rendering.k6.yaml
+diff <(grep -c 'unrenderable' conformance/render/ratio-not-assertable/rendering.gatling.yaml) \
+     <(grep -c 'unrenderable' conformance/render/ratio-not-assertable/rendering.k6.yaml)
+```
+
+Expected: the two renderings differ, and `document.yaml` is byte-identical for both — there is no
+per-tool section, override or conditional in it. That is the whole claim of user story 2, reduced to
+one `diff`.
+
+---
+
+## Scenario 4 — a threshold that does not convert is refused, not rounded (SC-008, FR-013)
+
+```bash
+cat conformance/render/threshold-does-not-convert/rendering.gatling.yaml
+```
+
+Expected: the predicate appears under `unrenderable`, with a reason citing the numeric-domain gap. A
+value of `0.4995 s` has no exact representation in a target that takes whole milliseconds.
+
+Rounding it would move the bar by half a millisecond and nobody would ever know. **The corpus fails
+if the rendering rounds**, which is the only way this rule is worth having.
+
+---
+
+## Scenario 5 — the gate can actually fail (SC-014, SC-015, FR-034, FR-035)
+
+```bash
+python3 scripts/test-gate.py
+```
+
+This plants, one at a time, each defect the gate exists to catch, and requires the build to go red.
+Expected output distinguishes two groups:
+
+- **pins** — the check works; the case stops a refactor from losing it;
+- **known-red** — the check is broken today, and the case is the specification of the fix.
+
+Four cases exist because the checks they guard were **broken and then repaired** while this feature
+was being specified — see [spec Appendix B](spec.md#appendix-b-four-checks-that-could-not-fail-and-what-they-cost-to-find).
+They are pins now, and they are the most valuable pins in the suite: each guards a check that was
+green for the life of the project without ever executing.
+
+The sharpest single check:
+
+```bash
+python3 scripts/test-gate.py --case no-skip-anywhere
+```
+
+Runs the gate with a required library shimmed away and asserts that **no line matches `skip`**. It
+asserts on the word rather than the exit code, because other sections already turn the run red and
+would mask the one that quietly passes.
+
+---
+
+## Scenario 6 — the six statements are expressible (SC-001, FR-022, FR-023)
+
+```bash
+ls conformance/render/six-statements/
+```
+
+Expected: one document expressing all six statements the prior format could express, and the
+assertions each becomes. Six for six. If one cannot be expressed, the format is narrower than the
+thing it replaces, and that is a finding rather than a rounding error.
+
+---
+
+## Scenario 7 — no tool name leaked into the format (SC-004)
+
+```bash
+grep -riE 'gatling|k6|jmeter|locust|artillery' schema/ examples/ conformance/*/*/document.yaml
+```
+
+Expected: **no output**. A tool name is legitimate in exactly two places — `mappings/<target>.yaml`,
+whose whole subject is one tool, and the dated evidence in the specification's appendices.
+
+Note the shape of this command: it is a `grep` whose *absence* of output is the pass. That is the
+silent-green shape spec Appendix B is about, so the corpus form of this check counts what it scanned
+and fails when that is zero.
+
+---
+
+## Scenario 8 — display names are inert (SC-013, FR-007)
+
+```bash
+python3 scripts/check-conformance.py --strip-display-names conformance/render/
+```
+
+Strips every `displayName` from every document, re-derives each rendering, and requires
+**byte-identical** output. A field that is documented as inert and not proved inert is a field that
+quietly acquires meaning — and this one is named invitingly enough that someone will try to make the
+target print it. It cannot: no surveyed target has anywhere to put an author-chosen string
+([spec Appendix D](spec.md#appendix-d-why-a-precondition-cannot-be-named-in-the-targets-report)).
+
+---
+
+## What a green run does not prove
+
+Worth reading before quoting a passing build. The full statement is
+[spec Appendix C](spec.md#appendix-c-what-the-corpus-will-not-establish); the short version:
+
+- **Nothing here renders.** The corpus is an oracle, unfalsified until an implementation elsewhere
+  runs against it.
+- **It can be uniformly wrong about a target.** If a description and a case agree and both are wrong,
+  every check passes. Only a dated human-checked source stands behind that, and a machine can verify
+  the date exists — never that the claim is true.
+- **Display names prove nothing.** Scenario 8 checks they are inert; nothing checks they are
+  accurate. A display name that contradicts its own criterion passes every check here.

--- a/specs/003-assertion-first-format/research.md
+++ b/specs/003-assertion-first-format/research.md
@@ -227,7 +227,8 @@ site waiting to happen, and it is exactly what FR-034 exists to catch.
 
 ## R10. What must the prerequisite amendments say?
 
-**Decision**: ten amendments across two artifacts, in earlier pull requests, per Principle VII.
+**Decision**: eleven amendments across two artifacts, landing as **three pull requests**, all
+earlier than this feature, per Principle VII.
 
 **The constitution goes to 2.0.0 — MAJOR.** Its own versioning policy defines MAJOR as "a principle
 is removed or redefined in a way that permits what it previously forbade", and three separate
@@ -240,11 +241,27 @@ changes meet that test:
 | Principle VI | Forbids consuming "a statistic a target computed for itself" as a verdict. That is now the design. Not violated — nothing in scope produces a verdict — but **vacuous rather than satisfied**, which reads to the next person as a live constraint |
 | § Governance, versioning policy | A PATCH limb correction, so that the three above can be version-stamped honestly. Blocks nothing directly; must be in force when 2.0.0 is stamped |
 
-**`ARCHITECTURE.md` — six sections.** It is unversioned and its own § "Status of this document" makes
-the amending route an ordinary pull request landing before the specification that diverges from it.
-§ 1 (the path, clauses 1–3), § 2 (the four roles and "what no role may do"), § 3 (targets), § 4 (the
-walkthroughs, clauses 8–16), § 5 (support is data, clauses 17–18), § 7 (the follow-up table and
-dependency graph).
+**`ARCHITECTURE.md` — seven sections, one pull request.** It is unversioned and its own § "Status of
+this document" makes the amending route an ordinary pull request landing before the specification
+that diverges from it. § 1 (the path, clauses 1–3), § 2 (the four roles and "what no role may do"),
+§ 3 (targets), § 4 (the walkthroughs, clauses 8–16), § 5 (support is data, clauses 17–18), § 6 (the
+monitoring direction, clause 20), § 7 (the follow-up table and dependency graph).
+
+They cannot be split: § 4 clause 11 is the **fourth copy** of the rule the constitution inverts, so
+removing § 1 clause 3 while leaving it would move the stale rule rather than retire it.
+
+**Why three PRs and not eleven.** The constitution's own amendment procedure says an amendment "is
+made by a PR that changes this file and any templates the change affects, **and nothing else**", so
+all four constitution edits are one PR carrying one `2.0.0` stamp. `ARCHITECTURE.md` is one PR for
+the reason above. ADR-0002 § D13 is the third, because the conformance levels are a
+compatibility-sensitive surface and only an ADR may re-derive them.
+
+**A sequencing problem this specification has not resolved.** Two of the eleven — Principle VI and
+`ARCHITECTURE.md` § 1 — block *the specification itself*, not a later task: Principle VII says a
+specification needing a role the architecture lacks "MUST amend the architecture first, in an earlier
+pull request". This specification was written and opened for review before either. Whether a Draft
+specification that declares its own prerequisites counts as diverging is a genuine question, and the
+conservative reading is that the two amendment PRs land first.
 
 **Note for whoever reviews § 2**: that amendment is where the repair to FR-009 becomes
 *architecturally* available — the R2 role's output column is what gives the rendering a definition to

--- a/specs/003-assertion-first-format/research.md
+++ b/specs/003-assertion-first-format/research.md
@@ -1,0 +1,262 @@
+# Phase 0 — Research
+
+**Feature**: [003-assertion-first-format](spec.md) | **Date**: 2026-08-20
+
+Every claim about an external tool below was checked against that tool's own source or
+documentation and carries the date, as Principle IV and FR-026 require. Three of these findings
+changed the specification rather than confirming it; those are marked **CONTRADICTED THE SPEC** and
+the spec has been amended.
+
+---
+
+## R1. Can a target carry an author-chosen name into its own report? — **No**
+
+**CONTRADICTED THE SPEC.**
+
+**Decision**: a precondition is identified in the **rendering**, by the native assertion identity the
+target derives its report line from, and flagged there as a precondition. No target is required to
+carry a name.
+
+**Rationale**: Gatling's assertion is `Assertion(path, target, condition)` — three fields, no label,
+verified at tag `v3.15.1` in `AssertionBuilders.scala` and against the last open-source definition of
+the type at `v3.9.5`. Every printed string is `AssertionMessage.message(assertion)`, a function of
+the assertion alone; the JUnit XML `testcase` name and the HTML report row use the same derived
+string. The only author-controlled fragment, `Details(parts)`, is resolved against paths actually
+recorded during the run, so it is an address rather than a label — and it is absent entirely at
+global scope, which is exactly where a throughput precondition lands. k6 is no better: its report is
+built from metric, selector and expression.
+
+**Alternatives considered**:
+
+| Alternative | Rejected because |
+|---|---|
+| Carry a name into the report *(the spec's original choice)* | The capability does not exist on either surveyed target. FR-020 forbids admitting a construct nothing can check |
+| Smuggle a label into `details("PRECONDITION: …")` | The parts must equal a recorded group or request name, so this would rename the user's own requests and corrupt the recorded vocabulary — and it is unavailable at global scope regardless |
+| Drop preconditions | Abandons the under-delivered-load failure mode the project was founded on |
+
+**Spec changes made**: FR-009 restated; SC-012 restated as report-line-to-entry resolution; decision
+D1 revised with the finding and the newly discovered rejected alternative; Appendix D added.
+
+**Incidental finding, in the project's favour**: an unresolvable request path in Gatling **fails**
+rather than skipping. Principle III is already honoured there without being asked.
+
+---
+
+## R2. Does the per-request scope justify an aggregate-versus-each distinction? — **No, on the format's own rule**
+
+**CONTRADICTED THE SPEC, and the decision was withdrawn.**
+
+**Decision**: the distinction is **not admitted**. Spec D2 is withdrawn; FR-007's slot now carries the
+display name instead.
+
+**Rationale**: FR-020's second half says one target being able to assert a construct is necessary and
+*"is not by itself sufficient, so a construct MUST NOT enter the format solely to reach one target's
+feature."* The distinction was admitted on exactly one target's native scope. Three findings from
+this probe point the same way: the scope is hard-wired to *every request observed in the run* rather
+than to a selection, so it renders only when the selection is "every request"; the second target has
+no equivalent, and its nearest construct quantifies over samples rather than requests; and that one
+renderable combination **exits successfully when it matches nothing**. The only place it worked was
+the only place it could lie.
+
+And the ambiguity it removed does not exist without it: a selector matching many requests is
+unambiguous while there is one reading. The idea returns to the notebook with its argument, per
+FORMAT.md's rule about a knob nobody asked for.
+
+**Superseded finding, kept for the record**: the scope is genuinely native and conjunction-folded, so
+the construct is *implementable* — it is simply not admissible under this format's own admission
+rule.
+
+**Alternatives considered before withdrawal**: admitting the distinction but restricting it to the
+one selection that renders — rejected, a construct whose validity depends on the value of another
+field is a rule a reader must simulate. Letting it quantify over *samples* so the second target could
+carry it — rejected, that is a third statement again, and one word meaning two things on two targets
+is the failure the format exists to prevent.
+
+**What the format gives up**: "no endpoint slower than 2 s" as a single statement. It becomes one
+requirement per endpoint, which is verbose and silently stops covering an endpoint added later. The
+cost is real, it is why the argument will return, and it returns with a second target or not at all.
+
+---
+
+## R3. What can the second target assert, and does the asymmetry fit in data? — **Eleven axes, all expressible**
+
+**CONFIRMED THE SPEC.**
+
+**Decision**: FR-016 and FR-017 are well-founded. The two targets differ on eleven concrete axes —
+available statistics, available comparisons, selection axes, threshold value type, abort support and
+the gaps — and every one is expressible as data with no bespoke parser.
+
+**Rationale and specific confirmations**:
+
+- **FR-008 is satisfiable on both.** k6 addresses a request inside a group as more tags on the same
+  selection, which is the shape FR-008 mandates and the same shape the spec's Appendix A claims for
+  Gatling. Hierarchical addressing needs no new term.
+- **FR-014 gets two real conversions**: milliseconds against seconds, and a `0..1` rate against a
+  `0..100` percent.
+- **FR-013 gets a concrete corpus case**: a fractional-millisecond threshold is exact on one target
+  (float64) and **unrenderable** on the other (integer). This is the rounding hazard, in one case.
+- **Principle V is honoured by both**: one target's left-hand side is a closed eight-token
+  enumeration and its selector is a conjunction of literal equalities. A target description can be a
+  closed enum with no grammar.
+- **No per-request-scope equivalent on the second target.** Combined with R2, this is what withdrew
+  the aggregate-versus-each distinction: FR-020 admits a construct one target can assert, and forbids
+  admitting it *solely* to reach that target's feature.
+
+---
+
+## R4. What shape is a target description? — **An enumerated capability table**
+
+**Decision**: an explicit table keyed by *(indicator shape, metric, scope, selection)*, each row
+carrying the aggregations and comparisons the target supports **and** the gaps that partition the
+same axes, plus per-file declarations of what a native assertion is made of, how the target's report
+line is derived, how units convert as **exact rationals**, and dated evidence every claim must cite.
+
+Chosen by judged panel over two alternatives (7 / 6 / 5).
+
+**Rationale**: exact-match lookup with a required can-only-reject default makes FR-010's sum rule
+structurally guaranteed rather than checked afterwards. Gaps that partition the same axis as the
+capabilities turn FR-017's "an undeclared gap is a defect of the description" into a schema
+constraint. Units as integer numerator/denominator pairs rather than floats is what lets FR-013
+decide exact representability rather than approximate it.
+
+**Alternatives considered**:
+
+| Alternative | Score | Rejected because |
+|---|---|---|
+| Axes plus declared gaps — the cross product implicit, exceptions explicit | 5 | Small files, but an unanticipated combination falls through as *supported* rather than as a gap. Wrong default under Principle III |
+| Ordered first-match rule list with a required catch-all | 6 | Structurally sound, and its required `otherwise` was **grafted in**. Rejected as the base because rule ordering is itself a grammar a reader must simulate |
+
+**Known fatal problem, carried rather than solved**: volume. A description for a target with one
+metric family is roughly 330 lines; rows grow as *metrics × path-kinds*. A target with twenty metrics
+is thousands of lines nobody hand-authors correctly — and the moment it is generated, the file's
+honesty becomes a generator's honesty, which is code, which is what FR-016 pushed out of this
+repository. **No answer.** Recorded in the plan's Complexity Tracking, and the reason the first two
+descriptions are deliberately narrow.
+
+---
+
+## R5. What shape is a rendering? — **A neutral tuple plus a pinned literal**
+
+**Decision**: one ordered list of entries, one per predicate, in document order. Each entry carries a
+structured identity *(requirement, role, id)* and exactly one of `rendered` or `unrenderable`. A
+rendered entry restates the criterion in the target's own tokens — the normative part the corpus
+checks — and pins the literal native text as **evidence** the corpus does not interpret.
+`role: criterion | guard` is where FR-009's repair lives.
+
+Chosen by judged panel over two alternatives (8.5 / 7.5 / 6.5).
+
+**Rationale**: the neutral tuple is what makes the sum rule and the unit conversion mechanically
+checkable; the pinned literal is what stops the corpus drifting away from what the tool actually
+receives. The judge required the literal to be an opaque string with **no `pattern`** — a pattern is
+the first line of a decoder, and Principle V forbids one.
+
+**Alternatives considered**: a neutral tuple alone (7.5) — clean, but nothing pins what the tool
+actually gets, so the corpus can be internally consistent and externally wrong. A quoted native
+artifact alone (6.5) — pins reality, but nothing is mechanically checkable and the sum rule becomes a
+reading exercise.
+
+**Justifying the duplication**: carrying both is not the two-sources failure this project exists to
+prevent, because the two halves are not both authorities. The tuple is normative; the literal is
+dated evidence. When they disagree, the literal is the finding and the tuple is the bug — which is
+exactly the direction a corpus needs.
+
+---
+
+## R6. Restating the sum rule — **predicate to bucket, not predicate to assertion**
+
+**CONTRADICTED THE SPEC.** Both judged panels reached this independently.
+
+**Decision**: FR-033 binds *predicate → exactly one bucket*. One criterion may become more than one
+native assertion where a target can only express it as a conjunction, and one native assertion may
+expand into many results at run time.
+
+**Rationale**: the original wording invited "one predicate, one assertion", which would forbid both
+of those legitimate cases and make the rule unusable on the first real target.
+
+---
+
+## R7. Where does a rejected YAML sketch go when the parking area is markdown-only?
+
+**Decision**: `docs/examples/checkout-perf.report.yaml` is **deleted**, and the argument it carries
+moves into a markdown note in `docs/experimental/` with the status, promotion and retirement
+conditions and date that Principle VIII requires.
+
+**Rationale**: `LAYOUT.md` § 1 makes the parked area markdown-only, and FR-041 requires a parked
+construct to arrive carrying its argument. The argument is what is worth keeping; the YAML is an
+illustration of a document kind FR-018 says the format will not define.
+
+**Alternative considered**: amend `LAYOUT.md` to admit YAML into the experimental area — rejected.
+The markdown-only rule is what keeps the parked area from accumulating things that look validatable
+but are not, and weakening a containment rule to preserve one unvalidated file is a bad trade.
+
+---
+
+## R8. Is *rendering* a fourth term?
+
+**Decision**: no — it names the artifact produced by an act this repository already calls *render*,
+in the glossary's layer diagram, in `ARCHITECTURE.md`'s R2 role, and in the spec's Key Entities. Its
+glossary entry must say exactly that, so the judgement is recorded rather than assumed.
+
+**Rationale**: SC-011's budget of three concepts is fully committed, and Principle I is
+non-negotiable. Naming an existing act's output is not a new concept; pretending otherwise would
+either break the budget or hide the decision.
+
+**Alternative considered**: spend the budget differently by folding the aggregate-versus-each
+distinction into the existing `Criterion` entry — rejected, because that distinction genuinely *is* a
+new concept while a nominalisation is not. Trading the real one away to protect a bookkeeping number
+would be the wrong direction.
+
+---
+
+## R9. `mappings/` or a new `targets/`?
+
+**Decision**: `mappings/`, the name `LAYOUT.md` § 1 already reserves.
+
+**Rationale**: no new artifact class is invented and no fourth term is spent. Two edits follow and
+must land in the same change: `LAYOUT.md` § 1's row loses "once it exists" and names the new kind,
+and § 5's step 1 stops saying `kind: MetricMapping`. The incumbent kind is superseded rather than
+kept alongside — FR-021 allows one spelling — and ADR-0002 § D12 receives a dated supersession note
+under FR-040 rather than being rewritten.
+
+**The trap that comes with it**, already documented in `LAYOUT.md` § 6 and now load-bearing:
+*"`verify.sh`'s sketch-label check is hardcoded to `docs/examples/*.yaml`. A mapping relocated to
+`mappings/` silently stops being checked until the script is extended."* That is a fifth silent-green
+site waiting to happen, and it is exactly what FR-034 exists to catch.
+
+---
+
+## R10. What must the prerequisite amendments say?
+
+**Decision**: ten amendments across two artifacts, in earlier pull requests, per Principle VII.
+
+**The constitution goes to 2.0.0 — MAJOR.** Its own versioning policy defines MAJOR as "a principle
+is removed or redefined in a way that permits what it previously forbade", and three separate
+changes meet that test:
+
+| Locator | What is wrong with the current text |
+|---|---|
+| Principle III | Mandates that a run which did not meet its conditions "MUST be reported as inconclusive … never as a pass or a fail". D1 removes that state; the target has OK/KO per assertion and nothing else. The **spirit is kept** — nothing reports success by omission — and the run-time half moves to the rendering and the corpus |
+| § Compatibility Constraints | Binds "The format MUST NOT contain a construct expressible only at conformance level `assert` or above", which FR-020 **inverts**. Separately lists "the conformance levels and what each one guarantees" as a surface requiring an ADR — and `report` is no longer a level at all |
+| Principle VI | Forbids consuming "a statistic a target computed for itself" as a verdict. That is now the design. Not violated — nothing in scope produces a verdict — but **vacuous rather than satisfied**, which reads to the next person as a live constraint |
+| § Governance, versioning policy | A PATCH limb correction, so that the three above can be version-stamped honestly. Blocks nothing directly; must be in force when 2.0.0 is stamped |
+
+**`ARCHITECTURE.md` — six sections.** It is unversioned and its own § "Status of this document" makes
+the amending route an ordinary pull request landing before the specification that diverges from it.
+§ 1 (the path, clauses 1–3), § 2 (the four roles and "what no role may do"), § 3 (targets), § 4 (the
+walkthroughs, clauses 8–16), § 5 (support is data, clauses 17–18), § 7 (the follow-up table and
+dependency graph).
+
+**Note for whoever reviews § 2**: that amendment is where the repair to FR-009 becomes
+*architecturally* available — the R2 role's output column is what gives the rendering a definition to
+point at. Until it lands, FR-009 and SC-012 have no binding twin.
+
+---
+
+## Open, and deliberately not closed here
+
+- **The volume problem in R4 has no answer.** It is the sharpest cost of the chosen shape.
+- **`each` on an empty match is a silent green inside the target.** Declared, not fixed; unfixable
+  from this side.
+- **The corpus cannot falsify itself.** Spec Appendix C states this; nothing in Phase 0 changes it.
+- **A third target is the real test of both shapes.** Two targets fitting a shape drawn around two
+  targets is not evidence.

--- a/specs/003-assertion-first-format/spec.md
+++ b/specs/003-assertion-first-format/spec.md
@@ -1,0 +1,810 @@
+# Feature Specification: An Assertion-First Requirement Format
+
+**Feature Branch**: `003-assertion-first-format`
+
+**Created**: 2026-08-19
+
+**Status**: Draft
+
+**Input**: User description, translated from the Russian original — ADR-0001 settled on English for
+everything published, so it is recorded here in English rather than quoted:
+
+> Rethink the NFR format on top of OpenNFR. Make it a good-looking format, compatible with Gatling,
+> for insertion as assertions. Reports and conformance checking are not wanted for now — those should
+> be done by the load testing tool itself. The format must also not be tied hard to Gatling: the point
+> is a general format that can be reused.
+
+Prior art this supersedes:
+[picatinny's NFR-YAML](https://github.com/galax-io/gatling-picatinny/blob/main/docs/assertions.md).
+
+**Scope note.** All work is inside this repository. Nothing here is a deliverable in, or a
+prerequisite for, any other project. picatinny's NFR-YAML appears only as evidence — it is the
+closest existing thing to what is being designed, and what it got wrong is the cheapest available
+source of requirements.
+
+## Context
+
+Two things force a rethink at the same time, and they point the same way.
+
+**The closest existing thing to this format is a dead end, and it is worth reading why.** The
+NFR-YAML that Gatling users write today is a format whose keys are Russian-language sentences — the key for the 99th percentile of response time is a
+six-word phrase in Russian — over a closed list of six supported requirement kinds, with thresholds as
+quoted strings and an `all` key meaning "every request". That format cannot be extended: a new
+statistic means a new key in a hardcoded table. It is also unreadable outside one language, which is
+what makes the six-kind ceiling permanent rather than temporary. Its six statements are nonetheless
+the best evidence available of what people actually want to assert, which is why they reappear below
+as a coverage bar rather than as a migration obligation.
+
+**OpenNFR is currently built around a component nobody asked for.** Today's design routes a document
+through normalised series → verdicts → gate → outcome → a result document. None of that exists, and
+the user's instruction is that none of it is wanted: the load tool already computes the statistics,
+already evaluates its own assertions, and already prints its own report. Keeping a parallel evaluation
+path means re-deriving percentiles the tool has already derived, and answering "why does OpenNFR say
+p95 = 480 ms when Gatling says 502 ms" forever.
+
+So the document's job **ends when it becomes the target's own assertions**. Everything after that
+belongs to the target.
+
+This does not make the format a Gatling file. It makes the format the one place a requirement is
+written, and rendering the only thing that is per-tool. `ARCHITECTURE.md` already carries the four
+roles; this feature keeps **R1 Parse** and **R2 Render** and takes **R3 Ingest** and **R4 Evaluate**
+out of scope, along with everything downstream of them.
+
+A useful finding sits behind that decision: the container defined in feature 002 already fits
+Gatling's assertion surface almost exactly. A `ratio` with a `bad` selector is
+`failedRequests.percent`; with a `good` selector it is `successfulRequests.percent`; `total` is
+`allRequests`; `rate` over a distribution is `requestsPerSec`; `avg` is `mean`; `p95` is
+`percentile(95)`. Three things do not fit; all three are settled in
+[Decisions taken](#decisions-taken-during-specification), and the evidence for them is in
+[Appendix A](#appendix-a-what-gatling-can-actually-assert).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A requirement becomes a Gatling assertion, with no tool named in it (Priority: P1)
+
+A performance engineer writes a requirement in the format, and it becomes an assertion Gatling can
+run — failing the build on exactly the condition the engineer wrote, without a single tool name
+appearing anywhere in the document.
+
+**Why this priority**: this is the whole feature. Every other story is a property of the thing it
+produces.
+
+**Independent Test**: take the six statements the existing NFR-YAML could express, express each one
+in an OpenNFR document, and show the assertion each becomes. Six for six, or the format is narrower
+than the thing it replaces.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requirement on the 95th percentile of response time for one named request, **When** it
+   is rendered for Gatling, **Then** it becomes an assertion on that request's 95th percentile, with
+   the threshold converted into the unit the tool expects.
+2. **Given** a requirement on the percentage of failed requests across all requests, **When** it is
+   rendered for Gatling, **Then** it becomes an assertion on the failed-request percentage over the
+   whole run.
+3. **Given** a document that names no tool anywhere, **When** a reader looks for one, **Then** there
+   is none — not in a field name, not in a value, not in a metric name.
+4. **Given** the old NFR-YAML and the OpenNFR document for the same requirement, **When** both are
+   read by someone who does not read the language the old keys are written in, **Then** only one of
+   them is readable.
+
+---
+
+### User Story 2 - The same document is reused for a different tool, unedited (Priority: P2)
+
+The engineer switches from Gatling to k6, or runs both. The requirement document does not change. Only
+the choice of target does.
+
+**Why this priority**: this is what makes the format worth having rather than a tidier NFR-YAML. It is
+second only because story 1 can ship and be useful before a second target exists — but if story 2 turns
+out to be impossible, story 1 was a wasted format.
+
+**Independent Test**: render one unchanged document for two independent targets and compare what each
+one asserts. The two lists of assertions differ; the document does not.
+
+**Acceptance Scenarios**:
+
+1. **Given** one requirement document and two targets, **When** each is rendered, **Then** both
+   renderings come from the same file with no per-tool section, override, or conditional in it.
+2. **Given** a target whose vocabulary differs from the document's, **When** it is rendered, **Then**
+   the correspondence lives in that target's own description and not in the requirement.
+3. **Given** a new target nobody has integrated, **When** support for it is added, **Then** what is
+   added is a description of that target, not a change to the format or to any existing document.
+
+---
+
+### User Story 3 - A requirement the target cannot assert is named, never dropped (Priority: P3)
+
+The engineer writes a requirement their tool cannot check. They are told so, by name, **before the run
+starts** — not by a green result at the end.
+
+**Why this priority**: it is the project's founding principle applied to the one component that
+survives this rethink. A dropped criterion is a check that never ran and a run that looks clean. It is
+P3 only because it is a property of rendering rather than a separate capability.
+
+**Independent Test**: write a document mixing renderable and unrenderable criteria. Every criterion
+appears in exactly one of two lists, and the counts add up to the number of criteria in the document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a criterion the target cannot express, **When** the document is rendered, **Then** the
+   criterion is named and the reason is given, and no assertion is produced for it.
+2. **Given** a criterion the target can express only approximately, **When** it is rendered, **Then**
+   it is reported as unrenderable — an approximation is never substituted for it.
+3. **Given** a rendering, **When** the rendered and unrenderable criteria are counted, **Then** the sum
+   equals the number of criteria in the document. There is no third bucket and no silent remainder.
+4. **Given** a target description that fails to declare a gap, **When** rendering hits it, **Then**
+   that is a defect in the description, and it surfaces rather than being absorbed.
+
+---
+
+### User Story 4 - A reader can predict the assertions before running anything (Priority: P4)
+
+Someone who has never seen the tooling reads a requirement document and a target's description, and can
+say what will be asserted and against what number.
+
+**Why this priority**: this is the "make it good-looking" requirement, stated so it can be tested. A
+format whose effect cannot be predicted from reading it is a configuration file, not a specification.
+P4 because it constrains how the first three are built rather than adding anything of its own.
+
+**Independent Test**: give a reader a document and a target description, ask them to write down the
+assertions; compare with what is actually produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requirement, **When** it is read aloud, **Then** it states what is measured, over which
+   requests, how it is reduced to a number, how that number is compared, and in what unit — and
+   nothing else.
+2. **Given** any value in the document, **When** it is read, **Then** it is a plain scalar or a
+   structure, never a string that has to be parsed to be understood.
+3. **Given** a threshold, **When** it is read, **Then** its unit is written next to it and not implied
+   by the tool that will consume it.
+
+---
+
+### User Story 5 - Every rule the format states about itself is checked by machine (Priority: P2)
+
+Someone changes the schema, the corpus, or the gate, and finds out from the build whether they broke
+a rule the project had written down — rather than from a reader noticing months later.
+
+**Why this priority**: shares P2 with story 2, and neither blocks the other. It is not P1 because
+story 1 is the feature and this is how the feature is known to hold; it is not lower because every
+claim the other four stories make is unfalsifiable without it. The project's own gate currently
+contains checks that have never once been observed failing, and at least one of them has never run
+at all — see [Appendix B](#appendix-b-what-the-gate-does-not-currently-catch).
+
+**Independent Test**: plant, one at a time, each defect the gate exists to catch. The build must go
+red every time, and name the case.
+
+**Acceptance Scenarios**:
+
+1. **Given** a document that breaks a rule the format states, **When** the suite runs, **Then** it
+   is rejected and the rejection names the place in the document that caused it.
+2. **Given** a check the gate performs, **When** the defect that check exists to catch is planted,
+   **Then** the build goes red. A check never observed failing is not known to work.
+3. **Given** a dependency the suite needs, **When** it is removed, **Then** the build goes red and
+   prints no skip — a suite that skips reads exactly like a suite that passes.
+4. **Given** a rule checked in two places, **When** it is looked for in the source, **Then** it is
+   implemented once and called twice.
+5. **Given** the corpus, **When** a reader asks what it proves, **Then** the corpus says in its own
+   text what it does **not** establish.
+
+### Edge Cases
+
+- **The document names a measurement the target has no assertion for.** Distinguishable from "the
+  target cannot express this comparison", and both are unrenderable for different, named reasons.
+- **The document names a comparison the target lacks.** Not every operator exists everywhere; the
+  document must not silently get the nearest one.
+- **The threshold does not survive the unit conversion.** A target that takes whole milliseconds cannot
+  take `0.4995 s`. Rounding a threshold silently moves the bar.
+- **Requests are addressed one way and the target addresses them another.** A route the target never
+  emits; a name that exists only inside one tool; a grouped path where the document has a flat name.
+- **A requirement matches no requests at run time.** The target asserts over nothing. What that means
+  is the target's business now — but the format must not make it *look* like a pass at render time.
+- **Two criteria in one requirement share an aggregation and neither is named.** Nothing can tell the
+  resulting assertions apart in the target's own report.
+- **The same document is rendered twice.** The second rendering must be identical, or nothing
+  downstream can be diffed or reviewed.
+- **A requirement is meaningful only if the run reached its intended load** — the case guards exist
+  for, in a world where the target has no way to say "inconclusive".
+
+## Requirements *(mandatory)*
+
+### What a document is
+
+- **FR-001**: A requirement document MUST name no tool — not in a field, a value, a metric name, or an
+  example.
+- **FR-002**: The format MUST NOT enumerate metric or attribute names. Measuring something new MUST NOT
+  require changing the format. *(carried unchanged from feature 002)*
+- **FR-003**: A criterion MUST be fully described by: what is measured, over which requests, how it is
+  reduced to one number, how that number is compared, to what value, and in what unit. No other kind of
+  statement is a criterion.
+- **FR-004**: Every value MUST be a scalar or a structure. Strings that must be parsed to be understood
+  — expressions, embedded units, operator symbols, composite keys — are forbidden.
+- **FR-005**: Every threshold MUST carry its unit. *(carried unchanged from feature 002)*
+- **FR-006**: An unknown field MUST be an error. *(carried unchanged from feature 002)*
+- **FR-007**: The document, each requirement and each predicate MAY carry a **display name**: free
+  human-readable text, in any script, with none of the identifier's constraints. It is **inert** —
+  it changes nothing about what is selected, measured, compared or rendered, and two documents
+  differing only in their display names MUST render identically. It MUST NOT be confused with the
+  identifier: the identifier is what a rendering points at, the display name is what a person reads.
+  And it **does not reach the target's own report** — no surveyed target has anywhere to put it
+  ([Appendix D](#appendix-d-why-a-precondition-cannot-be-named-in-the-targets-report)); a format that
+  let an author believe otherwise would repeat the mistake decision D1 already made once.
+- **FR-007a**: A display name MUST NOT restate a value the structured fields already carry — a
+  threshold, a unit, an operator, a metric or a selector value. A name saying "99th percentile under
+  500 ms" beside `threshold: 500` is a **second source for one number**, and the two diverge the
+  first time the threshold moves. A display name says *what is measured, over what*; never *what the
+  answer is*.
+- **FR-008**: Selecting requests MUST cover: every request; one request identified by route or by
+  name; and a request identified inside a group, because targets nest requests in groups. Hierarchical
+  identification MUST be more attributes on the same selection, never a second kind of address.
+- **FR-009**: A requirement MAY declare preconditions stating that the run happened in the intended
+  regime. A precondition MUST render into the same kind of native assertion a criterion does — no
+  target has an outcome between pass and fail, and inventing one the target cannot honour would be a
+  construct nothing can check. It MUST be **identifiable in the rendering** by the native assertion
+  identity the target derives its own report line from, and MUST be flagged there as a precondition,
+  so that a reader holding the target's report and the rendering can tell *"the run did not happen as
+  intended"* from *"the system did not hold"*. **No target may be required to carry an author-chosen
+  name**: neither surveyed target has a field for one — see
+  [Appendix D](#appendix-d-why-a-precondition-cannot-be-named-in-the-targets-report).
+
+### What rendering must do
+
+- **FR-010**: Rendering MUST account for every criterion in the document. Each is either rendered or
+  reported unrenderable **by name**, and the two lists together MUST cover the document exactly.
+- **FR-011**: Rendering MUST NOT approximate. Where a target cannot express a criterion exactly, the
+  criterion is unrenderable — never replaced by the nearest thing the target has.
+- **FR-012**: Rendering MUST report unrenderable criteria **before the run starts**, not as a result.
+- **FR-013**: A criterion whose threshold cannot be represented exactly in the target's own
+  representation MUST be treated as unrenderable, not rounded.
+- **FR-014**: Unit conversion MUST be declared in the target's description rather than assumed by
+  whoever implements rendering.
+- **FR-015**: Rendering MUST be deterministic: the same document and the same target description
+  produce the same assertions, in the same order.
+- **FR-016**: What a target can and cannot assert MUST be expressed as data. Adding a target MUST NOT
+  require changing the format, the schema, or any existing document.
+- **FR-017**: A target's description MUST declare its gaps. An undeclared gap is a defect of the
+  description, not of the format.
+
+### What the format must not contain
+
+- **FR-018**: The format MUST NOT define a result document, a verdict vocabulary, an outcome, a gate
+  policy, or a severity. Those belong to whatever evaluates, and nothing in scope evaluates.
+- **FR-019**: The format MUST NOT define a load profile. `workload` stays reserved and unused.
+- **FR-020**: A construct MUST NOT enter the format unless **at least one surveyed target can assert
+  it exactly**. This replaces the inherited rule — *"no construct may appear that is expressible only
+  at assertion time"* — which was written when post-run evaluation was the complete path and which now
+  protects a path this feature removes. A construct is never admitted on the promise that something
+  will be able to check it later. It is a floor and not a licence: one target being able to assert a
+  construct is necessary for admission and is not by itself sufficient, so a construct MUST NOT enter
+  the format solely to reach one target's feature.
+- **FR-021**: The format MUST NOT grow a second way to say something it can already say. No aliases, no
+  shorthands, no per-tool spellings.
+
+### What must be replaceable
+
+- **FR-022**: Every statement the existing NFR-YAML could express MUST be expressible: the 50th,
+  75th, 95th and 99th percentiles of response time, the maximum response time, and the percentage of
+  failed requests — each addressed either at one named request or across all requests. This is a
+  coverage bar for the format, not an obligation to any other project.
+- **FR-023**: Each of those six statements MUST be published **in this repository** as a worked
+  example: the document that expresses it, and the assertion it renders into. A claim of coverage
+  that nobody can read is not coverage.
+- **FR-024**: The format MUST NOT inherit that format's closed list of supported requirement kinds. A
+  statistic the format did not anticipate MUST be writable without changing the format.
+
+### What must stay honest
+
+- **FR-025**: Nothing may report success by omission — at render time as well as at run time. A
+  criterion that produced no assertion MUST be visible.
+- **FR-026**: Any claim about what a target can assert MUST be checked against that target's own
+  documentation or source, and MUST carry the date it was checked.
+- **FR-027**: A term MUST reach the glossary with a rejected alternative before it appears in the
+  format or an example.
+
+### What must be tested
+
+The repository ships a schema and no code, so "unit test" here means the smallest thing that can be
+checked mechanically about the format: one document, one rule, one expected outcome.
+
+- **FR-028**: Every rule this specification states about a document MUST be checked by machine
+  rather than by reading. A rule nobody can run is an intention.
+- **FR-029**: The corpus MUST contain documents required to be **rejected**, and each rejection MUST
+  name the place in the document that caused it. Checking only that valid documents pass leaves
+  untested the strictness that is the format's main claim.
+- **FR-030**: A rejection case MUST differ from a valid document by **exactly one** change, so that
+  exactly one rule can be responsible for the outcome.
+- **FR-031**: The expected outcome MUST live beside the case, never inside it. A case file is the
+  document exactly as written — an expectation embedded in it would itself be an unknown field, and
+  would mask the very finding the case exists to produce.
+- **FR-032**: A rendering MUST be testable as data: a triple of *(document, target description,
+  expected rendering)* that any implementation, in any language, in any repository, must reproduce.
+  The corpus is the oracle. Nothing in this repository renders, and the corpus MUST NOT pretend
+  otherwise.
+- **FR-033**: The sum rule of FR-010 MUST be checked mechanically on every rendering case: every
+  predicate in the document falls into exactly one of the two **buckets**, by identity, with no third
+  bucket and no silent remainder. The rule binds *predicate to bucket*, **not predicate to assertion**:
+  one criterion may legitimately become more than one native assertion where a target can only express
+  it as a conjunction, and a single native assertion may expand into many results at run time. Neither
+  is a violation; requiring one assertion per predicate would forbid both and make the rule unusable.
+- **FR-034**: The gate MUST be tested against itself. For every check it performs there MUST be a
+  case that plants the defect that check exists to catch and requires the build to go red. A check
+  never observed failing is not known to work.
+- **FR-035**: No part of the suite may skip. When it cannot run — a missing dependency, an empty
+  corpus, a case with no expectation — it MUST fail. A suite that skips reads exactly like a suite
+  that passes, which is Principle III applied to the project's own tooling.
+- **FR-036**: A rule MUST have exactly one implementation. Where the gate and the corpus check the
+  same rule, they MUST call the same code — otherwise the corpus asserts against a copy and proves
+  nothing about the gate that actually runs.
+- **FR-037**: The corpus MUST state, in its own text, what it does **not** establish.
+
+### What must leave the notebook
+
+- **FR-038**: Every note in `docs/` describing something this feature settles — accepts, rejects or
+  parks — MUST be deleted in the same change that settles it. This is FORMAT.md's existing rule; it
+  is restated here because this feature settles more notes at once than any before it.
+- **FR-039**: Where one rule is written in more than one place, **all** copies MUST be removed in a
+  single change, and any copy that **binds** — the constitution, `ARCHITECTURE.md` — MUST be amended
+  **first, in an earlier pull request**. Deleting the notebook copy alone leaves the repository
+  formally requiring what this feature forbids, which is a worse defect than the duplication it was
+  meant to cure.
+- **FR-040**: A decision record MUST NOT be rewritten to agree with this feature. A superseded ADR
+  entry receives a **dated supersession note**; the original argument stays readable. An ADR that
+  silently agrees with the present has stopped being a record.
+- **FR-041**: A note deleted for a construct that is **parked** rather than rejected MUST arrive in
+  the parked area carrying its argument, its rejected alternatives and a date. Deleting it outright
+  destroys reasoning that is expensive to reconstruct and cheap to move.
+- **FR-042**: Three glossary entries are **owed** before the constructs they name appear in the
+  schema or an example: the aggregate-versus-each distinction, the target description, and the
+  unrenderable criterion. Each with a rejected alternative, per FR-027.
+
+## Key Entities
+
+- **RequirementSet** — the document. One file, one set of requirements, no tool.
+- **Requirement** — one human statement about the system. Declares what is measured and which
+  predicates must hold over it.
+- **Indicator** — the measured quantity: what metric, over which requests, and of what shape (a
+  distribution of values, or a fraction of a total).
+- **Criterion** — one machine-checkable predicate over an indicator. The unit that becomes exactly one
+  native assertion, or exactly one named gap.
+- **Target** — the external tool that will host the assertions and decide the run. It never reads the
+  document.
+- **Target description** — the data that says how this target names things, what it can assert, what it
+  cannot, and how units convert. Adding a target is adding one of these.
+- **Rendering** — the act of turning criteria into a target's native assertions, producing both the
+  assertions and the named list of criteria it could not produce.
+- **Unrenderable criterion** — a criterion the target cannot express exactly, carried by name and
+  reason rather than dropped.
+- **Corpus** — the cases that check the format mechanically: documents that must be accepted,
+  documents that must be rejected and where, renderings any implementation must reproduce, and
+  defects the gate must catch. It is the oracle, not an implementation.
+- **Precondition** — a statement that the run happened in the intended regime at all. Renders like a
+  criterion, because no target has an outcome between pass and fail; carries a name into the target's
+  report, so a failure caused by the load generator is not read as a failure of the system.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All six statements the existing NFR-YAML supported are expressible — 6 of 6, each with
+  the document that expresses it and the assertion it renders into published in this repository.
+- **SC-002**: One unchanged requirement document produces assertions for at least two independent
+  targets.
+- **SC-003**: For every published example, the number of criteria rendered plus the number reported
+  unrenderable equals the number of criteria in the document. Exactly, every time.
+- **SC-004**: The number of tool names appearing anywhere in the format or in any validated example is
+  zero.
+- **SC-005**: The number of metric names enumerated in the format is zero.
+- **SC-006**: The number of constructs in the format that no surveyed target can assert **exactly** is
+  zero.
+- **SC-007**: Every claim in the target descriptions about what a tool can assert carries a source and
+  a date.
+- **SC-008**: A reader given a document and a target description predicts the assertions correctly,
+  including the numbers after unit conversion.
+- **SC-009**: Rendering the same document twice produces byte-identical output.
+- **SC-010**: After this change, the number of notes in `docs/` describing something this feature
+  settles is **zero** — every accepted, rejected or parked idea has had its note deleted in the same
+  change, per FORMAT.md.
+- **SC-011**: The number of new **concepts** this feature adds to the glossary is at most three, each
+  with a rejected alternative: the display name, the target description, and the unrenderable
+  criterion. A fourth entry, *rendering*, is owed but is not a fourth concept — it names
+  the artifact produced by an act this repository already calls *render*, in the glossary's own layer
+  diagram, in `ARCHITECTURE.md`'s R2 role and in this specification's Key Entities. Its glossary entry
+  MUST say exactly that, so the judgement is recorded rather than assumed.
+- **SC-012**: Every line a target's own report can produce for a rendered predicate resolves to
+  exactly one entry in the rendering, and each entry says whether it is a criterion or a precondition
+  — for 100% of predicates in every published example. Where two predicates would produce
+  indistinguishable report lines, the corpus says so rather than claiming a distinction that does not
+  exist.
+- **SC-013**: Stripping every display name from a document changes no rendering, on any target —
+  byte-identical output, every published case. An inert field that is not provably inert is a field
+  that will quietly acquire meaning.
+- **SC-014**: Every check the gate performs has a case that plants its defect and requires the build
+  to go red — 100% of checks, no exceptions.
+- **SC-015**: Running the suite with any required dependency removed turns the build red, and prints
+  no line reading `skip`.
+- **SC-016**: The number of rules implemented twice — once by the gate, once by the corpus — is zero.
+- **SC-017**: For every rendering case, rendered plus unrenderable equals the number of predicates in
+  the document. Exactly, every case.
+- **SC-018**: The number of notes deleted from `docs/` whose binding twin was not amended first is
+  **zero**. Orphaning a rule is worse than duplicating it.
+- **SC-019**: The corpus states what it does not establish, in its own text.
+
+## Assumptions
+
+- **Post-run evaluation is parked, not deleted.** Verdicts, gate, outcome and a result document remain
+  arguable ideas in the notebook. The user's instruction is that they are not needed *now*; this
+  feature takes them out of scope rather than out of existence. They return through the same route any
+  other idea does.
+- **The evaluation-shaped constructs stay out of the container.** `severity`, `gate`, `baseline` and
+  `tolerance` were already ideas rather than fields, so nothing has to be removed to satisfy the
+  instruction — only prevented from arriving.
+- **Rendering is implemented where the target lives, and that is outside this repository.** This
+  repository ships the format, the target descriptions, and the corpus that says what a correct
+  rendering produces. A library that builds Gatling assertion objects belongs to whoever integrates
+  Gatling — the format cannot hand Gatling a text file, because its assertions are constructed in code
+  at set-up time. Nothing in this feature is a commitment that such a library gets written, by anyone,
+  on any schedule.
+- **`http.route` stays the preferred way to address a request, and a request name stays the honest
+  fallback.** Almost no load generator emits a route, so most real documents will use names, and
+  documents written against names do not travel between tools. That is a stated cost, not a defect.
+- **The first two targets are Gatling and k6.** Gatling because it is the concrete case the format is
+  being shaped against; k6 because it is the most capable of the surveyed tools and therefore the best
+  test of whether the format is tool-agnostic rather than Gatling-shaped with a coat of paint. Both are
+  described as data in this repository; neither integration is built here.
+- **"Compatible with Gatling" means renderable into Gatling's assertion DSL**, not "resembles it".
+  Gatling's own vocabulary (`global`, `forAll`, `details`, `percentile3`) does not enter the format.
+- **`inconclusive` leaves the format with the rest of the outcome vocabulary.** A precondition still
+  exists and is still checked; what it cannot do is produce a third outcome, because no target has one
+  and FR-020 forbids admitting a construct nothing can check. The distinction it protects moves from an
+  outcome into a name in the target's report — which is where a human reads it anyway.
+
+## Decisions taken during specification
+
+Three questions were open when this specification was drafted, because each one changes what the
+format contains and none of them could be answered from the rest of the document. Each is recorded
+here with the alternative that was rejected, because a rejection outlives the term it protects.
+
+### D1. A precondition renders like a criterion, and carries a name
+
+> **Revised 2026-08-20, against Gatling's source.** As first written, this decision required a
+> precondition to carry a name into the target's own report, on the reasoning that "preserving it as
+> a name costs the format nothing". **That reasoning was wrong**: it costs a capability neither
+> surveyed target has. Gatling derives every printed assertion string from `(path, target,
+> condition)` and has no label field; the one author-controlled fragment must match a group or
+> request name recorded during the run, and is absent entirely at global scope — which is exactly
+> where a throughput precondition lands. The decision below is the repaired one; the evidence is in
+> [Appendix D](#appendix-d-why-a-precondition-cannot-be-named-in-the-targets-report).
+
+**Decided**: preconditions stay in the format and render into the same kind of native assertion a
+criterion does. The distinction is carried by the **rendering**, which records for each entry the
+native assertion identity the target derives its report line from, and flags which entries are
+preconditions. → FR-009, SC-012.
+
+**Why**: the distinction a precondition protects — *"the run did not happen as intended"* versus
+*"the system did not hold"* — has to survive into something a human reads. It cannot survive into the
+target's report, because no target has anywhere to put it. It can survive into the rendering, which
+already has to enumerate every predicate by identity, and from which a report line can be resolved
+back to its entry. This costs no new concept and requires no capability any target lacks.
+
+**Rejected — a third outcome (`inconclusive`)**: it is a construct no surveyed target can produce, so
+FR-020 forbids it. Every rendering would have to lie about it or drop it.
+**Rejected — dropping preconditions**: a run at 5 rps shows a green p95 and a false pass. That failure
+mode is the reason this project exists; a format that cannot state the precondition cannot catch it.
+**Rejected — keeping them as always-unrenderable**: a construct whose only behaviour is to be
+reported unsupported.
+**Rejected — smuggling a label into the target's request path**: Gatling's `details(...)` parts must
+equal a group or request name recorded during the run, so a label would force the adapter to rename
+the user's own requests, corrupting the recorded vocabulary — and it is unavailable at global scope
+regardless. This is the alternative the first version of this decision assumed would work.
+
+### D2. *(withdrawn)* A criterion says whether it holds over the aggregate or over each request
+
+> **Withdrawn 2026-08-20, on review.** The distinction is not admitted. The argument for it is kept
+> below because it was good and will be made again; what it lacked was a second target.
+
+**Was decided**: the format gains one distinction — *the aggregate of the selected requests* versus
+*each selected request individually, all of which must hold*.
+
+**Withdrawn because FR-020's second half forbids it, in as many words.** That rule says one target
+being able to assert a construct is necessary for admission and *"is not by itself sufficient, so a
+construct MUST NOT enter the format solely to reach one target's feature."* The distinction was
+admitted on the strength of exactly one target's native scope, which is the case the rule names. It
+was written in this specification and then broken by it.
+
+Three further facts, each found after the decision was taken, and each pointing the same way:
+
+- the native scope is hard-wired to **every request observed in the run**, so the distinction renders
+  only when the selection is *"every request"* — one combination, on one of two targets;
+- the second target has no equivalent at all, and its nearest construct quantifies over samples
+  rather than requests, which is a third statement again;
+- that single renderable combination is also the one that **exits successfully when it matches
+  nothing**. The only place the construct worked was the place it could lie.
+
+**And the ambiguity it was introduced to remove does not exist without it.** A selector matching many
+requests is unambiguous while there is only one reading. A spelling is needed to separate two
+meanings; with one meaning, the field is a required breaking change that buys nothing.
+
+**What the format loses**: "no endpoint slower than 2 s" as a single statement. It is written as one
+requirement per endpoint, which is verbose and silently stops covering an endpoint added later. That
+cost is real and is the reason the argument returns — with a second target that can assert it, or
+not at all.
+
+**Where it goes**: to the notebook, as an idea, with this argument attached. FORMAT.md's rule about a
+knob nobody asked for is the one that applies: it stays an idea until someone asks.
+
+### D3. A construct is admitted only if at least one target can assert it exactly
+
+**Decided**: FR-020. A construct enters the format only if at least one surveyed target can assert it
+exactly — a floor, not a licence. → FR-020, SC-006.
+
+**Why**: it is the same rule the project already applies to itself, pointed at the path that now
+exists. The inherited rule protected `report` as a complete path; this feature removes that path, so
+the rule protects nothing and its inverse is what is needed. Its bite is deliberate: `baseline` /
+`tolerance` and phase windows stay out until some target can assert them, which may be never. That is
+the honest answer, not a regression — they were already unbuildable, and this only stops the format
+promising them.
+
+**Rejected — "expressible regardless, gaps declared"**: it leaves room for post-run evaluation to
+return, at the price of a format most of which nothing checks. That is the state the surveyed formats
+are in, and the reason this project exists.
+**Rejected — "most targets must assert it"**: maximal portability, but it rejects constructs that are
+genuinely useful on the one tool a team actually runs, and it makes the format's contents a function
+of which tools happen to be in the survey.
+
+### Open — a problem this specification has not solved
+
+**A `ratio` names a metric it does not measure.** Found by a reader on 2026-08-20, while reading a
+worked example rather than by any check.
+
+An error-rate requirement reads `metric: http.client.request.duration`, because a histogram's count
+is the request count and OpenTelemetry defines no HTTP client request counter — verified against
+`model/http/metrics.yaml` on 2026-08-20, where the only `{request}`-unit instrument is
+`http.client.active_requests`, an in-flight gauge and not a total. The document is therefore
+*correct*, and reads as though it were about latency. That is a direct hit on User Story 4: a
+requirement is supposed to state what is measured and nothing else, and this one states a metric that
+is not what is measured.
+
+The root cause is not the metric name. It is that `ratio` reuses the `series` shape of
+`distribution` without recording that the metric is **counted** there rather than **measured** — one
+shape, two meanings, the difference written down nowhere.
+
+| Option | Cost |
+|---|---|
+| Leave it | The document misleads a competent reader; this one was found exactly that way |
+| Let `ratio` omit `metric` and mean "requests" | An implicit default, in a format that rejects unknown fields and demands units |
+| Coin `loadtest.requests` | Forbidden by Principle II — an alias for an existing histogram's count |
+| Rename the field inside `ratio`, e.g. `counting:` | Reads honestly; costs a term, and SC-011's budget is spent |
+
+The fourth is the strongest and none is free. Principle I requires the naming disagreement to be
+argued in an issue **before** any file changes, so this specification records the problem and does
+not settle it.
+
+**No convention exists for what a requirement's identifier should say.** Raised 2026-08-20 while
+reviewing a worked example, where the identifier `home-latency` turned out to carry two errors at
+once: *home* was an interpretation of a request whose recorded name is `GET /`, and *latency* names
+a narrower quantity than the metric it stood for — in one surveyed tool's own output, latency is
+time-to-first-byte while the metric is the whole duration. Both were invented by the author and
+neither is checkable.
+
+Two drift hazards pull in opposite directions and a convention has to price both:
+
+| Putting this in an identifier | Drifts when |
+|---|---|
+| a **value** — a threshold, a unit | the value changes and the name does not |
+| an **interpretation** — "home", "checkout", "critical" | the interpretation turns out to be wrong, and nothing ever re-checks it |
+| the **selector's own value** — the request's recorded name | the request is renamed in the test |
+
+The last is the least bad, because renaming the request arguably *does* make it a different
+requirement — but that is an argument, not a finding. FR-007a settles the display-name half (a name
+never restates a value). The identifier half is open, and Principle I puts it in an issue rather than
+in this document.
+
+## What leaves the notebook, and in what order
+
+FORMAT.md says a note is deleted in the same change that accepts, parks or rejects it, and that the
+step is not optional. This feature settles more notes at once than any before it, so the sweep was
+audited file by file and every proposed deletion was then argued against. **Most proposed deletions
+did not survive that argument**, and always for the same reason: the same rule is written in as many
+as four places, one of which binds.
+
+That produces the ordering rule now stated as FR-039, and the tiers below.
+
+### Tier 0 — deletable inside this feature
+
+Notes with no binding twin, or notes that duplicate something in their own file.
+
+| Where | What goes |
+|---|---|
+| `docs/units.md` | rule 1, which restates verbatim a rule stated eleven lines earlier **in the same file**; rule 3 (canonicalise, then compare), which describes evaluation; the "units inside the value" rejection row |
+| `docs/semconv/loadtest.md` | the `EvaluationReport.spec.run.attributes` field path in the run-identity heading. The heading, the table and the correlation finding stay — Principle II rests on them |
+| `docs/compatibility.md` | `report` as a conformance level; the sentence naming target-blind evaluation as the source of the format's portability claim |
+| `docs/GLOSSARY.md` | `severity`; the `gate` clause in the `RequirementSet` entry; the `→ fail` clause in `Criterion` |
+
+### Tier 1 — blocked on a constitution amendment
+
+Everything resting on Principle III's requirement that a run which did not meet its conditions
+**must** be reported as `inconclusive`. Decision D1 removes that outcome, so the principle and these
+notes have to move together.
+
+`gate`, `Verdict`, `Outcome`, the `inconclusive` half of `Guard`, `docs/examples/checkout-perf.report.yaml`.
+
+### Tier 2 — blocked on `ARCHITECTURE.md` and the constitution's Compatibility Constraints
+
+`Target`, `Adapter`, `MetricMapping`, the conformance ladder, and the old admission rule that FR-020
+replaces. The old rule exists in four copies — the constitution, `ARCHITECTURE.md` § 1, this
+notebook, and ADR-0002 — and the constitution's Governance section says the constitution wins.
+**Deleting the notebook copy first would leave the repository formally forbidding what FR-020
+requires.**
+
+### Tier 3 — dated notes on decision records, never rewrites
+
+ADR-0002 § D11, § D12, § D13 and ADR-0001 § D6, § D9, § D10 each receive a dated supersession note.
+Per FR-040 the original argument stays readable.
+
+### What the audit found that is not a deletion
+
+- **Three glossary entries are owed**, not removable: the aggregate-versus-each distinction, the
+  target description, and the unrenderable criterion (FR-042).
+- **`docs/references.md` is untouched** by this feature. Saying so plainly is cheaper than leaving a
+  reader to wonder.
+- **Appendix A's hierarchical-addressing claim survived a deliberate attempt to break it** — a
+  selector carrying a group attribute and a request-name attribute does reconstruct a target's
+  request path. But `loadtest.group.name` lives in an unsubmitted upstream proposal that
+  Principle VIII grandfathers *with an explicit warning that it may not be cited as precedent for
+  admitting new unsettled names*. That is a declared cost of D2's addressing, not a settled question.
+
+## Dependencies and Constraints
+
+These are named because two of them require a change to land **before** this feature does.
+
+| Dependency | Why it matters |
+|---|---|
+| `ARCHITECTURE.md` § 2, § 4, § 7 | It binds four component roles and a follow-up plan built on post-run evaluation. Taking R3 and R4 out of scope diverges from a binding document, which Principle VII says must be amended in an **earlier** pull request. |
+| Constitution Principle VI, *Evaluation Is Target-Blind* | It forbids consuming a statistic a target computed for itself as a verdict. An assertion-first format does exactly that — the whole point is that Gatling computes its own p95 and decides. The principle is not *violated*, because nothing in scope produces a verdict; but the ambiguity must be settled in the constitution before this ships, not discovered afterwards. |
+| Constitution Principle III, *No Silent Green* | **Requires an amendment, and this specification previously said it did not.** Its spirit survives intact and does most of the work here — it is why FR-010 through FR-013, FR-025 and FR-034 through FR-036 exist. But its letter mandates that a run which did not meet its conditions "MUST be reported as inconclusive", and decision D1 removes that outcome because no target has it. The principle must be amended in an earlier pull request to say what carries its run-time half under an assertion-first format, before Tier 1 above can be deleted. |
+| `docs/compatibility.md` design rule | "No construct may appear in OpenNFR that is expressible only at level `assert`." It protected `report` as a complete path; this feature removes that path, so the rule is void and **FR-020 replaces it** — inverting it, from *"nothing that only asserts"* to *"nothing that nothing can assert"*. The note must be edited in the same change that adopts FR-020, per FORMAT.md's rule that an accepted note is deleted rather than left as a second source. |
+| ADR-0002 conformance levels | `report`, `assert` and `abort` are cumulative levels over a path that ended in evaluation. With evaluation out of scope, `report` is no longer a conformance level at all — a tool that cannot assert is a tool this format cannot serve. The level table needs re-deriving, not editing. |
+| ADR-0001 | The naming arguments hold. Where this feature adds a term, ADR-0001's rule applies to it unchanged: it reaches the glossary with a rejected alternative first. |
+
+## Appendix A: what Gatling can actually assert
+
+Checked against `gatling/gatling` source on **2026-08-19**:
+`gatling-core/src/main/scala/io/gatling/core/assertion/AssertionSupport.scala` and
+`AssertionBuilders.scala`. This is evidence for the design, not part of the format.
+
+| Dimension | What exists |
+|---|---|
+| Scope | the whole run; **every request observed in the run**, individually; one request identified by a path of parts |
+| Response time | minimum, maximum, mean, standard deviation, any percentile |
+| Request counts | all / failed / successful, each as a count or as a percentage |
+| Throughput | mean requests per second |
+| Comparisons | less than, at most, greater than, at least, exactly, within a range, one of a set |
+| Aborting a run | not available |
+
+**Where the container from feature 002 already fits.** A fraction with a `bad` side is the
+failed-request percentage; with a `good` side, the successful one; its total is all requests. Reducing
+a distribution by `rate` is mean requests per second. `avg` is mean; `stddev` is standard deviation;
+`p95` is the 95th percentile. Response-time thresholds are whole milliseconds, which is exactly the
+conversion hazard FR-013 exists for.
+
+**Where it does not fit — the three things this feature must settle.**
+
+1. **Per-request-individually scope.** "Every request, each on its own, must hold" is a native scope in
+   Gatling and has no counterpart in selecting series. **Not adopted** — see D2, withdrawn. The scope
+   ranges over every request *observed in the run* rather than over a selection, one of two targets
+   has it at all, and an assertion in it that matches nothing exits successfully. A capability of the
+   target that the format does not reach for.
+2. **Hierarchical addressing.** A request is identified by a *path* of parts — group then request —
+   whereas the format addresses requests by flat attributes. The old NFR-YAML's `MyGroup / MyRequest`
+   key is the same shape, which is why people writing these requirements today will expect it. **Settled without a new term**: a selection
+   carrying both a group attribute and a request-name attribute reconstructs the path, and both
+   attributes already exist in `docs/semconv/loadtest.md`. → FR-008.
+3. **Comparisons with no counterpart in each direction.** The format has "not equal", which Gatling
+   lacks; Gatling has "within a range" and "one of a set", which the format lacks. Neither side may be
+   approximated into the other. **Settled by D3**: "not equal" now has to justify itself against
+   FR-020, and "within a range" is admissible on the strength of Gatling alone but is not admitted
+   automatically — FR-020 is a floor, not a licence. → FR-011, FR-020.
+
+Nothing in this appendix argues for adopting Gatling's vocabulary. It argues that the fit is close
+enough that three decisions, not a redesign, separate today's container from an assertion-first format.
+
+## Appendix B: four checks that could not fail, and what they cost to find
+
+Found while specifying the test corpus, each read in `scripts/verify.sh` and confirmed by hand on
+**2026-08-19**. Evidence for FR-034 and FR-035. **All four were fixed on `main` the same day**, by
+`fix(verify): make the English scan run, and fail loudly when a check cannot (#12)`; this appendix is
+the record of what they were and how they were found, not a list of open defects.
+
+| Site | Why it could not fail | Fixed by #12 |
+|---|---|---|
+| *Docs are English* | `grep -P` is a GNU extension; BSD grep exits 2, `2>/dev/null` ate the message and `\|\| true` ate the status. **The Cyrillic scan had never executed on macOS** | replaced with a `python3` scan of the same code-point range |
+| *YAML sketches parse* | printed `skip` on a missing interpreter or library and exited 0 | both branches now `FAIL` and exit non-zero |
+| *Sketches map one-to-one onto JSON* | iterated a glob with no empty-corpus guard: delete every sketch and the section printed nothing and passed | an explicit empty-corpus `FAIL` |
+| *Internal markdown links resolve* | the extraction pipeline's exit status was never examined; a broken pipeline yields zero links, zero failures, and `ok` | counts what it found, and fails when that is zero |
+
+### Why this is the argument for FR-034 rather than a closed matter
+
+**Not one of the four was caught by a test.** All four were found by reading the script while writing
+a specification about something else. The gate had been green on every commit, on both platforms, for
+the life of the project — and one of its sections had never once executed.
+
+A fix removes four defects; it does not make the fifth visible. What FR-034 requires is different in
+kind: for **every** check the gate performs, a case that plants the defect that check exists to catch
+and requires the build to go red. A check that has never been observed failing is not known to work,
+and that remains true of a freshly repaired one.
+
+The repository already knew the answer before the fix, which is the sharpest part: the schema section
+had always exited 1 on a missing library, with the comment *"a gate that skips itself reads exactly
+like a passing one"*, and had always guarded its empty corpus. Four sections had simply not copied
+it. Consistency is not something a reviewer reliably notices; a mutation case is.
+
+### One that is still open, of the opposite kind
+
+The link checker greps for `](` across every markdown file, so a regular expression written in prose
+— a character class followed by a group — reads as a link and is reported as dangling. It cost this
+feature a red build twice, on a documentation table. A false **positive**, so a nuisance rather than
+a danger, and untouched by #12 because the extraction is unchanged. Recorded because the next person
+to write a pattern into a document will hit it.
+
+## Appendix C: what the corpus will not establish
+
+Required by FR-037, and stated here so that planning does not treat the corpus as proof of more than
+it is.
+
+- **Nothing in this repository renders.** The rendering corpus is an oracle — a well-formed guess
+  until an integration somewhere else runs against it. Its checks are consistency checks between
+  files this repository writes.
+- **It can be uniformly wrong about a target.** If a target description wrongly claims a tool lacks
+  a comparison, and the case agrees, both are wrong and the build is green. Nothing here reads the
+  tool. FR-026's dated source is prose a human must check; a machine can verify that a date exists,
+  never that it is true.
+- **It does not check that the tool accepts the assertion.** The corpus pins the arguments, never
+  the API. A statistic name the tool does not have passes every check here.
+- **The sum rule closes over the document, not over intent.** It catches a criterion the renderer
+  dropped. It cannot catch the requirement nobody thought to write — which is the most common real
+  defect in requirement documents.
+- **Two targets do not prove the shape is neutral.** Any record designed while looking at Gatling
+  and k6 will fit Gatling and k6. The honest next probe is a third target with native assertions of
+  a different shape.
+
+## Appendix D: why a precondition cannot be named in the target's report
+
+Checked against `gatling/gatling` source on **2026-08-20**, tag `v3.15.1` where the file is still
+open-source and `v3.9.5` for the type that has since moved into a closed artifact. Evidence for the
+revision of decision D1 and for FR-009, and a caution about how the first version of that decision
+was reached.
+
+**An assertion is three fields and none of them is a name.** The single construction site is
+`Assertion(path, target, condition)` in `gatling-core/.../assertion/AssertionBuilders.scala`. The
+last open-source definition of the type — `gatling-commons-shared/.../assertion/AssertionModel.scala`
+at v3.9.5 — is a three-field case class. No step of the DSL, in any of its four language bindings,
+accepts a label, name or description.
+
+**Every printed string is derived from those three fields.** `gatling-app/.../RunResultProcessor.scala`
+builds its console line from `AssertionMessage.message(assertionResult.assertion)` — a function of
+the assertion alone. The JUnit XML template uses the same derived string as the `testcase` name; the
+HTML report renders it as a table row. There is nowhere for per-assertion metadata to enter.
+
+**The one author-controlled fragment is an address, not a label.** Only `AssertionPath.Details(parts)`
+carries author strings, and the validator resolves them against paths actually recorded during the
+run. A parts list matching nothing does not become a label — the assertion fails with a resolution
+error. Using it to smuggle a name would mean renaming the user's own requests and groups.
+
+**And it is absent exactly where it is needed.** A precondition about the run as a whole — "the
+generator actually reached 200 rps" — is global in scope. Its path prints as the literal `Global`.
+Author-controlled characters available: **zero**. A throughput precondition and a throughput
+criterion produce report lines of identical shape, which is precisely the confusion the precondition
+exists to prevent.
+
+**One finding in the project's favour.** An unresolvable request path **fails** rather than skipping.
+Gatling already honours Principle III at that point, without being asked to.
+
+### The caution worth keeping
+
+The first version of decision D1 chose "carry a name into the report" over three alternatives and
+recorded that it "costs the format nothing". It cost a capability that does not exist, and the error
+was not visible from the requirement — it was visible only in the tool's source. This is why FR-026
+requires every claim about a target to be checked and dated, and why the corpus exists: a decision
+that reads well and is unsourced is exactly the failure this repository was started to prevent,
+committed by this repository.

--- a/specs/003-assertion-first-format/tasks.md
+++ b/specs/003-assertion-first-format/tasks.md
@@ -1,0 +1,316 @@
+---
+description: "Task list for 003-assertion-first-format"
+---
+
+# Tasks: An Assertion-First Requirement Format
+
+**Input**: Design documents from `/specs/003-assertion-first-format/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/)
+
+**Tests**: **Required, and they are a user story of their own.** FR-028 through FR-037 and User
+Story 5 make the corpus part of the deliverable, not an optional extra. Every phase below that
+publishes a document also publishes what proves it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelisable — different files, no dependency on an incomplete task
+- **[Story]**: which user story the task serves (US1–US5)
+- Every task names the exact file it touches
+
+## Path conventions
+
+This repository ships JSON Schema and Markdown, no product code. Paths are repository-relative:
+`schema/opennfr.io/v1/`, `mappings/`, `conformance/`, `examples/`, `docs/`, `scripts/`.
+
+## Rules that bind every task below
+
+Taken from `AGENTS.md` and the constitution, restated because they change how the work is cut:
+
+- **One concern per PR**, and **one issue → one semantic commit**, each carrying a milestone and a
+  closing link. `scripts/check-linkage.sh` gates this in CI.
+- **`bash scripts/verify.sh` must pass on every commit.** A task that would leave it red is split.
+- **A term reaches `docs/GLOSSARY.md`, with a rejected alternative, before it appears in a schema or
+  an example.** This is why Phase 2 puts vocabulary ahead of schema.
+- **A published example is a compatibility-sensitive surface.** Any field name in one needs an ADR
+  to change later, so the first document published fixes the vocabulary in place.
+
+---
+
+## Phase 0: Prerequisite amendments — NOT THIS FEATURE'S PRs
+
+**Purpose**: Principle VII requires the architecture and the constitution to be amended in **earlier**
+pull requests, never diverged from silently. Nothing in Phase 2 onward may merge until these land.
+
+**⚠️ These are separate issues, separate PRs, and separate milestones-worth of review.** They are
+listed here because they block everything, not because this feature performs them. The written text
+for each is in [research.md § R10](research.md).
+
+- [ ] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now
+- [ ] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level
+- [ ] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format
+- [ ] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)**
+- [ ] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 7 — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at
+- [ ] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note
+
+**Checkpoint**: the repository permits what this feature does. Until then FR-020 is formally
+forbidden by the constitution, and Governance says the constitution wins.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: create the two homes `LAYOUT.md` already reserves, and wire the gate so an empty corpus
+fails instead of passing.
+
+- [ ] T007 [P] Create `mappings/` with a `README.md` stating what a target description is and that it is the only artifact class where a tool name is legitimate
+- [ ] T008 [P] Create `conformance/README.md` stating what the corpus binds and — required by FR-037 — what it does **not** establish, drawn from [spec Appendix C](spec.md#appendix-c-what-the-corpus-will-not-establish)
+- [ ] T009 Update `LAYOUT.md` § 1: the `mappings/` and `conformance/` rows lose "once it exists"; `mappings/` names `kind: TargetDescription` instead of `kind: MetricMapping`
+- [ ] T010 Update `LAYOUT.md` § 5 step 1 and § 6 so the relocation trap it already documents is closed: extend the sketch-label check beyond `docs/examples/*.yaml` in the same change that adds `mappings/`
+- [ ] T011 Add a `Conformance corpus` section to `scripts/verify.sh` that **fails** when the corpus is empty or its runner is missing — never skips (FR-035)
+
+**Checkpoint**: the gate reports a missing corpus as red. Nothing else has changed yet.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: vocabulary, then schema, then the one shared check implementation. Every user story
+depends on all three.
+
+**⚠️ CRITICAL**: no user story work begins until this phase is complete.
+
+### Vocabulary before schema (Principle I)
+
+- [ ] T012 [P] Add the `Display name` entry to `docs/GLOSSARY.md` with its rejected alternatives — `label` (in one surveyed tool a label *is* the sampler name, i.e. a selector value), `title` (collides with the document title and with JSON Schema's `title`), `description` (invites paragraphs)
+- [ ] T013 [P] Add the `Target description` entry to `docs/GLOSSARY.md` with a rejected alternative, and mark the incumbent `MetricMapping` entry superseded rather than deleting it
+- [ ] T014 [P] Add the `Unrenderable criterion` entry to `docs/GLOSSARY.md` with a rejected alternative
+- [ ] T015 Add the `Rendering` entry to `docs/GLOSSARY.md`, and record in the entry itself that it is **not a fourth concept** — it names the output of an act the glossary diagram, `ARCHITECTURE.md` R2 and the spec already call *render*. SC-011's budget depends on that judgement being written down, not assumed
+
+### Schema
+
+- [ ] T016 Add optional `displayName` to `metadata`, each requirement and each predicate in `schema/opennfr.io/v1/requirementset.schema.json` — string, `minLength: 1`, additive so every existing document stays valid (FR-007)
+- [ ] T017 Create `schema/opennfr.io/v1/targetdescription.schema.json` per [data-model.md § 2](data-model.md): `evidence` with `minItems: 1` cited by every claim, `native.fields`, `report.derivedFrom`, `units` as integer numerator/denominator pairs, `names.unlisted` **required**, and `assertable` with gaps partitioning each axis
+- [ ] T018 Create `schema/opennfr.io/v1/rendering.schema.json` per [data-model.md § 3](data-model.md): one ordered `predicates` list, `predicate.role`, `oneOf` between `rendered` and `unrenderable`, `minItems: 1` on both `assertions` and `reasons`, and `native.text` as a string with **no `pattern`**
+- [ ] T019 Extend the schema section of `scripts/verify.sh` to validate `mappings/*.yaml` and `conformance/**/*.yaml` against their kinds, and to fail on a `kind` with no schema rather than passing over it
+
+### One rule, one implementation (FR-036)
+
+- [ ] T020 Extract the gate's inline heredoc checks into `scripts/opennfr_check.py` — YAML-event scan, JSON-mappability, schema validation, predicate identity — importable as a module and runnable as a script
+- [ ] T021 Replace the corresponding sections of `scripts/verify.sh` with calls into `scripts/opennfr_check.py`, so the corpus later asserts against the gate that actually runs rather than a copy
+- [ ] T022 Fix predicate identity in `scripts/opennfr_check.py` to be unique across `criteria` **and** `guards` together — today the gate resets its seen-set per section, so a guard and a criterion may collide silently ([data-model.md § 1.2](data-model.md))
+
+**Checkpoint**: vocabulary, three schemas and one shared checker. User stories can now proceed in
+parallel.
+
+---
+
+## Phase 3: User Story 1 — A requirement becomes a Gatling assertion (Priority: P1) 🎯 MVP
+
+**Goal**: an engineer writes a requirement and it becomes an assertion the tool can run, with no tool
+name anywhere in the document.
+
+**Independent test**: express the six statements the prior NFR-YAML could carry, and show the
+assertion each becomes. Six for six, or the format is narrower than what it replaces.
+
+- [ ] T023 [US1] Write `mappings/gatling.yaml` — the capability table, every claim citing dated evidence per FR-026/SC-007. Source the assertion surface from [spec Appendix A](spec.md#appendix-a-what-gatling-can-actually-assert), which is already dated and sourced
+- [ ] T024 [US1] Declare in `mappings/gatling.yaml` that `report.carriesAuthorName: false`, with the evidence from [spec Appendix D](spec.md#appendix-d-why-a-precondition-cannot-be-named-in-the-targets-report) — this is what makes SC-012 checkable rather than aspirational
+- [ ] T025 [US1] Declare the numeric domain in `mappings/gatling.yaml` as integer milliseconds, so FR-013 has something exact to decide against
+- [ ] T026 [P] [US1] Write `conformance/render/six-statements/document.yaml` — all six statements in one document: the 50th, 75th, 95th and 99th percentiles of response time, the maximum, and the failed-request share, addressed at one request and across all
+- [ ] T027 [US1] Write `conformance/render/six-statements/rendering.gatling.yaml` — one entry per predicate, in document order, each `rendered` with the assertion the target receives
+- [ ] T028 [P] [US1] Write `conformance/render/request-in-a-group/` — document and rendering for a request addressed inside a group, proving FR-008's hierarchical addressing needs no new term
+- [ ] T029 [P] [US1] Write `conformance/render/precondition-named/` — a requirement carrying a guard, its rendering marking `role: guard`, demonstrating FR-009's repair
+- [ ] T030 [US1] Copy the six statements into `examples/` as validated examples so FR-023's "published in this repository" is discharged by an artifact the gate holds up, not by a claim
+
+**Checkpoint**: the MVP. One document, no tool named in it, and the assertions it becomes.
+
+---
+
+## Phase 4: User Story 2 — The same document is reused for another tool (Priority: P2)
+
+**Goal**: the requirement document does not change; only the choice of target does.
+
+**Independent test**: render one unchanged document for two targets and compare. The assertion lists
+differ; the document is byte-identical.
+
+- [ ] T031 [US2] Write `mappings/k6.yaml` — the second capability table, with the eleven axes of difference recorded in [research.md § R3](research.md), each cited and dated
+- [ ] T032 [US2] Declare in `mappings/k6.yaml` the `0..1` rate against `0..100` percent conversion and the float threshold domain — the pair that makes FR-014 concrete rather than theoretical
+- [ ] T033 [US2] Write `conformance/render/ratio-not-assertable/` — one `document.yaml`, two renderings, opposite outcomes on the same predicate
+- [ ] T034 [US2] Write `conformance/render/threshold-does-not-convert/` — a fractional-millisecond threshold, exact on one target and **unrenderable** on the other. The three-orders-of-magnitude hazard, in one case
+- [ ] T035 [US2] Add a corpus check that every `document.yaml` under `conformance/render/` is byte-identical across the targets that render it — the claim of this story, made mechanical
+
+**Checkpoint**: two targets, one unchanged document, and the difference is entirely in the mappings.
+
+---
+
+## Phase 5: User Story 5 — Every rule is checked by machine (Priority: P2)
+
+**Goal**: a change that breaks a stated rule is caught by the build, not by a reader months later.
+
+**Independent test**: plant, one at a time, each defect the gate exists to catch. The build goes red
+every time and names the case.
+
+### The runner
+
+- [ ] T036 [US5] Write `scripts/check-conformance.py` with the exit contract from [contracts/corpus-runner.md § E1](contracts/corpus-runner.md): `0` passed, `1` a case failed, `2` **could not run**. No skip branch anywhere
+- [ ] T037 [US5] Implement the check codes `SCHEMA`, `IDENTITY`, `SUM`, `ORDER`, `CONVERT`, `GAP`, `PARTITION`, `EVIDENCE`, `COLLIDE`, `NOTOOL` in `scripts/check-conformance.py`, calling `scripts/opennfr_check.py` for anything the gate also checks
+- [ ] T038 [US5] Implement `CONVERT` in exact rational arithmetic from the description's `units` — a float comparison cannot decide exact representability, which is the whole point of FR-013
+- [ ] T039 [US5] Implement `COLLIDE` to **report rather than fail**: two predicates with equal `report.derivedFrom` projections are a fact about the target, and failing on it would push authors to hide collisions (SC-012)
+
+### The parse corpus
+
+- [ ] T040 [P] [US5] Write `conformance/parse/accept/` — valid documents covering both indicator shapes, an empty selector, a fractional percentile, a guard with its own indicator, and two named criteria sharing an aggregation
+- [ ] T041 [US5] Write `conformance/parse/reject/` — one mutation per case, each differing from a valid document by **exactly one** change (FR-030): unknown field at root, in a criterion and in a guard; missing unit; misspelled unit, operator and aggregation; percentile over a ratio; both indicator shapes; neither; `good` and `bad` together; uppercase name; non-scalar selector value; a threshold that is a date; anchors and aliases; duplicate identity; empty `requirements`
+- [ ] T042 [US5] Write one `.expected.yaml` sidecar per rejection case naming the **exact path** the error must report (FR-031) — never an `expect:` key inside the case, which would itself be an unknown field and mask the finding
+- [ ] T043 [P] [US5] Write `conformance/parse/known-gaps/` for rules the schema cannot yet express, each dated, so a gap is a register entry rather than a silent pass
+
+### The gate mutation suite
+
+- [ ] T044 [US5] Write `scripts/test-gate.py`, which copies the tree, plants one defect and requires the gate to go red (FR-034)
+- [ ] T045 [US5] Add the mandatory control case to `scripts/test-gate.py`: an unmutated copy must exit `0`, or the whole suite can pass because the gate is red for an unrelated reason
+- [ ] T046 [US5] Add mutation cases for the four checks repaired in `9657819` — Cyrillic in a document, a shimmed-away library, an emptied sketch corpus, a broken link pipeline. These are the most valuable pins in the suite: each guards a section that reported `ok` for the life of the project ([spec Appendix B](spec.md#appendix-b-four-checks-that-could-not-fail-and-what-they-cost-to-find))
+- [ ] T047 [US5] Add mutation cases for every remaining check in `scripts/verify.sh`, so SC-014 is 100% and not "the ones we thought of"
+- [ ] T048 [US5] Add a mutation case asserting **no line matches `skip`** when a dependency is removed — assert on the word, not the exit code, because other sections turn the run red and would mask a section that quietly passes
+- [ ] T049 [US5] Wire `scripts/check-conformance.py` and `scripts/test-gate.py` into `scripts/verify.sh`, propagating exit codes into `fail`
+
+**Checkpoint**: every rule the specification states about a document is now falsifiable.
+
+---
+
+## Phase 6: User Story 3 — An unrenderable requirement is named, never dropped (Priority: P3)
+
+**Goal**: the engineer is told, by name and before the run, what their tool cannot check.
+
+**Independent test**: a document mixing renderable and unrenderable criteria. Every criterion is in
+exactly one of two lists and the counts add up.
+
+- [ ] T050 [P] [US3] Write `conformance/render/comparison-not-available/` — a predicate using an operator one target lacks, unrenderable with a reason citing the comparison gap, never approximated (FR-011)
+- [ ] T051 [P] [US3] Write `conformance/render/statistic-not-available/` — unrenderable for a **different** named reason, so the spec's three kinds of unrenderability are distinguishable by which axis the gap partitions
+- [ ] T052 [US3] Add negative corpus cases under `conformance/render/negative/` that the runner MUST trip: a silently dropped predicate, a fabricated assertion for a predicate nobody wrote, a rounded threshold, and a predicate refused for a capability the description **does** declare
+- [ ] T053 [US3] Implement the second direction of `GAP` in `scripts/check-conformance.py` — declaring something unrenderable that the target can in fact assert is as much a defect as the reverse, and only one of the two is uncomfortable to report
+- [ ] T054 [US3] Implement `PARTITION` so a combination declared in neither capabilities nor gaps is reported as a **defect of the description**, which is FR-017 stated as an executable rule
+
+**Checkpoint**: no criterion can disappear between a document and a rendering.
+
+---
+
+## Phase 7: User Story 4 — A reader can predict the assertions (Priority: P4)
+
+**Goal**: someone who has never seen the tooling reads a document and a description and can say what
+will be asserted, and against what number.
+
+**Independent test**: give a reader both files and ask them to write down the assertions; compare.
+
+- [ ] T055 [US4] Rewrite the "Deliberately not in it — yet" table in `FORMAT.md`: several rows are now settled permanently rather than "yet", and `enforcement`, `onViolation`, `gate` and `severity` are rejected rather than pending
+- [ ] T056 [US4] Document `displayName` in `FORMAT.md` together with FR-007a — a display name never restates a threshold, a unit or an operator, because that is a second source for one number and the two diverge the first time the threshold moves
+- [ ] T057 [US4] State in `FORMAT.md`, where the field is introduced, that a display name **does not reach the target's report**. A field named this invitingly will otherwise be assumed to
+- [ ] T058 [US4] Add the `--strip-display-names` mode to `scripts/check-conformance.py` and the SC-013 case: stripping every display name must leave every rendering byte-identical
+- [ ] T059 [US4] Write `docs/targets/gatling.md` and `docs/targets/k6.md` explaining each mapping in prose, so the capability tables are readable by someone who will not read YAML
+
+**Checkpoint**: the format is predictable from reading, which is the testable form of "good-looking".
+
+---
+
+## Phase 8: Polish and the deletion sweep
+
+**Purpose**: FORMAT.md's rule — a note accepted, parked or rejected is deleted in the same change
+that settles it — applied in the order [spec § What leaves the notebook](spec.md#what-leaves-the-notebook-and-in-what-order) establishes. **Tier order is not a preference.** A rule written in four places cannot be
+removed from the notebook copy alone.
+
+### Tier 0 — no binding twin, safe now
+
+- [ ] T060 [P] Delete rule 1 and rule 3 from `docs/units.md`, and the "units inside the value" rejection row. Rule 1 restates verbatim a rule stated eleven lines above it **in the same file**
+- [ ] T061 [P] Drop the `EvaluationReport.spec.run.attributes` field path from the run-identity heading in `docs/semconv/loadtest.md`, keeping the table and the correlation finding — Principle II rests on them
+- [ ] T062 [P] Delete `report` as a conformance level from `docs/compatibility.md`, and the sentence naming target-blind evaluation as the source of the format's portability claim
+- [ ] T063 [P] Delete the `severity` entry from `docs/GLOSSARY.md`, the `gate` clause from `RequirementSet`, and the `→ fail` clause from `Criterion`
+
+### Tier 1 — after T001 (Principle III)
+
+- [ ] T064 Move `gate`, `Verdict`, `Outcome` and the `inconclusive` half of `Guard` out of `docs/GLOSSARY.md` into a parked note under `docs/experimental/`, carrying each argument and its rejected alternatives with a date (FR-041)
+- [ ] T065 Delete `docs/examples/checkout-perf.report.yaml`, carrying its argument into the same markdown parked note — the parked area is markdown-only, so the YAML has no compliant home ([research.md § R7](research.md))
+
+### Tier 2 — after T002 and T005
+
+- [ ] T066 Remove all four copies of the superseded admission rule in one change — `.specify/memory/constitution.md`, `ARCHITECTURE.md` § 1, `docs/compatibility.md` and `docs/adr/0002-compatibility.md`. Removing the notebook copy alone would leave the repository formally forbidding what FR-020 requires
+- [ ] T067 Update the `Target`, `Adapter` and `MetricMapping` entries in `docs/GLOSSARY.md` to match the amended architecture, and fix every same-file anchor in the same change
+
+### Tier 3 — dated notes on decision records, never rewrites
+
+- [ ] T068 [P] Append dated supersession notes to ADR-0002 §§ D11, D12, D13 in `docs/adr/0002-compatibility.md`, leaving the original arguments readable (FR-040)
+- [ ] T069 [P] Append dated supersession notes to ADR-0001 §§ D6, D9, D10 in `docs/adr/0001-terminology.md`
+
+### The two open questions, into issues rather than files
+
+- [ ] T070 [P] Open an issue for the `ratio` readability problem: an error-rate requirement names `http.client.request.duration`, a metric it does not measure. Carry the four options and their costs from [spec § Open](spec.md#open--a-problem-this-specification-has-not-solved). Principle I puts a naming disagreement in an issue before any file changes
+- [ ] T071 [P] Open an issue for the requirement-identifier convention, carrying the three drift hazards recorded in the same section
+- [ ] T072 [P] Open an issue for the link checker's false positive: it greps for `](`, so a regular expression written in prose reads as a dangling link. Untouched by `9657819` because the extraction is unchanged
+
+**Checkpoint**: `docs/` holds live ideas only, and every settled note has been deleted or parked in
+the change that settled it.
+
+---
+
+## Dependencies
+
+```text
+Phase 0 (amendments, separate PRs)
+   │
+   ├──> Phase 1 (setup) ──> Phase 2 (vocabulary, schema, shared checker)
+   │                              │
+   │                              ├──> Phase 3  US1  (P1) 🎯 MVP
+   │                              │       │
+   │                              │       └──> Phase 4  US2  (P2)
+   │                              │
+   │                              ├──> Phase 5  US5  (P2)  — independent of US1/US2
+   │                              │
+   │                              ├──> Phase 6  US3  (P3)  — needs US1 for cases to exist
+   │                              └──> Phase 7  US4  (P4)
+   │
+   └──> Phase 8 Tier 0 (safe now)
+        Phase 8 Tier 1 needs T001
+        Phase 8 Tier 2 needs T002 + T005
+```
+
+**Story independence**
+
+| Story | Depends on | Why |
+|---|---|---|
+| US1 | Phase 2 | Needs both new schemas and the vocabulary |
+| US2 | Phase 2 | Independent of US1 — a second mapping can be written in parallel; only T033/T035 need US1's documents |
+| US5 | Phase 2 | The parse corpus and the gate mutation suite need nothing from US1 or US2 and can be built first |
+| US3 | US1 | Needs a target description and at least one document to declare something unrenderable against |
+| US4 | US1, US2 | Prose about mappings needs the mappings |
+
+**Soft dependency worth stating**: US1 publishes renderings that only become *checked* when US5's
+runner lands. Reviewing them by hand in between is exactly the state this feature exists to end, so
+prefer landing T036–T039 early even though the phase is numbered later.
+
+## Parallel opportunities
+
+- **T007, T008** — two new directories, no overlap
+- **T012, T013, T014** — three glossary entries in one file; parallel only if authored separately and merged in one commit, since the Development Workflow requires a term change and its glossary update in the same PR
+- **T026, T028, T029** — three independent corpus case directories
+- **T040, T043** — accept and known-gaps corpora, different directories
+- **T050, T051** — two unrenderable cases, different reasons
+- **T060, T061, T062, T063** — Tier 0 deletions, four different files
+- **T068, T069** — two ADRs
+- **T070, T071, T072** — three issues, no files touched
+
+## Implementation strategy
+
+**MVP is Phase 3 alone.** US1 delivers the whole claim of the feature: a requirement written with no
+tool named in it becoming an assertion the tool runs. Everything after it either widens the claim
+(US2), makes it falsifiable (US5), makes it honest under failure (US3) or makes it readable (US4).
+
+**Suggested landing order**, one concern per PR:
+
+1. Phase 0 amendments — three or four PRs, each amending one document
+2. Phase 1 + Phase 2 — setup, vocabulary, schema; the vocabulary PR lands before the schema PR
+3. Phase 5, T036–T039 — the runner, early, so nothing below is reviewed by eye
+4. Phase 3 — the MVP
+5. Phase 4, Phase 5 remainder, Phase 6, Phase 7
+6. Phase 8 — the sweep, in tier order, each tier after its amendment
+
+**What must not be batched**: Tier 2's four copies of the admission rule are one change precisely
+because splitting them leaves the repository self-contradictory between merges. The opposite applies
+to Tier 0, where four independent files can go separately.

--- a/specs/003-assertion-first-format/tasks.md
+++ b/specs/003-assertion-first-format/tasks.md
@@ -58,15 +58,27 @@ architecture amended "first, in an earlier pull request". The specification was 
 ahead of both. The conservative reading is that PR #14 waits for them; that call has not been made,
 and it should be made rather than defaulted into.
 
-- [ ] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now
-- [ ] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level
-- [ ] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format
-- [ ] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)**
-- [ ] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 6, 7 in **one** pull request — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", clause 20 in the monitoring direction, and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at; § 4 clause 11 is the fourth copy of the rule the constitution inverts, so splitting the sections would move the stale rule rather than retire it
-- [ ] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note
+- [X] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now — **written, in #16, awaiting merge**
+- [X] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level — **written, in #16, awaiting merge**
+- [X] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format — **written, in #16, awaiting merge**
+- [X] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)** — **written, in #16, awaiting merge**
+- [X] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 6, 7 in **one** pull request — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", clause 20 in the monitoring direction, and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at; § 4 clause 11 is the fourth copy of the rule the constitution inverts, so splitting the sections would move the stale rule rather than retire it — **written, in #18, awaiting merge**
+- [X] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note — **written, in #20, awaiting merge**
 
 **Checkpoint**: the repository permits what this feature does. Until then FR-020 is formally
 forbidden by the constitution, and Governance says the constitution wins.
+
+**Status 2026-08-21.** All three pull requests are open, `verify` and `linkage` green on each:
+
+| PR | Issue | Covers | Merge order |
+|---|---|---|---|
+| [#16](https://github.com/galax-io/opennfr/pull/16) | #15 | Constitution → 2.0.0, and `plan-template.md` | first |
+| [#18](https://github.com/galax-io/opennfr/pull/18) | #17 | `ARCHITECTURE.md` §§ 1–7 | after #16 |
+| [#20](https://github.com/galax-io/opennfr/pull/20) | #19 | ADR-0003 retiring the ladder; dated notes on ADR-0002 | after #16 |
+
+Marked `[X]` because the work is written and submitted, not because it has landed. **Phase 1
+onward stays blocked until these merge** — the constitution still carries the constraint FR-020
+inverts, and Governance says the constitution wins while it does.
 
 ---
 

--- a/specs/003-assertion-first-format/tasks.md
+++ b/specs/003-assertion-first-format/tasks.md
@@ -42,15 +42,27 @@ Taken from `AGENTS.md` and the constitution, restated because they change how th
 **Purpose**: Principle VII requires the architecture and the constitution to be amended in **earlier**
 pull requests, never diverged from silently. Nothing in Phase 2 onward may merge until these land.
 
-**⚠️ These are separate issues, separate PRs, and separate milestones-worth of review.** They are
-listed here because they block everything, not because this feature performs them. The written text
-for each is in [research.md § R10](research.md).
+**⚠️ Eleven amendments, landing as three pull requests.** They are listed here because they block
+everything, not because this feature performs them. The written text for each is in
+[research.md § R10](research.md).
+
+| PR | Covers | Why it cannot be split further |
+|---|---|---|
+| Constitution → **2.0.0** | T001–T004 | Its own amendment procedure: a PR that changes "this file and any templates the change affects, **and nothing else**". One version stamp |
+| `ARCHITECTURE.md` | T005 | § 4 clause 11 is the fourth copy of the rule § 1 clause 3 retires; separating them moves the stale rule |
+| ADR-0002 § D13 | T006 | The conformance levels are a compatibility-sensitive surface; only an ADR may re-derive them |
+
+**Two of these block the specification itself, not a later task.** Principle VI and
+`ARCHITECTURE.md` § 1 are what make this feature formally permitted, and Principle VII requires the
+architecture amended "first, in an earlier pull request". The specification was opened for review
+ahead of both. The conservative reading is that PR #14 waits for them; that call has not been made,
+and it should be made rather than defaulted into.
 
 - [ ] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now
 - [ ] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level
 - [ ] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format
 - [ ] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)**
-- [ ] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 7 — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at
+- [ ] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 6, 7 in **one** pull request — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", clause 20 in the monitoring direction, and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at; § 4 clause 11 is the fourth copy of the rule the constitution inverts, so splitting the sections would move the stale rule rather than retire it
 - [ ] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note
 
 **Checkpoint**: the repository permits what this feature does. Until then FR-020 is formally
@@ -65,11 +77,22 @@ fails instead of passing.
 
 - [ ] T007 [P] Create `mappings/` with a `README.md` stating what a target description is and that it is the only artifact class where a tool name is legitimate
 - [ ] T008 [P] Create `conformance/README.md` stating what the corpus binds and — required by FR-037 — what it does **not** establish, drawn from [spec Appendix C](spec.md#appendix-c-what-the-corpus-will-not-establish)
-- [ ] T009 Update `LAYOUT.md` § 1: the `mappings/` and `conformance/` rows lose "once it exists"; `mappings/` names `kind: TargetDescription` instead of `kind: MetricMapping`
+- [ ] T009 Update `LAYOUT.md` § 1: the `mappings/` and `conformance/` rows lose "once it exists"; `mappings/` names `kind: TargetDescription` instead of `kind: MetricMapping`. **Lands in the same PR as T013** — the Development Workflow requires a PR that changes a term to update `docs/GLOSSARY.md` in that same PR, and this is where `TargetDescription` first appears
 - [ ] T010 Update `LAYOUT.md` § 5 step 1 and § 6 so the relocation trap it already documents is closed: extend the sketch-label check beyond `docs/examples/*.yaml` in the same change that adds `mappings/`
-- [ ] T011 Add a `Conformance corpus` section to `scripts/verify.sh` that **fails** when the corpus is empty or its runner is missing — never skips (FR-035)
+- [ ] T011 Add a `Conformance corpus` section to `scripts/verify.sh` that **fails** when the corpus is empty or its runner is missing — never skips (FR-035). **Lands in the same commit as T040 and T044**, the first corpus cases: a section that fails on an empty corpus turns the gate red on the commit that introduces it, and the constitution requires `verify.sh` green on every commit. Writing it to tolerate an empty corpus instead would be the silent green it exists to prevent
 
-**Checkpoint**: the gate reports a missing corpus as red. Nothing else has changed yet.
+**Checkpoint**: the two homes exist and `LAYOUT.md` describes them. The gate is unchanged until
+T011 lands with its first cases.
+
+### Task-ordering constraints found while planning execution
+
+Two tasks in this phase cannot land alone, and both are the same shape — a rule this repository
+already binds, hit from an unexpected direction:
+
+| Task | Cannot land alone because |
+|---|---|
+| T009 | It introduces `TargetDescription` into a published document. A PR that changes a term updates `docs/GLOSSARY.md` in the same PR, so T009 and T013 are one PR |
+| T011 | A section that fails on an empty corpus is red on the commit that adds it, and `verify.sh` must be green on every commit. It lands with T040 and T044 |
 
 ---
 

--- a/specs/003-assertion-first-format/tasks.md
+++ b/specs/003-assertion-first-format/tasks.md
@@ -58,27 +58,27 @@ architecture amended "first, in an earlier pull request". The specification was 
 ahead of both. The conservative reading is that PR #14 waits for them; that call has not been made,
 and it should be made rather than defaulted into.
 
-- [X] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now — **written, in #16, awaiting merge**
-- [X] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level — **written, in #16, awaiting merge**
-- [X] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format — **written, in #16, awaiting merge**
-- [X] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)** — **written, in #16, awaiting merge**
-- [X] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 6, 7 in **one** pull request — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", clause 20 in the monitoring direction, and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at; § 4 clause 11 is the fourth copy of the rule the constitution inverts, so splitting the sections would move the stale rule rather than retire it — **written, in #18, awaiting merge**
-- [X] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note — **written, in #20, awaiting merge**
+- [X] T001 Amend Principle III in `.specify/memory/constitution.md`: its letter mandates a run that missed its conditions "MUST be reported as inconclusive"; no surveyed target has a third outcome. Keep the spirit, state what carries the run-time half now — **landed**, `d10beff`
+- [X] T002 Amend § Compatibility Constraints in `.specify/memory/constitution.md`: the binding "no construct expressible only at conformance level `assert` or above" is inverted by FR-020, and `report` ceases to be a conformance level — **landed**, `d10beff`
+- [X] T003 Amend Principle VI in `.specify/memory/constitution.md`: decide narrow-or-remove; it is vacuous rather than satisfied under an assertion-first format — **landed**, `d10beff`
+- [X] T004 Correct the versioning-policy limb in `.specify/memory/constitution.md` § Governance so T001–T003 can be stamped honestly, and stamp the document **2.0.0 (MAJOR)** — **landed**, `d10beff`
+- [X] T005 [P] Amend `ARCHITECTURE.md` §§ 1, 2, 3, 4, 5, 6, 7 in **one** pull request — clauses 1–3, the R1–R4 role table and "what no role may do", the target classes, the walkthroughs, "support is data", clause 20 in the monitoring direction, and the § 7.1 follow-up table. § 2 is where the rendering gets a definition to point at; § 4 clause 11 is the fourth copy of the rule the constitution inverts, so splitting the sections would move the stale rule rather than retire it — **landed**, `21082bd`
+- [X] T006 Amend ADR-0002 § D13 (conformance levels) — the levels are an ADR-gated surface, so re-deriving them cannot be done by editing a note — **landed**, `066e9e3`
 
 **Checkpoint**: the repository permits what this feature does. Until then FR-020 is formally
 forbidden by the constitution, and Governance says the constitution wins.
 
-**Status 2026-08-21.** All three pull requests are open, `verify` and `linkage` green on each:
+**Landed 2026-08-21**, in this order:
 
-| PR | Issue | Covers | Merge order |
-|---|---|---|---|
-| [#16](https://github.com/galax-io/opennfr/pull/16) | #15 | Constitution → 2.0.0, and `plan-template.md` | first |
-| [#18](https://github.com/galax-io/opennfr/pull/18) | #17 | `ARCHITECTURE.md` §§ 1–7 | after #16 |
-| [#20](https://github.com/galax-io/opennfr/pull/20) | #19 | ADR-0003 retiring the ladder; dated notes on ADR-0002 | after #16 |
+| Commit | PR | Covers |
+|---|---|---|
+| `d10beff` | #16 | Constitution → **2.0.0**, and `plan-template.md` |
+| `21082bd` | #18 | `ARCHITECTURE.md` §§ 1–7 |
+| `066e9e3` | #20 | ADR-0003 retiring the ladder; dated notes on ADR-0002 |
 
-Marked `[X]` because the work is written and submitted, not because it has landed. **Phase 1
-onward stays blocked until these merge** — the constitution still carries the constraint FR-020
-inverts, and Governance says the constitution wins while it does.
+**The phase is closed and Phase 1 is unblocked.** The constraint FR-020 inverts is gone from the
+constitution — verified, zero occurrences — so the format may now contain a construct on the
+strength of a target being able to assert it.
 
 ---
 


### PR DESCRIPTION
Closes #13

## What changes

Specification and plan only — `specs/003-assertion-first-format/`. No schema, no corpus, no
implementation. Spec-first, per AGENTS.md.

The format stops being the input to an evaluation engine this project has not built and becomes the
input to the load tool's own assertions. Of `ARCHITECTURE.md`'s four roles, **R1 Parse** and
**R2 Render** stay; **R3 Ingest** and **R4 Evaluate** leave the scope, along with verdicts, outcomes,
gate policy and the result document. Those are parked as ideas, not deleted.

42 functional requirements, 19 success criteria, 5 user stories, plus Phase 0 research and Phase 1
design artifacts.

## Why

The load tool already computes the statistics, evaluates its own assertions and prints its own
report. A parallel evaluation path means re-deriving percentiles the tool has already derived, and
answering *"why does OpenNFR say p95 = 480 ms when the tool says 502 ms"* forever.

## What a reviewer should know

**Two decisions were reversed by evidence, and the record says so rather than being tidied.**

- **D1 was wrong.** It required a precondition to carry a name into the target's report, reasoning
  that this "costs the format nothing". Checked against the tool's source: the assertion type is
  `(path, target, condition)`, every printed string is derived from those three fields, and the one
  author-controlled fragment must match a name recorded during the run — and is absent entirely at
  global scope, which is exactly where a throughput precondition lands. The identity moves into the
  rendering. Appendix D carries the evidence and the caution.
- **D2 is withdrawn.** The per-request scope was admitted on one target's strength, which FR-020's
  own second half forbids in as many words. It renders in one combination on one of two targets, and
  that combination exits successfully when it matches nothing.

The container change is therefore **additive**: an optional display name beside the machine
identifier. Every existing document stays valid.

**Three amendments must land before most of this can be implemented.** They are recorded, with
written text, in `research.md` § R10 — not left as an intention:

| Artifact | Why |
|---|---|
| Principle III | Its letter mandates `inconclusive`; no surveyed target has a third outcome. Its spirit survives and does most of the work here |
| § Compatibility Constraints | Binds *"no construct expressible only at conformance level `assert`"*, which FR-020 inverts; and the conformance levels are an ADR-gated surface |
| `ARCHITECTURE.md` | Six sections; the role table is where the rendering gets a definition to point at |

The constitution goes to **2.0.0 (MAJOR)** under its own versioning policy. Principle VII requires
all three in **earlier** PRs, so the Constitution Check in `plan.md` records four gates as failing
rather than claiming a pass.

**The `docs/` deletion sweep is specified but mostly not in this PR.** Every proposed deletion was
argued against; most did not survive, always for the same reason — a rule written in as many as four
places cannot be removed from the notebook copy alone while the binding copy still stands, or the
repository formally forbids what it requires. Four tiers, in `spec.md` § *What leaves the notebook*.

**Two problems are recorded open rather than solved**: a `ratio` names a metric it does not measure
(semconv has no HTTP client request counter — checked), and there is no convention for what a
requirement's identifier should say. Both are naming matters, and Principle I puts those in an issue
before files change.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #13` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally (`PASS`, with pyyaml + jsonschema installed)
- [x] No term changed in `docs/GLOSSARY.md` — three are *owed* by FR-042 and land with the schema, not here
- [x] No ADR contradicted: ADR-0002 § D11/D12/D13 receive dated supersession notes under FR-040, in a later PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)