### PR TITLE
Homes for target descriptions and the corpus, checked from the first commit

### DIFF
--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -15,8 +15,8 @@ never becomes one.
 | **The format** | `FORMAT.md` and `schema/opennfr.io/v1/` at the repository root | Anyone, by pull request | A term reaches [docs/GLOSSARY.md](docs/GLOSSARY.md) with a rejected alternative first; a naming disagreement is argued in an issue **before** files change; a compatibility-sensitive change requires an ADR | **Yes** |
 | **Ideas and notes** | `docs/` | Anyone, by pull request | Say what is checked and what is opinion. A note may contradict the format — that is what notes are for | No |
 | Decision records | `docs/adr/NNNN-slug.md` | Anyone, by pull request | A PR that contradicts an ADR amends that ADR instead; status stays `proposed` until something validates it | No, but they are why the format is what it is |
-| Tool mappings | `mappings/` once it exists | Anyone, by pull request | The claimed conformance level is evidenced and dated; every gap the target cannot honour is declared | No — the conformance ladder is |
-| Conformance corpus | `conformance/` once it exists | Anyone, by pull request | Every case states the outcome a conforming consumer must reach | **Yes** |
+| Target descriptions | `mappings/` | Anyone, by pull request | Every claim about what the target can and cannot assert is evidenced and dated; capabilities and gaps partition each axis, so a combination in neither is a defect of the description | **Yes** — what a description may declare is a compatibility-sensitive surface |
+| Conformance corpus | `conformance/` | Anyone, by pull request | Every case states the rendering a conforming consumer must reproduce | **Yes** |
 | Validated examples | `examples/` | Anyone, by pull request | They must validate against the schema. `verify.sh` fails if they do not — that is the point of them | **Yes** |
 | Sketches | `docs/examples/` | Anyone, by pull request | Every file announces itself as a sketch in its first six lines. Nothing validates them | No |
 | Parked experiments | `docs/experimental/` | Anyone, by pull request | Status, promotion and retirement conditions, a date; nothing outside links in; markdown only | No, by construction |
@@ -77,8 +77,8 @@ and not below.
 | **follow-up spec** | One concrete future task with a boundary and a dependency | `roadmap item` — implies a schedule; these carry dependencies, not dates |
 | **obligation** | What a change to a class requires of the person making it | `policy` — pulls towards OPA and rule engines |
 | **non-conformance list** | The published record of what is currently mis-filed | `tech debt` — invites deferral rather than disclosure |
-| **component role** | A named job on the path from requirement to outcome, defined by input, output and forbidden knowledge | `layer` — already used for the vocabulary's three layers, and roles are contracts rather than strata |
-| **tool mapping** | The data that binds the format to one target | `binding` — collides with `MetricMapping`, and `binding` is already load-bearing in this repository as an adjective meaning normative |
+| **component role** | A named job on the path from a requirement to a target's own assertions, defined by input, output and forbidden knowledge | `layer` — already used for the vocabulary's three layers, and roles are contracts rather than strata |
+| **target description** | The data that says how one target names things, what it can and cannot assert, how its units convert, and where it can pass on absent data | `tool mapping` — the incumbent, superseded: it named name-correspondence rather than capability. `binding` — already load-bearing here as an adjective meaning normative |
 | **file adapter** | The sub-role of `Adapter` that reads a target's output files | `reader` — in this repository's documents `reader` means a human, and two success criteria rest on that sense |
 
 ## 3. What is currently mis-filed
@@ -91,7 +91,7 @@ cheaper to know now than to discover mid-rename.
 |---|---|---|---|
 | `docs/examples/mapping-k6.yaml` | Tool mappings | Linked from five other documents; a move turns `scripts/verify.sh` red across the tree | **`verify.sh`'s sketch-label check is hardcoded to `docs/examples/*.yaml`.** A mapping relocated to `mappings/` silently stops being checked until the script is extended. Extend it in the same PR |
 | `docs/examples/mapping-jmeter.yaml` | Tool mappings | Same | Same |
-| `docs/compatibility.md` | Three classes at once | Splitting it is a separate concern from publishing this layout | It spans conformance levels (normative), the dated tool survey (evidence) and the Go notes (proposal). A split must keep the survey's date attached to the survey |
+| `docs/compatibility.md` | Three classes at once | Splitting it is a separate concern from publishing this layout | It spans a retired conformance ladder, the dated tool survey (evidence) and the Go notes (proposal). A split must keep the survey's date attached to the survey |
 | `docs/references.md` | Evidence, which has no class | Inventing a class for one file costs a governance word | Either widen the normative core's definition or accept it as an unclassified note, stated as such |
 | `docs/units.md` | Normative core | Already correctly filed; listed because its status line predates the layout | Confirm it announces its own status |
 | `mappings/` | Tool mappings | The directory does not exist yet | Created by the first target follow-up specification, not by this document |
@@ -110,16 +110,21 @@ Extending the list is a constitutional amendment, not a layout change.
 
 The whole point of the layout: this needs no permission and touches no normative-core file.
 
-1. Write one `kind: MetricMapping` document in `mappings/`, named for the target.
-2. Declare, at minimum: the correspondence between the target's names and canonical ones; the
-   unit conversion for each; the correspondence between the target's labelling and canonical
-   attributes; how the target signals a failed request; and how it derives percentiles.
-3. Declare the conformance level the mapping claims, and **the list of constructs the target
-   cannot honour**. An undeclared gap is a defect of the mapping, not of the format.
-4. Evidence the claimed level with a **dated manual verification against the target's own
-   documentation**, in the mapping's own annotations. This is what
+1. Write one `kind: TargetDescription` document in `mappings/`, named for the target.
+2. Declare, at minimum: the correspondence between the target's names and the document's; the
+   unit conversion for each, as an exact ratio rather than a float; how the target signals a
+   failed request; how it derives percentiles; and how it builds its own report line.
+3. Declare **what the target cannot assert**, on the same axes as what it can, so the two
+   partition each axis. A combination declared in neither is a defect of the description, not
+   of the format — and a description silent about a capability is not claiming the target has
+   it.
+4. Cite, for every claim in both directions, a **source and the date it was checked** against
+   the target's own documentation or source. This is what
    [Principle IV](.specify/memory/constitution.md) requires of every claim about an external
-   tool.
+   tool, and here it is a schema constraint rather than a habit.
+5. Declare **where the target can report success on absent data** — an assertion whose scope
+   expands to nothing, a selection that received no samples. One surveyed target does exactly
+   that, and nothing outside its own description can discover it.
 5. Open a pull request. A maintainer attaches the milestone and the closing link if you cannot.
 
 **This procedure is unenforceable today, and says so.** There is no schema to validate the
@@ -137,8 +142,9 @@ should not be.
 A tool-native integration — a Gatling plugin, a k6 extension — lives in **that tool's own
 repository** and consumes this one. It never lives here.
 
-**This repository is authoritative** for the format, the vocabulary and the conformance levels.
-An integration that disagrees is wrong and is fixed there, not here.
+**This repository is authoritative** for the format and the vocabulary. An integration that
+disagrees is wrong and is fixed there, not here. It is *not* authoritative for what a target can
+do: that is the target's, and a description records it with a date rather than deciding it.
 
 How drift becomes visible is deliberately unanswered: every detection mechanism is an
 executable artifact, and this feature ships none. Detection is assigned to the conformance-corpus

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,65 @@
+# Conformance corpus
+
+What a conforming consumer must reproduce, as data. Three parts, three notions of a case.
+
+| Part | A case is | The expectation lives |
+|---|---|---|
+| `parse/` | one document that must be accepted, or rejected | in a sidecar file naming every finding and the exact path it must report |
+| `render/` | a directory holding one document and one rendering per target | the rendering **is** the expectation |
+| `gate/` | a described mutation of a tracked file | the exit code and the line `scripts/verify.sh` must print |
+
+## Two rules that make a rejection case readable
+
+**One mutation per case.** A rejection case differs from a valid document by exactly one
+change, so exactly one rule can be responsible for the outcome. A case that breaks three rules
+proves only that something was wrong.
+
+**The expectation is a sidecar, never inside the case.** A case file is the document exactly as
+written. An `expect:` key inside it would itself be an unknown field — and unknown fields are
+what several of these cases exist to catch, so the expectation would mask the finding.
+
+Rejection cases may not live in `examples/`: everything there must validate, and a field name
+in a published example is a compatibility-sensitive surface.
+
+---
+
+## What this corpus does **not** establish
+
+Required by the specification, and worth reading before quoting a green run.
+
+**Nothing here renders.** The rendering implementation belongs to whoever integrates a target,
+in that target's own repository. What lives here is an **oracle** — the triple *(document,
+target description, rendering)* that any implementation, in any language, must reproduce. Until
+an implementation somewhere runs against it, the corpus is unfalsified: a very well-formed
+guess.
+
+**It can be uniformly wrong about a target.** Every check is a consistency check between files
+this repository writes. If a target description wrongly claims a tool lacks a comparison, and
+the case agrees, both are wrong and the build is green. The only defence is the dated source
+each claim carries — and a machine can verify that a date *exists*, never that the claim is
+true.
+
+**It does not check that the target accepts the assertion.** The corpus pins the arguments,
+never the API. A statistic name the tool does not have passes every check here; that failure
+surfaces only in an integration test in the tool's own repository, running a real simulation.
+
+**The counting rule closes over the document, not over intent.** It catches a predicate the
+renderer dropped. It cannot catch the requirement nobody thought to write — which is the most
+common real defect in requirement documents, and the one nothing mechanical will ever find.
+
+**Two targets do not prove the shape is neutral.** Any record designed while looking at two
+targets fits those two. The honest next probe is a third with native assertions of a different
+shape.
+
+---
+
+## How it fails
+
+Never by skipping. The runner distinguishes *ran and passed* from *could not run*, and the
+second is a failure: a missing dependency, an unreadable schema, an empty corpus, or a case
+with no expectation all turn the build red rather than quietly reporting nothing.
+
+That is the same rule this repository applies to its own gate, and it is applied here from the
+start because four sections of that gate once did not have it — each reporting `ok` on every
+commit, on both platforms, for the life of the project, and one of them without ever having
+executed.

--- a/mappings/README.md
+++ b/mappings/README.md
@@ -1,0 +1,45 @@
+# Target descriptions
+
+One file per target, `kind: TargetDescription`, named for the target.
+
+A description says everything about one target: how it names things, **what it can assert and
+what it cannot**, how its units convert, how it builds its own report line, and where it can
+report success on absent data. Adding a target is adding one of these — it changes no schema,
+no existing document, and no code anywhere.
+
+This is the **only** artifact class in this repository where a tool name legitimately appears.
+A requirement document names no tool, in a field, a value, a metric name or an example; the
+whole subject of a file here is one tool, so its name belongs in `metadata.name` and nowhere
+else matters.
+
+## What every claim owes
+
+**A source and the date it was checked.** A capability claim is an assertion about somebody
+else's software, and undated it rots without anyone noticing. This is a schema constraint here,
+not a convention.
+
+**Its opposite.** Capabilities and gaps partition each axis. A combination declared in neither
+is a **defect of the description**, catchable mechanically — and a description that is silent
+about a capability is not claiming the target has it.
+
+## Two things easy to get wrong
+
+**Units are exact ratios, never floats.** Whether a threshold is *exactly* representable in the
+target's own numeric type decides whether it renders at all, and a floating-point conversion
+cannot answer that. The surveyed targets differ by three orders of magnitude in one direction
+and by a factor of a hundred in another; a rounding opinion here produces a confident, wrong,
+green result.
+
+**Where the target can pass on absent data.** One surveyed target has an assertion scope that
+exits *successfully* when it matches nothing. Nothing outside that target's own description can
+discover this, and nothing downstream can prevent it — so it is declared, or it is a silent
+green nobody owns.
+
+## What does not live here
+
+A tool-native integration — a plugin, an extension, a library that constructs the target's
+assertion objects — lives in **that tool's own repository** and consumes this one. Nothing here
+renders; these files say what a correct rendering would produce.
+
+See [LAYOUT.md](../LAYOUT.md) § 5 for the full procedure, and
+[docs/GLOSSARY.md](../docs/GLOSSARY.md) for the term.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -113,9 +113,15 @@ JSONABLE
 fi
 
 section "Examples validate against the schema"
-# The real gate. Every document in examples/ must satisfy the schema. The
-# sketches under docs/examples/ are deliberately outside it — see AGENTS.md >
-# Test Model — because they illustrate ideas the format does not have.
+# The real gate. Every document in examples/, mappings/ and conformance/ must
+# satisfy the schema for its kind. The sketches under docs/examples/ are
+# deliberately outside it — see AGENTS.md > Test Model — because they illustrate
+# ideas the format does not have.
+#
+# LAYOUT.md § 6 warns that a document relocated into mappings/ silently stops
+# being checked. That hole is closed here rather than when the first file lands:
+# a kind with no schema is a FAIL, so the window in which something could arrive
+# unchecked never opens.
 if ! command -v python3 >/dev/null 2>&1; then
   bad "python3 not found — the schema gate cannot run"
 else
@@ -128,14 +134,27 @@ except ImportError as e:
     # A gate that skips itself reads exactly like a passing one.
     print(f"  FAIL  {e.name} not installed (pip install jsonschema pyyaml)")
     sys.exit(1)
-schema = json.load(open("schema/opennfr.io/v1/requirementset.schema.json", encoding="utf-8"))
-Draft202012Validator.check_schema(schema)
-v = Draft202012Validator(schema)
+import os
+# kind -> validator. A kind absent from this table has no schema and is a failure,
+# never a pass. Entries appear as their schema files land.
+KINDS = {}
+for kind, name in (("RequirementSet", "requirementset"),
+                   ("TargetDescription", "targetdescription"),
+                   ("Rendering", "rendering")):
+    path = f"schema/opennfr.io/v1/{name}.schema.json"
+    if os.path.exists(path):
+        sch = json.load(open(path, encoding="utf-8"))
+        Draft202012Validator.check_schema(sch)
+        KINDS[kind] = Draft202012Validator(sch)
 rc = 0
 files = sorted(glob.glob("examples/*.yaml"))
 if not files:
     print("  FAIL  examples/ holds no document to validate")
     sys.exit(1)
+# mappings/ and conformance/ are validated too. They may hold only a README while
+# no YAML has landed yet, so an empty result here is not a failure — but any YAML
+# that does land is checked, or the FAIL below says nothing validates it.
+files += sorted(glob.glob("mappings/*.yaml") + glob.glob("conformance/**/*.yaml", recursive=True))
 for f in files:
     docs = [d for d in yaml.safe_load_all(open(f, encoding="utf-8"))]
     if not docs or all(d is None for d in docs):
@@ -148,10 +167,11 @@ for f in files:
             rc = 1
             continue
         kind = doc.get("kind")
-        if kind != "RequirementSet":
-            print(f"  FAIL  {f}: kind {kind!r} has no schema yet — move it out of examples/")
+        if kind not in KINDS:
+            print(f"  FAIL  {f}: kind {kind!r} has no schema — nothing validates this file")
             rc = 1
             continue
+        v = KINDS[kind]
         errs = sorted(v.iter_errors(doc), key=lambda e: list(e.path))
         for e in errs:
             where = "/".join(map(str, e.path)) or "(root)"


### PR DESCRIPTION
Closes #23

## What changes

| File | Change |
|---|---|
| `mappings/README.md` | **new** — what a target description is, and the only place a tool name is legitimate |
| `conformance/README.md` | **new** — the three parts, and **what the corpus does not establish** |
| `LAYOUT.md` | §§ 1, 4, 5, 6, 7 — the artifact, the procedure, and the authority claim |
| `scripts/verify.sh` | the schema gate covers both new directories and dispatches on `kind` |

## Why the gate change is in this PR and not the next one

`LAYOUT.md` § 6 already recorded the trap:

> *"`verify.sh`'s sketch-label check is hardcoded to `docs/examples/*.yaml`. A mapping relocated
> to `mappings/` silently stops being checked until the script is extended. Extend it in the
> same PR."*

Creating the directory **opens** that window. Closing it afterwards means a period in which a
file could land unchecked, and the whole point of this repository is that such periods are
where silence gets in. So the gate is widened in the same commit: it dispatches on `kind`, and
a kind with no schema is a `FAIL` saying *nothing validates this file* — not a pass.

Neither new schema exists yet, so a target description dropped in today fails loudly. That is
the intended behaviour, not a gap.

**Verified by mutation, not by reading:**

```
mappings/probe.yaml → FAIL  kind 'TargetDescription' has no schema — nothing validates this file
removed             → PASS
```

## What a reviewer should know

**§ 5 gains a fifth step that did not exist**: declare where the target can report success on
absent data. One surveyed target has an assertion scope that exits *successfully* when it
matches nothing. Nothing outside that target's own description can discover this and nothing
downstream can prevent it — so either it is declared, or it is a silent green nobody owns.

**Unit conversion is now specified as an exact ratio rather than a float.** Whether a threshold
is *exactly* representable in the target's numeric type decides whether it renders at all, and
a floating-point conversion cannot answer that.

**The authority claim is narrowed, deliberately.** This repository is authoritative for the
format and the vocabulary. It is **not** authoritative for what a target can do — that belongs
to the target, and a description records it with a date rather than deciding it. The old
wording claimed authority over the conformance levels, which no longer exist.

**`conformance/README.md` leads with what the corpus cannot establish**, before anything else,
because that is the section someone quoting a green build will not have read otherwise.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #23` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally, and the new check was proved able to fail
- [x] No term changed — `target description` reached `docs/GLOSSARY.md` in the previous PR, with its rejected alternative, before appearing here
- [x] No ADR contradicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)