### PR TITLE
Architecture: end the path at the target's assertions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
-How a requirement becomes an outcome, what each component on that path may not know, and how
-the format reaches a tool at all.
+How a requirement becomes a target's own assertions, what each component on that path may not
+know, and what the target is told it could not be given.
 
 ## Status of this document
 
@@ -26,38 +26,43 @@ than the workaround, because a route more expensive than the workaround is not a
 
 ## 1. The path
 
-A requirement is written once, by a human, and names no tool. Everything else happens to it.
+A requirement is written once, by a human, and names no tool. It is rendered into the target's
+own assertions, and there it stops.
 
 ```text
-requirement ── criterion ──> verdict ──> gate ──> outcome
-     │             │            ▲                    │
-     │             │            │                    └─ what a CI job prints
-     │             └─ rendered into a target's native form (R2)
+requirement ── criterion ──> the target's own assertion ──> the target runs it and decides
+     │             │                    │
+     │             │                    └─ plus one named entry for every predicate that
+     │             │                       could not be rendered, before the run starts
+     │             └─ rendered against one target description (R2)
      └─ parsed into an object model (R1)
-                                │
-        a target's raw output ──┴── normalised into series (R3), evaluated (R4)
 ```
 
-1. *(binding)* The path ends at **outcome**, not at verdict. A `Verdict` is the result of
-   checking one criterion or guard; an `Outcome` is the aggregated result of the whole run.
-   A trace that stops at verdict stops one component short of `gate`. See
-   [docs/GLOSSARY.md](docs/GLOSSARY.md).
-2. *(binding)* No role may read the requirement document to discover its data source. The
-   source is a parameter of evaluation, never a property of the requirement —
-   [ADR-0002 § D18](docs/adr/0002-compatibility.md).
-3. *(binding)* No construct may be checkable only while a run is in progress. Anything
-   expressible must also be evaluable afterwards, or the format silently excludes every tool
-   that cannot assert inline. This is already a ratified constitutional constraint.
+1. *(binding)* The path ends at the **rendering**: the target's own assertions, together with
+   the named list of predicates that could not be rendered. What happens next belongs to the
+   target — it evaluates, it reports, it decides the run. This repository defines no verdict,
+   no outcome, no gate policy and no result document, and no component here consumes a
+   target's output.
+2. *(binding)* No role may read the requirement document to discover which target it is for.
+   The target is a parameter of rendering, never a property of the requirement — the
+   constitution's Principle VI. The same holds one step further out for any source of
+   measurement, which is [ADR-0002 § D18](docs/adr/0002-compatibility.md) and is unaffected by
+   the narrowing.
+3. *(binding)* What may enter the format at all is decided by the constitution's Compatibility
+   Constraints, and this document deliberately keeps no copy of that rule. The clause that
+   stood here — "No construct may be checkable only while a run is in progress" — was the
+   third of four copies of a rule that has since been inverted, and four copies are what let
+   four documents disagree.
 
 ---
 
-## 2. The four component roles
+## 2. The component roles
 
-Roles are contracts, not modules. Two of them — Render and Ingest — are **sub-roles of the
-glossary's `Adapter`**, not rivals to it: the glossary already defines an `Adapter` as doing
-four jobs, of which rendering assertions is one and collecting a tool's output is another.
-Introducing a competing decomposition of the same pipeline is what
-[Principle I](.specify/memory/constitution.md) forbids.
+Roles are contracts, not modules. Two remain. **Render is now the whole of the glossary's
+`Adapter`**, not one of its four jobs: renaming metrics, converting units and renaming a tool's
+tags survive only inasmuch as rendering needs them to write an assertion the target will
+accept. The glossary's `Adapter` entry is narrowed accordingly rather than joined by a rival
+word, which is what [Principle I](.specify/memory/constitution.md) requires.
 
 The original request called these *interpreters*. In this repository's vocabulary that word is
 `Adapter`; `interpreter` is not used.
@@ -65,157 +70,132 @@ The original request called these *interpreters*. In this repository's vocabular
 | # | Role | Input | Output | MUST NOT know | Status |
 |---|---|---|---|---|---|
 | R1 | Parse | One document | An object model, or a parse error naming the field and its line | Which target will consume the result | **binding** |
-| R2 | Render *(Adapter)* | Criteria + one tool mapping | The target's native artifact, **plus a named list of every criterion it could not render** | Whether the run will pass | **binding** |
-| R3 | Ingest *(Adapter)* | A target's raw output + one tool mapping | Normalised series under canonical names, in canonical units | What the criteria say | **binding** |
-| R4 | Evaluate | Normalised series, criteria, guards, `gate` | One verdict per criterion and guard, then one outcome | Which target produced the measurements, or how | **binding** |
+| R2 | Render *(Adapter)* | The document's predicates + one target description | The target's native assertions; **a named list of every predicate it could not render, with a reason**; and, per rendered entry, **the identity the target will derive its own report line from**, and whether that entry states a condition of the run rather than a property of the system | Whether the run will pass | **binding** |
+| R3 | ~~Ingest~~ | — | — | — | **withdrawn 2026-08-20, with post-run evaluation** |
+| R4 | ~~Evaluate~~ | — | — | — | **withdrawn 2026-08-20, with post-run evaluation** |
 
-**R4 is [Principle VI](.specify/memory/constitution.md)** *(binding)*, and it is the only
-reason one document can mean one thing across many targets. Its sharpest consequence: a
-statistic the target already computed — k6's own p95 — must not be consumed as a verdict. The
-moment it is, the verdict depends on that tool's percentile machinery.
+R3 and R4 are withdrawn and their numbers are withdrawn with them. R1 and R2 are cited
+elsewhere and a reused number silently redirects a citation. The arguments for both roles are
+parked, not deleted: they return through the same route any other idea does.
 
-**R3 is where units are converted** *(binding)*. The survey records tools reporting
-milliseconds where semantic conventions require seconds. An error here is three orders of
-magnitude wide and produces a confident, wrong, green result, which is why the conversion is
-declared in the mapping rather than left to whoever implements the role.
+**Why R2's third output exists** *(binding)*. A target need not let a document name an
+assertion, and neither surveyed target does. Gatling derives every string it prints for an
+assertion from the assertion itself — console, JUnit XML and the HTML table all render one
+derived message per result, and its per-request scope is rewritten to a concrete request path
+before any message is built (checked in `gatling/gatling`, 2026-08-20). k6 prints the metric,
+the tag selector and the expression. A statement about the run's conditions therefore cannot
+be told from a statement about the system by a name in the report; it is told apart by matching
+the report's line to the rendering entry that produced it. That correlation is what makes
+[Principle III](.specify/memory/constitution.md) enforceable at run time against a target that
+has no field for a name.
 
-**Naming** *(binding)*: R3 is the **file adapter** where it reads files. It is not called a
-*reader* — in this project's documents `reader` means a human.
+**Units are converted at render time** *(binding)*, by the declaration in the target's
+description, never by whoever implements the role. The survey records targets whose duration
+thresholds are whole milliseconds and targets that take a float; an error here is three orders
+of magnitude wide and produces a confident, wrong, green result. A threshold that does not
+survive the conversion exactly makes its predicate unrenderable rather than rounded.
 
 ### What no role may do
 
-4. *(binding)* A criterion is either rendered or reported unrenderable **by criterion
-   identity**. Dropping one silently is forbidden: a dropped criterion is a check that never
-   ran and a result that looks clean.
+4. *(binding)* Every predicate is either rendered or reported unrenderable **by identity**.
+   Dropping one silently is forbidden: a dropped predicate is a check that never ran and a
+   result that looks clean. The identity relation is *predicate → exactly one of the two
+   lists*. It is **not** *predicate → exactly one assertion*: one predicate may legitimately
+   render into more than one native assertion — a range a target expresses only as two
+   comparisons, a per-request scope a target reaches only by naming each request, a companion
+   assertion that stops the target passing on an empty selection — and that is not a breach of
+   the sum rule.
 5. *(binding)* When a target cannot honour a construct, the result is a **named failure** —
    never a substitution, an approximation, or a silent omission. The gap is declared in the
-   mapping and surfaces at render time, before the run rather than after it.
+   target's description and surfaces at render time, before the run rather than after it.
 6. *(binding)* A measurement taken at one vantage point may not stand in for one taken at
    another. A load generator measures latency as a client; a production stack usually measures
-   it as a server. The numbers are not comparable.
-7. *(binding)* Missing data produces `noData` and a violated guard produces `inconclusive`.
-   Neither is a pass. [Principle III](.specify/memory/constitution.md).
+   it as a server. The numbers are not comparable — and neither are two targets' derivations of
+   the same statistic, which each target's description records for itself, dated.
+7. *(binding)* Silence is not a pass, at render time or at run time. A predicate that produced
+   neither an assertion nor a named entry is forbidden here. A target that can pass an
+   assertion which matched nothing is a property of that target and MUST be declared in its
+   description; rendering may not present a predicate as covered when the description says the
+   target cannot fail it. [Principle III](.specify/memory/constitution.md).
 
 ---
 
 ## 3. Targets
 
-*(binding)* A **target** is the external product an adapter faces. Two classes, supported
-identically — by adding data, never by adding code:
+*(binding)* A **target** is the external product an adapter faces. Support is added by adding
+data, never by adding code.
 
 | Class | What it does | Can host assertions? | Status |
 |---|---|---|---|
-| Load generator | Produces the traffic and reports what happened | Sometimes, at conformance level `assert` and above | **binding** |
-| Monitoring backend | Holds telemetry, answers a query, can host a standing monitor | Not applicable — see § 6 | **proposed** |
+| Load generator | Produces the traffic, asserts against what it measured, reports, and decides the run | Yes — and only a target that can is served by this format. *What* it can assert is declared per capability in its own description, each claim dated and sourced, never as a level | **binding** |
+| Monitoring backend | Holds telemetry and answers a query | No. It hosts no assertion, so it has no path in scope; the direction is parked — see § 6 | **parked** |
 
 The full definition, including why `monitoring backend` is defined inside the `Target` entry
-rather than on its own, is in [docs/GLOSSARY.md](docs/GLOSSARY.md). A target faces **outward**; a
-*data source* faces inward and supplies normalised series to R4. One product may play both
-roles in one run, in which case it is named by the role it is playing. This document cites
-[ADR-0002 § D18](docs/adr/0002-compatibility.md) for `data source` rather than redefining it.
+rather than on its own, is in [docs/GLOSSARY.md](docs/GLOSSARY.md).
+
+A target faces **outward**: it receives rendered assertions. A *data source* faces inward and
+supplied normalised series to the withdrawn evaluation role; with that role parked, nothing in
+scope has an inward face, and the word survives only so that the parked argument stays
+readable. What survives unconditionally is the rule that kept them two words:
+[ADR-0002 § D18](docs/adr/0002-compatibility.md) — a requirement carries neither a target nor a
+source — which the constitution's Principle VI now states directly.
 
 ---
 
-## 4. Three walkthroughs
+## 4. What the walkthroughs established
 
-*(proposed — none of the machinery exists; the tool facts are dated)*
+*(the three walkthroughs are withdrawn with post-run evaluation: each traced a document through
+R3 and R4, and the document they traced carries constructs the assertion-first format does not
+have. The findings that survive are kept as clauses, because they were expensive to get and
+none of them depends on the withdrawn roles. Tool facts are dated; the machinery is proposed.)*
 
-One document, unchanged in every character:
-[docs/examples/checkout-perf.yaml](docs/examples/checkout-perf.yaml). It carries five requirements, two
-guards, and a `gate`. Every tool statement below comes from this repository's own survey in
-[docs/compatibility.md](docs/compatibility.md), *"Verified against documentation as of August 2026"*, or
-from the mapping sketches in `examples/`. Nothing here is asserted from outside those files.
-
-### 4.1 k6 — the best case
-
-Conformance **`abort`**: OTLP output built in, native `thresholds`, `abortOnFail`.
-
-| Requirement | R2 renders | R3 ingests | Result |
-|---|---|---|---|
-| `checkout-throughput` | `rate` over the histogram count | `k6_http_req_duration` → `http.client.request.duration`, **ms → s** | works |
-| `checkout-latency` p95/p99 | `p(95)`, `p(99)` thresholds; `onViolation: abort` → `abortOnFail` | same metric | works |
-| guard `generator-not-saturated` | — (guards are evaluated post-run) | `k6_dropped_iterations` → `loadtest.dropped_iterations` | works |
-| `checkout-error-rate` | **cannot render** | `k6_http_req_failed` via `errorSignal` | **gap** |
-| `no-latency-regression` | **cannot render** | — | **gap** |
-
-**Declared gaps** *(binding that they are declared, proposed how)*:
-
-8. *(binding)* The ratio indicator cannot become a k6 threshold. `mapping-k6.yaml` renders selectors as k6
-   tags (`selectorAs: tag`), and `error.type` is not a tag — it is derived from a separate
-   metric through `errorSignal`. Evaluation post-run is unaffected; only the inline rendering
-   is impossible. Per clause 4, R2 reports it rather than dropping it.
-9. *(binding)* `http.route` is not emitted by k6. The mapping carries k6's `name` tag to
-   `loadtest.request.name`, and reconstructing a route needs `routeHints` — a field of
-   `kind: MetricMapping` sketched in `examples/mapping-jmeter.yaml`, not specific to JMeter.
-   Requirements written against `loadtest.request.name` do not travel between tools.
-
-### 4.2 Gatling — the case with a named customer and no mapping
-
-Conformance **`assert`**: native `assertions`, **no abort**, and OTLP only in the Enterprise
-Edition — the open-source build goes through `simulation.log`.
-
-10. *(binding)* **There is no `mapping-gatling.yaml`.** `examples/` holds mappings for k6 and JMeter only.
-    This walkthrough is therefore traced from the survey alone, and producing the mapping is the
-    first deliverable of the `target-gatling` follow-up specification. Until it exists, no
-    criterion in the example document can actually be rendered for Gatling.
-
-| Construct | Status against the survey |
-|---|---|
-| Latency, throughput | Response time is recorded; canonical naming needs the missing mapping |
-| `onViolation: abort` | **Impossible** — the survey records Abort: `no` for Gatling |
-| guard on `loadtest.dropped_iterations` | **No equivalent** — the mapping table in [docs/semconv/loadtest.md](docs/semconv/loadtest.md) records an em-dash |
-| Error signal | `KO` carries it |
-| `http.route` | Reconstructed by an adapter, per the survey — which does not exist yet |
-
-### 4.3 JMeter — the worst case, and still complete
-
-Conformance **`report`**: no OTLP output, no native assertions, no abort. The path is JTL files
-through R3.
-
-11. *(binding)* `report` is **not a degraded mode**. Every requirement in the example document
-    is evaluable after the run: R2 renders nothing, reports all criteria as unrenderable per
-    clause 4, and R4 produces the same verdicts it would for k6. `assert` and `abort` shorten
-    the feedback loop; they add no expressiveness. This is why the format may contain no
-    construct expressible only at `assert` or above.
-
-| Construct | Status |
-|---|---|
-| Latency | `elapsed` (**ms**), `Latency` ≈ TTFB only |
-| `http.request.method` | **Not in the mapping** — `mapping-jmeter.yaml` maps `label`, `responseCode` and `URL` only. `checkout-latency`'s method selector cannot be satisfied as mapped |
-| `http.route` | Via `routeHints`, manually maintained |
-| `loadtest.dropped_iterations` | **No equivalent** |
-| Native assertions, abort | **None** |
-
-### 4.4 What the walkthroughs expose about the example itself
-
-*(binding that these are declared; each needs its own issue — fixing them changes the format,
-which this feature does not do)*
-
-12. *(binding)* **`overall-availability` can produce a silent RED.** A run in which nothing fails yields no
-    series carrying `error.type`, hence `noData`, hence `onNoData: fail`. The run fails because
-    the system was perfect.
-13. *(binding)* **An unmeasurable guard fails for the wrong reason.** Gatling and JMeter cannot measure
-    `loadtest.dropped_iterations`, so the guard lands on `onNoData: fail` rather than
-    `onGuardViolation: inconclusive`, and a tool limitation reads as a system failure.
-14. *(binding)* **`skipped` has no gate key.** It appears in the status enum and in the report sketch, but
-    no `gate` key handles it. Silence is undefined behaviour in a project whose Principle III
-    forbids exactly that.
-15. *(binding)* **`indicatorRef: checkout-latency` points at a Requirement name**, while ADR-0001 § D10 and
-    the glossary describe `Indicator` as a reusable kind of its own.
-16. *(binding)* **Two constructs are satisfiable by no tool in the survey**: `window.phase` rests on
-    `loadtest.phase`, which nothing emits, and `baseline: previousPassed` needs stored history
-    no load generator provides. Both are core constructs with a published dependency.
+8. *(binding, checked 2026-08-20)* An error-ratio predicate whose bad side is selected by the
+   presence of an error attribute has no counterpart in a target whose selection is a
+   conjunction of exact equalities over tags it actually emits. It is unrenderable, named, and
+   reported before the run — clauses 4 and 5. There is no post-run path that quietly covers it.
+9. *(binding, checked 2026-08-20)* A route is not emitted by the surveyed load generators; each
+   carries a request name instead, defaulting in one case to the URL. Requirements written
+   against a request name do not travel between targets. That is a declared cost of addressing,
+   carried in each target's description, and the mechanism formerly proposed for reconstructing
+   a route belonged to a withdrawn artifact and has no owner today.
+10. *(binding)* Neither first target has a description in this repository yet. Producing them —
+    dated and sourced, gaps declared — is a deliverable of the assertion-first feature itself,
+    not of a later one. Until a target has a description, nothing in a document can be rendered
+    for it, and saying so is cheaper than a reader assuming otherwise.
+11. *(binding)* A target that cannot host assertions has no path in this format. That is a real
+    loss against the previous design, in which such a tool was served completely after the run,
+    and it is recorded here rather than absorbed: the admission rule in the constitution's
+    Compatibility Constraints is what makes it so.
+12. *(binding)* A predicate that is only violated when something goes wrong can be passed by a
+    target that saw nothing at all. Verified for one surveyed target on 2026-08-20: a threshold
+    on a selection that received no samples exits successful, and the target's own test suite
+    pins that behaviour. Per clause 7 this MUST be declared in that target's description. A
+    rendering may pair such a predicate with a companion assertion the target can fail — which
+    is one predicate rendering into two assertions, expressly permitted by clause 4.
+13. *(binding)* A statement about the run's conditions that rests on a quantity the target
+    cannot measure is unrenderable and is named before the run. It never becomes a red run
+    blamed on the system, and it never becomes a silent omission.
+14. *(binding)* Two constructs are satisfiable by no surveyed target: a phase window, which
+    rests on an attribute nothing emits, and a comparison against a previous run, which needs
+    stored history no load generator provides. Under the constitution's admission rule these
+    are not declared gaps but inadmissible, and they stay out until some target can assert them
+    — which may be never.
 
 ---
 
 ## 5. Support is data
 
-17. *(binding)* Support for any target is added as **data** — a `kind: MetricMapping` document
-    — and requires changing no normative-core artifact and no reference implementation. This is
-    [ADR-0002 § D12](docs/adr/0002-compatibility.md), generalised to both target classes by
-    [the constitution's Compatibility Constraints](.specify/memory/constitution.md).
-18. *(binding)* A mapping declares what its target **cannot** do. An undeclared gap is a defect
-    of the mapping, not of the format.
+17. *(binding)* Support for a target is added as **data** — a description of that target — and
+    requires changing no normative-core artifact, no existing document, and no reference
+    implementation. A description says how the target names things, what it can assert, what it
+    cannot, how its units convert, and where it can report success on absent data. This is
+    [ADR-0002 § D12](docs/adr/0002-compatibility.md) with its artifact re-derived: D12's
+    conclusion — a target list only maintainers can extend is not tool-agnostic — is why the
+    rule exists, and D12's `kind: MetricMapping` was shaped for a path that ended in evaluation.
+    D12 carries a dated supersession note; its argument stays readable.
+18. *(binding)* A target's description declares what that target **cannot** do. An undeclared
+    gap is a defect of the description, not of the format. A description that is silent about a
+    capability is not asserting the target has it.
 
 ---
 
@@ -233,10 +213,16 @@ and carries its promotion and retirement conditions. That area is outside the
 compatibility-sensitive surface, holds markdown only, and **nothing outside it links into it** —
 which is what makes it removable in one operation.
 
-20. *(binding)* Preconditions about the load generator do not survive the crossing. A guard on
-    `loadtest.dropped_iterations` is not applicable to production telemetry and must be reported
-    as such by name, never silently dropped so the requirement can be evaluated without it.
+With the format now ending at a target's own assertions, this direction is further from scope
+rather than nearer: a monitoring backend hosts no assertion, so the parked claim would have to
+establish a second kind of path, not merely a second target.
 
+20. *(binding)* Statements about the load generator do not survive the crossing. A statement
+    that the run reached its intended load, or that the generator was not itself the
+    bottleneck, is not applicable to production telemetry, and must be reported as
+    unrenderable **by name** — never silently dropped so the rest of the document can go
+    across without it. This is clause 4's sum rule applied at the crossing, and the crossing is
+    where dropping one would be least visible.
 
 ---
 
@@ -256,39 +242,38 @@ needs a role this document does not have amends this document first)*
 
 | Slug | Delivers | Depends on | Role | Scheduling |
 |---|---|---|---|---|
-| `core-schema` | `schema/opennfr.io/v1/common.schema.json`, `requirementset.schema.json`, `indicator.schema.json`, `evaluationreport.schema.json`, one ADR fixing the field names | — | Substrate for all four roles | scheduled |
-| `mapping-schema` | `schema/opennfr.io/v1/metricmapping.schema.json` | `core-schema` | Substrate for R2 and R3 | scheduled |
-| `object-model` | The reference parser and its type declarations; `docs/object-model.md` | `core-schema` | **R1 Parse** | scheduled |
-| `ingest` | The normalised-series contract and the file adapter | `object-model`, `mapping-schema` | **R3 Ingest** | scheduled |
-| `evaluation` | The verdict and gate engine; `docs/evaluation.md` | `object-model` | **R4 Evaluate** | scheduled |
-| `renderer` | The criterion-to-native-artifact renderer and its unrenderable report | `object-model`, `mapping-schema` | **R2 Render** | scheduled |
-| `target-gatling` | `mappings/gatling.yaml`, `docs/targets/gatling.md` | `renderer` | A target, as data | scheduled — **serves the named customer** |
-| `target-k6` | `mappings/k6.yaml`, `docs/targets/k6.md` | `renderer` | A target, as data | scheduled |
-| `target-jmeter` | `mappings/jmeter.yaml`, `docs/targets/jmeter.md` | `ingest` | A target, as data | scheduled |
-| `conformance-corpus` | `conformance/` — documents paired with the outcome any conforming consumer must reach | `core-schema`, `evaluation` | Cross-cutting; also the first artifact able to detect cross-repository drift | scheduled |
-| `monitoring-experiment` | Everything under `docs/experimental/` | `core-schema` | Second target class | **parked — no position, see § 7.4** |
+| `core-schema` | `schema/opennfr.io/v1/requirementset.schema.json` and the common definitions it needs; one ADR fixing the field names | — | Substrate for R1 and R2 | **partly delivered** — the requirement schema has shipped. `evaluationreport.schema.json` is withdrawn with post-run evaluation; `indicator.schema.json` is withdrawn with `indicatorRef` |
+| `target-description-schema` | the schema for a target's description: how it names things, what it can and cannot assert, how units convert, where it can report success on absent data | `core-schema` | Substrate for R2 | scheduled — supersedes the former `mapping-schema`; `metricmapping.schema.json` is withdrawn |
+| `object-model` | the reference parser and its type declarations; `docs/object-model.md` | `core-schema` | **R1 Parse** | scheduled — without verdict or outcome types |
+| `rendering-contract` | what a rendering is, and the corpus of *(document, target description, expected rendering)* triples any implementation in any language must reproduce | `core-schema`, `target-description-schema` | **R2 Render**, as a contract | scheduled — **nothing in this repository renders**; the implementation belongs to whoever integrates a target. Absorbs the former `renderer` and `conformance-corpus` |
+| `target-gatling` | a Gatling target description and `docs/targets/gatling.md`, every claim dated and sourced | `target-description-schema` | A target, as data | scheduled — **serves the named customer**, and no longer waits on a renderer |
+| `target-k6` | a k6 target description and `docs/targets/k6.md` | `target-description-schema` | A target, as data | scheduled — the second target is what makes portability checkable rather than claimed |
+| `target-jmeter` | — | — | — | **withdrawn**. Scheduled on the strength of level `report`, which no longer exists. Whether the tool can host an assertion of the shape this format renders needs a fresh dated check before any entry returns |
+| `ingest` | — | — | ~~R3~~ | **withdrawn with post-run evaluation** |
+| `evaluation` | — | — | ~~R4~~ | **withdrawn with post-run evaluation**; `docs/evaluation.md` is parked with the argument, not deleted |
+| `conformance-corpus` | — | — | — | **absorbed** into `rendering-contract`: what a conforming consumer must reach is a rendering, not an outcome |
+| `mapping-schema` | — | — | — | **superseded** by `target-description-schema` |
+| `monitoring-experiment` | everything under `docs/experimental/` | `core-schema` | Second target class | **parked — no position, see § 7.4** |
 
 `docs/README.md` says the next step is *"A JSON Schema for the requirement and result
-documents"*. That names `core-schema` exactly, and it stays true: it is first in dependency
-order, and the other ten were always implied by it, because a schema with nothing reading it
-changes nothing.
+documents"*. Half of that has shipped and half is withdrawn: there is no result document, and
+the sentence should be corrected where it lives rather than reinterpreted here.
 
 ### 7.2 The dependency graph
 
 ```text
-001 (this feature)
- ├─> core-schema
- │    ├─> mapping-schema ──┐
- │    ├─> object-model ────┼─> ingest ──────> target-jmeter
- │    │      ├─────────────┴─> renderer ────> target-gatling
- │    │      │                          └───> target-k6
- │    │      └─> evaluation ─┐
- │    └────────────────────  ┴─> conformance-corpus
+assertion-first format
+ ├─> core-schema (requirement schema already shipped)
+ │    ├─> target-description-schema ─┬─> target-gatling
+ │    │                              └─> target-k6
+ │    ├─> object-model
+ │    └─> rendering-contract  (also needs target-description-schema)
  └─> monitoring-experiment   (parked)
 ```
 
-Nothing in that graph is a schedule. `target-gatling` sits three edges deep and is still the
-entry that should be started first, because it is the only one with a counterparty waiting.
+Nothing in that graph is a schedule. `target-gatling` is still the entry that should be
+started first, because it is the only one with a counterparty waiting — and it now sits one
+edge deep instead of three.
 
 ### 7.3 The answer owed to the named customer
 
@@ -299,11 +284,14 @@ entry that should be started first, because it is the only one with a counterpar
     - picatinny 2.0 removes `assertionFromYaml` **without** a one-to-one replacement, and its
       migration note documents that assertions are written with Gatling's native DSL. That
       unblocks 2.0 immediately.
-    - The same migration note names OpenNFR's `target-gatling` as the intended successor once
-      `renderer` lands, so the removal is a deprecation with a destination rather than a hole.
+    - The same migration note names OpenNFR as the intended successor: the format, a dated
+      Gatling target description, and the rendering corpus that says what a correct rendering
+      produces. The library that constructs Gatling assertion objects belongs to whoever
+      integrates Gatling — nothing in this repository commits anyone to writing it, and the
+      destination no longer waits on a component nobody has started.
 
-    The first deliverable of `target-gatling` is the Gatling mapping that does not exist today
-    — see clause 10.
+    The first deliverable of `target-gatling` is the Gatling target description, which does not
+    exist today — see clause 10.
 
 ### 7.4 The parked entry
 


### PR DESCRIPTION
Closes #17
Depends on #15

## What changes

`ARCHITECTURE.md` only. Seven sections; two of the four component roles are withdrawn.

| Section | Change |
|---|---|
| Title, § 1 | The path ends at the **rendering**, not at an outcome |
| § 1 clause 3 | **Removed, not rewritten** — the fourth copy of the rule #15 inverts |
| § 2 | R3 and R4 withdrawn, numbers withdrawn with them. R2 gains a third output |
| § 3 | Stops citing a conformance level; the monitoring class is marked parked |
| § 4 | The three walkthroughs are withdrawn; their findings survive as clauses |
| § 5 | A target description, not a `MetricMapping` |
| § 6 | Clause 20 restated without the retired outcome vocabulary |
| § 7 | `renderer` + `conformance-corpus` → `rendering-contract`; `target-jmeter` withdrawn |

## Why R2's third output exists

Neither surveyed target lets a document name an assertion. Gatling derives every string it
prints from the assertion itself, and its per-request scope is rewritten to a concrete request
path before any message is built. k6 prints the metric, the tag selector and the expression.

So "the run did not happen as intended" cannot be told from "the system does not hold" by a
name in the report. It is told apart by matching the report's line back to the rendering entry
that produced it — which is why R2 must emit that identity, and why this is the section that
makes Principle III enforceable at run time against a target with no field for a name.

## What a reviewer should know

**Clause 3 is deleted rather than reworded, deliberately.** It was one of four copies of a rule
that has been inverted. Rewriting a copy leaves four documents to keep in step; deleting it
leaves one owner, which is the constitution.

**The walkthroughs cost something to lose and the cost is stated.** Each traced a document
through the withdrawn roles. Their findings are kept as clauses 8–14 because they were
expensive to get and none depends on those roles — including two verified against a surveyed
target's own source and test suite on 2026-08-20.

**Clause 11 records a real loss, not a tidy-up**: a tool that cannot host assertions now has no
path in this format, where the previous design served it completely after the run. That is what
the constitution's inverted admission rule costs, and it is written down rather than absorbed.

**`target-jmeter` is withdrawn rather than re-scoped.** It was scheduled on the strength of
level `report`. Whether that tool can host an assertion of the shape this format renders needs
a fresh dated check before any entry returns — and inventing one here would be the unsourced
claim Principle IV forbids.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #17` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally
- [x] No term changed in `docs/GLOSSARY.md` — the glossary's `Adapter`, `Target` and `MetricMapping` entries are narrowed by the feature PR that owns them, and this document points at the glossary rather than restating it
- [x] ADR-0002 § D12 and § D13 are cited as needing dated supersession notes, not contradicted here

🤖 Generated with [Claude Code](https://claude.com/claude-code)