### PR TITLE
Constitution 2.0.0: amend Principles III and VI, and invert the admission constraint

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,54 +1,63 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: 1.0.0 → 1.1.0
-Bump rationale: MINOR on both limbs of the versioning policy simultaneously — three
-principles are added (VI, VII, VIII), and an existing binding constraint is materially
-expanded to cover a second class of target.
+Version change: 1.1.0 → 2.0.0
 
-Principles added:
-  VI.   Evaluation Is Target-Blind
-  VII.  Architecture Before Implementation
-  VIII. Experiments Are Parked, Not Merged
+Bump rationale: MAJOR on three counts, each independently sufficient under this document's
+own policy — "a principle or a binding constraint is removed, or redefined in a way that
+permits what it previously forbade".
 
-Principles renamed or removed: none. I-V are untouched.
+  1. Principle III no longer mandates the outcome `inconclusive`, which it previously
+     required and which no surveyed target can produce.
+  2. The first binding constraint is INVERTED. It forbade a construct expressible only by
+     asserting; the replacement requires that at least one target be able to assert it.
+  3. Principle VI permitted nothing it now permits: consuming a target's own statistic to
+     decide a run was forbidden and is the design.
 
-Sections materially expanded:
-  - Compatibility Constraints — "Support for a load testing tool MUST be expressible as
-    data" widened to "Support for any target", naming both classes. Widened rather than
-    duplicated: a parallel bullet saying nearly the same thing is what spec 001 § FR-011
-    forbids.
-  - Governance → Compliance review — "five principles above" → "eight".
+Principles renamed:
+  VI. "Evaluation Is Target-Blind" → "The Requirement Is Target-Blind"
+      The number is kept. Numbers are cited from templates, specifications and
+      ARCHITECTURE.md, and a reused or renumbered principle silently redirects every
+      citation without touching a citing file. The versioning policy now says so.
 
-Grandfather clause, stated in VIII rather than hidden: `docs/semconv/loadtest.md` and the
-`errorSignal` sketch in `docs/examples/mapping-k6.yaml` both practise labelling without
-containment and predate this amendment. VIII binds work admitted after 2026-08-18.
+Principles removed: none. I, II, IV, V, VII, VIII are untouched.
+
+Sections materially changed:
+  - Principle III — rewritten. The guarantee is unchanged; where it is enforced moved. It
+    now names the two places silence can actually enter under an assertion-first format: a
+    predicate dropped at render time, and a target passing an assertion that matched
+    nothing. Both were observed in a surveyed target's own source and tests, not inferred.
+  - Principle VI — rewritten. 1.1.0 placed the obligation on a component that was never
+    built and cited a proposal as its authority. The obligation is not deleted; it is made
+    dormant and binds the specification that revives that component.
+  - Compatibility Constraints — the surface list's third item changes from "the conformance
+    levels and what each one guarantees" to what a target's description may declare. The
+    ladder is RETIRED rather than edited, and until the ADR retiring it lands, no artifact
+    may cite a conformance level.
+  - Governance → versioning policy — a limb correction, PATCH in isolation, carried here so
+    2.0.0 can be stamped honestly. Adds the highest-limb rule and the principle-number rule.
+
+Grandfather clause from 1.1.0 (VIII, docs/semconv/loadtest.md and the errorSignal sketch)
+is untouched and still binds work admitted after 2026-08-18.
 
 Templates and docs reviewed:
-  ✅ .specify/templates/plan-template.md   — stale pointer "(v1.0.0)" corrected to
-                                             "(v1.1.0)"; three Constitution Check gates
-                                             added for VI, VII and VIII
-  ✅ .specify/templates/spec-template.md   — no change needed; the added principles impose
-                                             no new mandatory spec section, and all three
-                                             are checked at plan time
-  ✅ .specify/templates/tasks-template.md  — no change needed; task categories stay generic
+  ✅ .specify/templates/plan-template.md   — pointer corrected to (v2.0.0); the III, VI and
+                                             Compatibility gates rewritten to ask what the
+                                             amended principles actually require
+  ✅ .specify/templates/spec-template.md   — no change needed; no new mandatory section
+  ✅ .specify/templates/tasks-template.md  — no change needed
   ✅ .specify/templates/checklist-template.md — no change needed
-  ✅ AGENTS.md                             — no change needed; VII generalises its
-                                             Spec-first rule rather than restating it
-  ✅ docs/                                 — no change needed; VI cites compatibility.md
-                                             § Layering, which already says it
 
-Citations, each resolvable by file and section without reading git history:
-  VI   → docs/compatibility.md § Requirements for the Go implementation → Layering
-  VII  → AGENTS.md § Commits & PRs (Spec-first), co-cited with Principle I's ordering rule
-  VIII → Principle III's "Any artifact nothing validates MUST say so in its own text",
-         which grounds the notice half; the containment half is new, which is why the
-         grandfather clause exists.
+Owed by this amendment, in their own pull requests:
+  - ARCHITECTURE.md §§ 1–7. Its clause 3 is the fourth copy of the inverted constraint, and
+    its § 2 role table is where a rendering gets a definition to point at.
+  - An ADR superseding ADR-0002 § D13. The Compatibility Constraints text forbids only NEW
+    citations; the four documents that carry existing ones — ARCHITECTURE.md, docs/GLOSSARY.md,
+    LAYOUT.md, docs/adr/0002-compatibility.md — are corrected by the PRs above, and specs/ is
+    history and stays as written.
 
-Deferred / TODO: whether the compatibility-surface list should also cover names the format
-defines under `loadtest.*` — currently it covers only names the format *borrows*. Argued in
-specs/001-nfr-format-architecture/research.md § D4b; not taken here because it may exceed
-MINOR.
+Deferred: whether the compatibility-surface list should also cover names the format defines
+under `loadtest.*` — carried forward unresolved from 1.1.0.
 -->
 
 # OpenNFR Constitution
@@ -90,18 +99,58 @@ traces of the same run without glue.
 ### III. No Silent Green (NON-NEGOTIABLE)
 
 Nothing may report success by omission. Every state that is not a verified pass MUST be
-representable and distinguishable.
+representable and distinguishable — and where nothing on the path can represent one, the
+format MUST NOT pretend otherwise.
 
-- Missing data MUST produce an outcome of its own, never a pass.
-- A run that did not meet the conditions a requirement assumes MUST be reported as
-  inconclusive — "the test did not happen" — never as a pass or a fail.
 - An unknown field in an input document MUST be a parse error, not an ignored key.
+- Every predicate in a document — a criterion, or a statement of the conditions a
+  requirement assumes — MUST be accounted for when the document is rendered for a target:
+  either rendered into that target's own assertions, or reported by name, with a reason, as
+  one that target cannot express. The two lists MUST cover the document exactly, and the
+  report MUST arrive before the run starts. A predicate that produced neither is a check
+  that never ran and a run that looks clean.
+- A predicate a target can express only approximately MUST be reported as one that target
+  cannot express. An approximation is a silent green with a plausible number in it.
+- A run that did not meet the conditions a requirement assumes MUST be statable in the
+  document, and MUST render into the target's own assertions, so that such a run fails
+  where the target reports rather than passing quietly. The format MUST NOT define a third
+  report state for it. No surveyed target can produce one, and a construct nothing can
+  honour is a silent green of its own.
+- Why such a failure happened MUST be recoverable after the run. Where a target derives
+  every line it prints from the assertion itself and accepts no name of the author's
+  choosing, that attribution is carried by the rendering — which records, per entry, the
+  identity the target will derive its own report line from, and which entries state a
+  condition of the run rather than a property of the system. It is never carried by a field
+  the target does not have.
+- Where a target's own evaluation can pass on absent data — an assertion whose scope
+  expands to nothing, a selection that received no samples — that MUST be declared in that
+  target's description, dated and sourced. An undeclared one is a defect of the
+  description, not of the format.
+- Any check that can fail to find data MUST define what that means before it ships, and any
+  check that cannot run MUST fail rather than skip. A suite that skips reads exactly like a
+  suite that passes.
 - Any artifact nothing validates MUST say so in its own text.
-- Any new check that can fail to find data MUST define what that means before it ships.
 
 **Rationale**: this is the failure mode the entire format exists to address. A load test
-that under-delivered its load shows green thresholds and a false verdict, and no
-surveyed format catches it. A project built to fix that must not reproduce it.
+that under-delivered its load shows green thresholds and a false verdict, and no surveyed
+format catches it. A project built to fix that must not reproduce it.
+
+What changed in 2.0.0 is where the guarantee is enforced, not the guarantee. While post-run
+evaluation was the path, this principle could name outcomes — `inconclusive` for a run that
+did not happen as intended, an outcome of its own for missing data — because this project
+would have produced them. Nothing in scope produces an outcome now; the target does, and no
+surveyed target has a third one. An obligation written in a vocabulary nobody emits is not a
+guarantee but an unenforceable sentence, and while it stood it read as the guarantee — which
+left the two places silence can now actually enter unguarded: a predicate dropped at render
+time, and a target passing an assertion that matched nothing. Those are what the bullets
+above name, and they are named because both have been observed in a surveyed target's own
+source and its own tests, not inferred.
+
+The distinction the removed outcome protected — "the test did not happen" against "the
+system does not hold" — is not abandoned. It survives as a statement the document can make,
+an assertion the target actually runs, and an entry in the rendering that says which line of
+the target's report it will become. That is one place fewer than before, and every part of
+it is something a surveyed target can do.
 
 ### IV. Honest Status
 
@@ -128,25 +177,45 @@ contributions and, worse, invites someone to build against names that will chang
 every backend that reads it — and it never is. This is precisely where the string-DSL
 formats surveyed in `docs/references.md` fail.
 
-### VI. Evaluation Is Target-Blind
+### VI. The Requirement Is Target-Blind
 
-The component that turns measurements into verdicts is the only thing standing between one
-document and one meaning. It stays blind, or the meaning becomes the tool's.
+One document means one thing because the document — not the machinery under it — is the thing
+that stays free of targets.
 
-- The component that produces verdicts MUST NOT know which target produced the measurements,
-  nor how they were obtained.
-- A statistic a target computed for itself MUST NOT be consumed as a verdict. Verdicts are
-  computed from normalised series under canonical names.
-- How a target derives a percentile MUST be recorded alongside any result that rests on it.
-- A measurement taken at one vantage point MUST NOT stand in for one taken at another. A gap
-  is declared, never filled by the nearest available number.
+- A requirement document MUST NOT name a target: not in a field, a value, a metric name, or an
+  example. It carries no per-target section, override or conditional.
+- The correspondence between the document's vocabulary and a target's own MUST live in that
+  target's description. Adding a target MUST NOT change the format, the schema, or any
+  existing document.
+- A target's own statistic MAY decide the run. That is what an assertion-first format is: the
+  target computes its percentile, asserts against it, and reports. This project does not
+  recompute it. What the format MUST NOT do is imply that two targets asserting the same
+  criterion compute the same number. Where a derivation differs — how a percentile is taken,
+  at what vantage point a measurement is made, in what unit and at what precision a threshold
+  is held — that difference MUST be recorded in each target's description, dated and sourced,
+  and MUST NOT be closed by the format.
+- A measurement taken at one vantage point MUST NOT stand in for one taken at another. A load
+  generator measures latency as a client; a production stack usually measures it as a server.
+  A gap is declared, never filled by the nearest available number.
+- Should a component that turns measurements into verdicts ever return to scope, it MUST NOT
+  know which target produced the measurements nor how they were obtained, and MUST NOT consume
+  a statistic a target computed for itself. That obligation is dormant, not deleted: it binds
+  the specification that revives the component, and binds nothing today.
 
-**Rationale**: `docs/compatibility.md` § Requirements for the Go implementation → Layering
-already says it — "the evaluation layer knows nothing about tools or sources" — and calls that
-"the only reason the format can promise compatibility with an arbitrary tool". But that section
-is a proposal and nothing is built against it yet, which is exactly when the rule is cheap to
-fix. The moment a verdict depends on a tool's own arithmetic, one document stops meaning one
-thing and every portability claim the format makes is void.
+**Rationale**: 1.1.0 placed this obligation on a component that was never built and cited a
+proposal as its authority. Under an assertion-first format the obligation is vacuous — nothing
+in scope produces a verdict — while reading, to anyone opening the file, as a prohibition on
+the feature the project is now built around. Principle IV forbids a document reading as more
+settled than it is; a rule that forbids nothing while appearing to forbid everything is the
+same defect pointed inward.
+
+What actually carries the portability claim is the document: the same file, unedited, reaching
+a second target through a second description. That is checkable — two renderings, one file —
+whereas the old claim was checkable only once a component existed that nobody had started. The
+cost of the change is stated rather than hidden: two targets asserting one criterion do not
+necessarily produce the same number, and no rule here can make them. The most the format can
+honestly promise is that the *statement* is one statement, and that every place the targets
+disagree is written down where a reader will find it.
 
 ### VII. Architecture Before Implementation
 
@@ -198,19 +267,44 @@ Compatibility-sensitive surfaces, which MUST NOT change without an ADR:
 
 - any OpenTelemetry name the format borrows;
 - any field name that appears in a published example;
-- the conformance levels and what each one guarantees.
+- what a target's description may declare — the shape of the statements it makes about how a
+  target names things, what it can and cannot assert, how its units convert, and where it can
+  report success on absent data.
 
 Binding constraints:
 
-- The format MUST NOT contain a construct expressible only at conformance level `assert`
-  or above. Anything checkable during a run MUST also be checkable after it, or the
-  format silently excludes every tool that cannot assert inline.
-- Requirement documents MUST remain portable across observability stacks. The data
-  source is a parameter of evaluation, never part of the requirement.
-- Support for any target MUST be expressible as data, not as code in the reference
-  implementation. This covers both classes: a load generator that produces the traffic, and a
-  monitoring backend that holds telemetry and answers a query. A target list that only
-  maintainers can extend is not tool-agnostic.
+- A construct MUST NOT enter the format unless at least one surveyed target can assert it
+  exactly. A construct is never admitted on the promise that something will be able to check
+  it later. This is a floor and not a licence: one target being able to assert a construct is
+  necessary for admission and is not by itself sufficient, and a construct MUST NOT enter the
+  format solely to reach one target's feature.
+- Requirement documents MUST remain portable. Neither the target that will assert a
+  requirement nor the source of any measurement is part of the requirement — see
+  Principle VI.
+- Support for any target MUST be expressible as data — a description of that target — and not
+  as code in a reference implementation. A target list that only maintainers can extend is not
+  tool-agnostic. Only a target that can host assertions has a path in this format today; the
+  monitoring-backend class named in 1.1.0 keeps no path in scope and is parked under
+  Principle VIII.
+
+**On the conformance levels.** `report`, `assert` and `abort` were cumulative rungs on a path
+that ended in post-run evaluation, and the bottom rung — mapping metrics and attributes to
+canonical names — guaranteed the whole format precisely because evaluation would do the rest.
+With evaluation out of scope the bottom rung guarantees nothing anything can consume, so the
+ladder is retired rather than edited. A tool that cannot host assertions is a tool this format
+does not serve, and the difference between the tools that remain is not one ordinal: each has
+capabilities the other lacks in both directions. What a target can assert, what it cannot, how
+it names things, how its units convert and where it can pass on absent data are declared per
+capability in that target's description, each claim dated and sourced. Aborting a run survives
+as one such declared capability rather than as a rung.
+
+Retiring the ladder changes a compatibility-sensitive surface and therefore requires an ADR of
+its own, which supersedes ADR-0002 § D13 with a dated note rather than rewriting it. From this
+amendment, **no new artifact may cite a conformance level**. Existing citations are not
+retroactively invalid and are not to be edited out one by one: `ARCHITECTURE.md`,
+`docs/GLOSSARY.md`, `LAYOUT.md` and `docs/adr/0002-compatibility.md` are corrected by the
+pull requests this amendment already owes, and the `specs/` directory is a record of what was
+decided when — it is read as history and left alone.
 
 ## Development Workflow
 
@@ -237,11 +331,20 @@ same issue/milestone/linkage rules as every other change.
 
 **Versioning policy**: semantic versioning of this document.
 
-- MAJOR — a principle is removed or redefined in a way that permits what it previously
-  forbade;
+- MAJOR — a principle or a binding constraint is removed, or redefined in a way that permits
+  what it previously forbade; or an item is removed from the list of
+  compatibility-sensitive surfaces;
 - MINOR — a principle or binding section is added, or existing guidance is materially
   expanded;
 - PATCH — clarification, rewording, or a fix that changes no obligation.
+
+Where one amendment carries material at more than one limb, the highest limb governs and the
+document takes one version number.
+
+A principle keeps its **number** when its heading changes, and a withdrawn number stays
+withdrawn. Numbers are cited from the templates, from specifications and from
+`ARCHITECTURE.md`; a reused number silently redirects every citation without touching a single
+citing file.
 
 **Compliance review**: `/speckit-plan` MUST evaluate its Constitution Check against the
 eight principles above before Phase 0 research and again after Phase 1 design. PR review
@@ -252,4 +355,4 @@ justified in writing in the plan's Complexity Tracking section.
 **Runtime guidance**: `AGENTS.md` for process, `docs/GLOSSARY.md` for vocabulary,
 `docs/adr/` for why any of it is the way it is.
 
-**Version**: 1.1.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-18
+**Version**: 2.0.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-21

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -41,7 +41,7 @@
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 Answer each gate explicitly. A "no" is either fixed or justified in Complexity Tracking
-below — never left blank. See `.specify/memory/constitution.md` (v1.1.0).
+below — never left blank. See `.specify/memory/constitution.md` (v2.0.0).
 
 - [ ] **I. Vocabulary Before Features** — does this feature introduce or rename a term?
       If so, is `docs/GLOSSARY.md` updated in the same change, with a rejected
@@ -49,18 +49,23 @@ below — never left blank. See `.specify/memory/constitution.md` (v1.1.0).
 - [ ] **II. Borrow Names, Never Invent Them** — is every metric and attribute name taken
       from OpenTelemetry semconv where an equivalent exists? Is anything new confined to
       `loadtest.*`? Are there aliases or derived quantities masquerading as metrics?
-- [ ] **III. No Silent Green** — for every check this feature adds: what happens when the
-      data is missing, and when the run did not meet its assumed conditions? Is either
-      answer "pass"?
+- [ ] **III. No Silent Green** — for every predicate a document can carry: is it either
+      rendered into the target's assertions or reported by name as one that target cannot
+      express, with the two lists covering the document exactly and arriving before the run?
+      Is any approximation substituted for a construct a target cannot express? Where a
+      target can pass on absent data, is that declared in its description, dated and sourced?
+      Does any check this adds skip rather than fail when it cannot run?
 - [ ] **IV. Honest Status** — do the artifacts state what is verified and what is
       speculation? Is every claim about an external tool dated and sourced?
 - [ ] **V. Structure Over Grammar** — is every new field validatable by schema without a
       bespoke parser? Are value sets closed? Does anything need custom decoding, and is
       that justified in an ADR?
-- [ ] **VI. Evaluation Is Target-Blind** — does anything here let the component that
-      produces verdicts learn which target supplied the measurements, or consume a statistic
-      a target computed for itself? Is percentile provenance recorded? Is any measurement
-      from one vantage point standing in for another?
+- [ ] **VI. The Requirement Is Target-Blind** — does any requirement document name a
+      target, in a field, a value, a metric name or an example? Does adding a target change
+      the format, the schema, or an existing document? Where two targets derive the same
+      criterion differently — the percentile, the vantage point, the unit, the precision — is
+      each difference recorded in that target's description, dated and sourced, rather than
+      closed by the format?
 - [ ] **VII. Architecture Before Implementation** — does every component this adds or alters
       name the architectural role it fills? If it needs a role the architecture lacks, does
       an earlier PR amend the architecture rather than diverging from it?
@@ -69,8 +74,10 @@ below — never left blank. See `.specify/memory/constitution.md` (v1.1.0).
       promotion and retirement conditions, and the date? Is the experimental area still
       removable in one operation, with nothing outside linking into it?
 - [ ] **Compatibility** — does this touch a borrowed OTel name, a published example's
-      field name, or the conformance levels? Is any construct expressible only at
-      conformance level `assert` or above?
+      field name, or what a target description may declare? For every construct added: can
+      **at least one surveyed target assert it exactly**, and is it being added for a reason
+      beyond reaching that one target's feature? Does any artifact still cite a conformance
+      level, which nothing may until the ADR retiring the ladder lands?
 
 ## Project Structure
 


### PR DESCRIPTION
Closes #15

## What changes

`.specify/memory/constitution.md` and the one template the change affects, and nothing else —
that is what the document's own amendment procedure admits.

| Clause | Change |
|---|---|
| **Principle III** | No longer mandates `inconclusive`. Names the two places silence can actually enter under an assertion-first format |
| **Compatibility Constraints**, first binding rule | **Inverted**: a construct enters only if at least one surveyed target can assert it exactly |
| **Principle VI** | Rewritten; renamed *The Requirement Is Target-Blind*, keeping its number |
| **Governance → versioning policy** | Highest-limb rule, and a principle keeps its number when its heading changes |
| **Conformance ladder** | Retired rather than edited |

## Why

Each of the three was checked against a surveyed target's own source, not argued from the
requirement — the full evidence is in `specs/003-assertion-first-format/`, Appendices A and D.

- Principle III mandated an outcome **no surveyed target can produce**. An obligation written
  in a vocabulary nobody emits is not a guarantee; and while it stood it *read* as the
  guarantee, which left the real gaps unguarded.
- The first binding constraint forbade a construct expressible only by asserting. It protected
  `report` as a complete path. That path is gone, so the rule forbade exactly what the format
  is for.
- Principle VI forbade nothing — nothing in scope produces a verdict — while reading as a ban
  on the feature the project is now built around. Principle IV forbids a document reading as
  more settled than it is; this was the same defect pointed inward.

## Why MAJOR

Three independent counts, each meeting this document's own test: *"a principle or a binding
constraint is removed, or redefined in a way that permits what it previously forbade."*

## What a reviewer should know

**Nothing is deleted that was doing work.** Principle III's guarantee is unchanged — only where
it is enforced moved. Principle VI's old obligation is **dormant, not deleted**: it binds the
specification that revives a verdict-producing component, and binds nothing today.

**The distinction the removed outcome protected survives.** "The test did not happen" versus
"the system does not hold" is still statable in a document, still renders into an assertion the
target actually runs, and is still attributable — through the rendering, which records the
identity the target derives its own report line from. That is one place fewer than before, and
every part of it is something a surveyed target can do.

**The ladder clause is deliberately forward-looking.** Ten files cite a conformance level
today. The rule forbids only *new* citations: four documents are corrected by the PRs this
amendment owes, and `specs/` is a record of what was decided when — it is read as history and
left alone. A rule that invalidated the repository on the commit that introduced it would be a
worse defect than the one it fixes.

**Two more PRs are owed and named in the file**: `ARCHITECTURE.md` §§ 1–7, whose clause 3 is
the fourth copy of the inverted constraint, and an ADR superseding ADR-0002 § D13.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #15` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally
- [x] No term changed in `docs/GLOSSARY.md` — this amendment adds none
- [x] No ADR contradicted: retiring the ladder is explicitly deferred to an ADR that supersedes ADR-0002 § D13 with a dated note

🤖 Generated with [Claude Code](https://claude.com/claude-code)