### PR TITLE
Schemas: the target description and the rendering

### DIFF
--- a/schema/opennfr.io/v1/rendering.schema.json
+++ b/schema/opennfr.io/v1/rendering.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opennfr.io/schema/v1/rendering.schema.json",
+  "title": "Rendering",
+  "description": "What one document becomes for one target: the target's own assertions, plus every predicate that could not be rendered, named, with a reason. This is the format's output and the path stops here — the target evaluates and reports for itself. Nothing in this repository produces a Rendering; the corpus uses it as the oracle any implementation, in any language, must reproduce.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": { "const": "opennfr.io/v1" },
+    "kind": { "const": "Rendering" },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "$ref": "#/$defs/name" },
+        "displayName": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["document", "target", "predicates"],
+      "properties": {
+        "document": {
+          "$ref": "#/$defs/name",
+          "description": "metadata.name of the RequirementSet this renders. Resolved inside the case's own directory, never as a path, so a case can be moved without editing its contents."
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["description", "version", "checked"],
+          "properties": {
+            "description": { "$ref": "#/$defs/name" },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The target's version the native text below was read against. It MUST equal the target description's own version — a mismatch means one of the two is stale, and that is worth failing on."
+            },
+            "checked": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" }
+          }
+        },
+        "predicates": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/entry" },
+          "description": "ONE ordered list, not two. Exactly one entry per predicate, in document order: for each requirement in order, its guards then its criteria. `rendered` and `unrenderable` are projections of this list. That is what makes the counting rule hold by construction — there is no way to spell a predicate that appears twice, and none to spell one that appears in neither bucket."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+      "maxLength": 253
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requirement", "role", "id"],
+      "properties": {
+        "requirement": { "$ref": "#/$defs/name" },
+        "role": {
+          "enum": ["criterion", "guard"],
+          "description": "Whether this entry states a property of the system or a condition of the run. This is the only place either surveyed target can carry the distinction: neither has a field a document can write a name into, so a failed precondition is told from a failed criterion by resolving the target's report line back to this entry."
+        },
+        "id": {
+          "anyOf": [
+            { "$ref": "#/$defs/name" },
+            { "$ref": "#/$defs/aggregation" }
+          ],
+          "description": "The predicate's identity: its `name` if set, otherwise its `aggregation`. Not a name alone — `p99.9` is a legal identity and contains a dot."
+        }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["predicate"],
+      "properties": {
+        "predicate": { "$ref": "#/$defs/identity" },
+        "rendered": { "$ref": "#/$defs/rendered" },
+        "unrenderable": { "$ref": "#/$defs/unrenderable" }
+      },
+      "oneOf": [
+        { "required": ["rendered"] },
+        { "required": ["unrenderable"] }
+      ]
+    },
+    "rendered": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["assertions"],
+      "properties": {
+        "assertions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/assertion" },
+          "description": "At least one. A rendered entry with no assertion is unspellable on purpose: success by omission has no syntax here. More than one is admissible only as a conjunction that strictly narrows the pass condition — a range a target spells as two comparisons, or a companion assertion that stops the target passing on an empty selection."
+        }
+      }
+    },
+    "assertion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "selector", "aggregation", "op", "threshold", "unit", "native"],
+      "properties": {
+        "metric": { "type": "string", "minLength": 1, "description": "The target's own token." },
+        "selector": {
+          "type": "object",
+          "additionalProperties": { "type": ["string", "number", "boolean"] },
+          "description": "The target's own selection keys. {} means every request, written explicitly rather than implied. Serialised in lexicographic key order, which is half of what makes a rendering deterministic."
+        },
+        "aggregation": { "type": "string", "minLength": 1 },
+        "percentile": {
+          "type": "number",
+          "description": "Present only where the aggregation is the target's percentile token. Two values — a token and a number — never the single string 'percentile(95)', which would have to be parsed to be understood."
+        },
+        "op": { "type": "string", "minLength": 1 },
+        "threshold": {
+          "type": "number",
+          "description": "AFTER conversion, in the target's own representation. A value that does not land exactly inside the declared numeric domain makes its predicate unrenderable rather than rounded."
+        },
+        "unit": { "$ref": "#/$defs/unit" },
+        "native": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The literal form the target receives, pinned as dated evidence. Deliberately carries NO `pattern`: a pattern is the first line of a decoder, and nothing interprets this string. When it disagrees with the structured fields above, the literal is the finding and the fields are the bug."
+            }
+          }
+        }
+      }
+    },
+    "unrenderable": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reasons"],
+      "properties": {
+        "reasons": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reason" },
+          "description": "At least one, each citing a gap the target description actually declares. That is what makes an unrenderable claim traceable rather than asserted — and it is checked in both directions, because calling something unrenderable that the target can in fact assert is as much a defect as the reverse."
+        }
+      }
+    },
+    "reason": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gap", "detail"],
+      "properties": {
+        "gap": {
+          "enum": [
+            "no-such-metric",
+            "no-such-attribute",
+            "no-such-selection",
+            "no-such-aggregation",
+            "no-such-comparison",
+            "no-such-shape",
+            "threshold-not-representable"
+          ],
+          "description": "Which axis the target description declares a gap on. The three kinds the edge cases require — a missing statistic, a missing comparison, a threshold that does not convert — are told apart by this rather than by prose."
+        },
+        "detail": { "type": "string", "minLength": 1 }
+      }
+    },
+    "aggregation": {
+      "type": "string",
+      "anyOf": [
+        { "enum": ["avg", "min", "max", "count", "rate", "sum", "stddev"] },
+        { "pattern": "^p\\d{1,2}(\\.\\d+)?$" }
+      ]
+    },
+    "unit": {
+      "enum": ["ns", "us", "ms", "s", "min", "h", "%", "1", "By", "KiBy", "MiBy", "GiBy",
+               "{request}", "{request}/s", "{iteration}", "{iteration}/s", "{vu}"]
+    }
+  }
+}

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -30,6 +30,12 @@
         },
         "annotations": {
           "$ref": "#/$defs/annotations"
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Free human-readable text, any script, beside the machine identifier. Inert: it changes nothing selected, measured, compared or rendered, and stripping every display name must leave a rendering byte-identical. It MUST NOT restate a value the structured fields already carry — a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number. It does NOT reach the target's own report; no surveyed target has a field for an author-chosen string."
         }
       }
     },
@@ -145,6 +151,12 @@
         },
         "unit": {
           "$ref": "#/$defs/unit"
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Free human-readable text, any script, beside the machine identifier. Inert: it changes nothing selected, measured, compared or rendered, and stripping every display name must leave a rendering byte-identical. It MUST NOT restate a value the structured fields already carry — a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number. It does NOT reach the target's own report; no surveyed target has a field for an author-chosen string."
         }
       }
     },
@@ -192,6 +204,12 @@
             ],
             "unevaluatedProperties": false
           }
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Free human-readable text, any script, beside the machine identifier. Inert: it changes nothing selected, measured, compared or rendered, and stripping every display name must leave a rendering byte-identical. It MUST NOT restate a value the structured fields already carry — a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number. It does NOT reach the target's own report; no surveyed target has a field for an author-chosen string."
         }
       },
       "allOf": [

--- a/schema/opennfr.io/v1/targetdescription.schema.json
+++ b/schema/opennfr.io/v1/targetdescription.schema.json
@@ -1,0 +1,652 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opennfr.io/schema/v1/targetdescription.schema.json",
+  "title": "TargetDescription",
+  "description": "Everything about one target: how it names things, what it can and cannot assert, how its units convert, how it builds its own report line, and where it can report success on absent data. Adding a target is adding one of these — it changes no other schema, no existing document and no code. Two properties are load-bearing: every claim cites dated evidence, and capabilities and gaps partition each axis, so a combination declared in neither is a defect of the description rather than a surprise at render time.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "opennfr.io/v1"
+    },
+    "kind": {
+      "const": "TargetDescription"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name",
+          "description": "The target's name. This is the only place in the format where a tool name legitimately appears: a requirement document names none."
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "evidence",
+        "native",
+        "report",
+        "units",
+        "names",
+        "assertable"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The target's own version this description was checked against. A capability claim without a version is a claim about no particular software."
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          },
+          "description": "Every claim in this file cites at least one of these by id. That turns 'a claim about an external tool is dated and sourced' from a habit into a schema constraint."
+        },
+        "native": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "fields",
+            "evidence"
+          ],
+          "properties": {
+            "fields": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/name"
+              },
+              "description": "What a native assertion is made of, here. Declared per file so a target with an unanticipated assertion shape needs no schema change. The order is also the serialisation order, which is half of what makes a rendering deterministic."
+            },
+            "evidence": {
+              "$ref": "#/$defs/evidenceRefs"
+            }
+          }
+        },
+        "report": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "derivedFrom",
+            "carriesAuthorName",
+            "evidence"
+          ],
+          "properties": {
+            "derivedFrom": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/reportInput"
+              },
+              "description": "What this target's own report line is built from. Load-bearing: two predicates whose projections onto this list are equal are INDISTINGUISHABLE in that target's report, which is a fact about the target that a corpus can detect and say out loud rather than a distinction the format may claim."
+            },
+            "carriesAuthorName": {
+              "type": "boolean",
+              "description": "Whether the target has a field a document can write an author-chosen name into. False on both surveyed targets. When false, a precondition is told apart from a criterion by its entry in the rendering, never by a name in the report."
+            },
+            "evidence": {
+              "$ref": "#/$defs/evidenceRefs"
+            }
+          }
+        },
+        "units": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/unitConversion"
+          }
+        },
+        "absentData": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "canPass",
+            "evidence"
+          ],
+          "description": "Where this target's own evaluation can report success having measured nothing. Nothing outside this file can discover it and nothing downstream can prevent it, so an undeclared one is a silent green nobody owns.",
+          "properties": {
+            "canPass": {
+              "type": "boolean"
+            },
+            "conditions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "when",
+                  "detail"
+                ],
+                "properties": {
+                  "when": {
+                    "$ref": "#/$defs/name"
+                  },
+                  "detail": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            },
+            "evidence": {
+              "$ref": "#/$defs/evidenceRefs"
+            }
+          }
+        },
+        "names": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "metrics",
+            "attributes",
+            "unlisted"
+          ],
+          "properties": {
+            "metrics": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nameMapping"
+              }
+            },
+            "attributes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nameMapping"
+              }
+            },
+            "unlisted": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "metric",
+                "attribute"
+              ],
+              "description": "What happens to a canonical name that is not in the lists above. Required, because the complement is infinite: without it an unlisted metric falls through as supported, which is the wrong default.",
+              "properties": {
+                "metric": {
+                  "$ref": "#/$defs/gap"
+                },
+                "attribute": {
+                  "$ref": "#/$defs/gap"
+                }
+              }
+            }
+          }
+        },
+        "assertable": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/assertableRow"
+          },
+          "description": "Exact-match lookup on (shape, metric, side, selections), then on aggregation, then on comparison. Nothing is expanded by rule: there is no inference step for a reader to simulate, and a combination this table does not declare is unrenderable."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+      "maxLength": 253
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "source",
+        "checked",
+        "states"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/name"
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where it was read: a repository path with a tag, or a URL."
+        },
+        "checked": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "description": "The date this source was read. A capability claim is an assertion about somebody else's software; undated, it rots without anyone noticing."
+        },
+        "states": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What the SOURCE says — not what was concluded from it. The distinction is the whole value of the field."
+        }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/name"
+      }
+    },
+    "reportInput": {
+      "enum": [
+        "scope",
+        "selection",
+        "metric",
+        "aggregation",
+        "comparison",
+        "threshold",
+        "unit"
+      ]
+    },
+    "unitConversion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "multiplyBy",
+        "evidence"
+      ],
+      "description": "An exact ratio, never a float. Whether a threshold is EXACTLY representable in the target's own numeric type decides whether it renders at all, and floating-point arithmetic cannot answer that.",
+      "properties": {
+        "from": {
+          "$ref": "#/$defs/unit"
+        },
+        "to": {
+          "$ref": "#/$defs/unit"
+        },
+        "multiplyBy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "numerator",
+            "denominator"
+          ],
+          "properties": {
+            "numerator": {
+              "type": "integer"
+            },
+            "denominator": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidenceRefs"
+        }
+      }
+    },
+    "unit": {
+      "enum": [
+        "ns",
+        "us",
+        "ms",
+        "s",
+        "min",
+        "h",
+        "%",
+        "1",
+        "By",
+        "KiBy",
+        "MiBy",
+        "GiBy",
+        "{request}",
+        "{request}/s",
+        "{iteration}",
+        "{iteration}/s",
+        "{vu}"
+      ]
+    },
+    "nameMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical",
+        "native",
+        "evidence"
+      ],
+      "properties": {
+        "canonical": {
+          "type": "string",
+          "minLength": 1
+        },
+        "native": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidenceRefs"
+        }
+      }
+    },
+    "gapReason": {
+      "enum": [
+        "no-such-metric",
+        "no-such-attribute",
+        "no-such-selection",
+        "no-such-aggregation",
+        "no-such-comparison",
+        "no-such-shape",
+        "threshold-not-representable"
+      ],
+      "description": "A closed list. A target that fails in a way none of these describes needs a schema change and a re-review of every existing gap — which is the cost of making the reason checkable rather than free text, and it is the right trade."
+    },
+    "gap": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/gapFields"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "description": "A declared gap on an axis that needs no further key — the infinite complement of a name list."
+    },
+    "numericDomain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "description": "What the target accepts as a threshold. A value outside it, or one that does not land exactly inside it after conversion, is unrenderable — never rounded.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "integer",
+            "real"
+          ]
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "maxFractionDigits": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "aggregationCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parts",
+        "value",
+        "evidence"
+      ],
+      "properties": {
+        "parts": {
+          "type": "array",
+          "minItems": 1,
+          "description": "How the native assertion is built for this aggregation, in terms of the fields declared in spec.native.fields.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "field",
+              "value"
+            ],
+            "properties": {
+              "field": {
+                "$ref": "#/$defs/name"
+              },
+              "value": {
+                "type": "object",
+                "additionalProperties": false,
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "literal": {
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ]
+                  },
+                  "from": {
+                    "enum": [
+                      "percentile",
+                      "comparison",
+                      "threshold",
+                      "selection",
+                      "metric"
+                    ],
+                    "description": "Taken from the predicate being rendered. A closed list rather than an expression: Principle V forbids a grammar here."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "value": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "unit",
+            "domain"
+          ],
+          "properties": {
+            "unit": {
+              "$ref": "#/$defs/unit"
+            },
+            "domain": {
+              "$ref": "#/$defs/numericDomain"
+            }
+          }
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidenceRefs"
+        }
+      }
+    },
+    "assertableRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "shape",
+        "metric",
+        "selections",
+        "aggregations",
+        "aggregationGaps",
+        "comparisons",
+        "comparisonGaps"
+      ],
+      "properties": {
+        "shape": {
+          "enum": [
+            "distribution",
+            "ratio"
+          ]
+        },
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "side": {
+          "enum": [
+            "bad",
+            "good"
+          ],
+          "description": "Ratio rows only: which side of the fraction this row describes."
+        },
+        "selections": {
+          "type": "array",
+          "minItems": 1,
+          "description": "The exact attribute key sets this target can select on. An empty inner array means 'every request'. A key set not listed here is not selectable, and the row's gaps say so.",
+          "items": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "aggregations": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/aggregationCapability"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/aggregationKey"
+          }
+        },
+        "aggregationGaps": {
+          "type": "array",
+          "description": "Together with `aggregations`, partitions the aggregation axis. An aggregation in neither is a defect of this description.",
+          "items": {
+            "$ref": "#/$defs/aggregationGap"
+          }
+        },
+        "comparisons": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/op"
+          }
+        },
+        "comparisonGaps": {
+          "type": "array",
+          "description": "Together with `comparisons`, partitions the comparison axis.",
+          "items": {
+            "$ref": "#/$defs/comparisonGap"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "shape": {
+                "const": "ratio"
+              }
+            },
+            "required": [
+              "shape"
+            ]
+          },
+          "then": {
+            "required": [
+              "side"
+            ]
+          },
+          "description": "A ratio row describes one side of the fraction; a distribution row has no side."
+        }
+      ]
+    },
+    "aggregationKey": {
+      "anyOf": [
+        {
+          "enum": [
+            "avg",
+            "min",
+            "max",
+            "count",
+            "rate",
+            "sum",
+            "stddev"
+          ]
+        },
+        {
+          "pattern": "^p(\\*|\\d{1,2}(\\.\\d+)?)$"
+        }
+      ],
+      "description": "The document's aggregation vocabulary, plus `p*` standing for every percentile where a target supports them uniformly."
+    },
+    "op": {
+      "enum": [
+        "lt",
+        "lte",
+        "gt",
+        "gte",
+        "eq",
+        "neq"
+      ]
+    },
+    "gapFields": {
+      "type": "object",
+      "required": [
+        "reason",
+        "detail",
+        "evidence"
+      ],
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/gapReason"
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidenceRefs"
+        }
+      }
+    },
+    "aggregationGap": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/gapFields"
+        }
+      ],
+      "required": [
+        "aggregation"
+      ],
+      "properties": {
+        "aggregation": {
+          "$ref": "#/$defs/aggregationKey"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "comparisonGap": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/gapFields"
+        }
+      ],
+      "required": [
+        "op"
+      ],
+      "properties": {
+        "op": {
+          "$ref": "#/$defs/op"
+        }
+      },
+      "unevaluatedProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Closes #25

## What changes

| File | Change |
|---|---|
| `schema/…/targetdescription.schema.json` | **new** |
| `schema/…/rendering.schema.json` | **new** |
| `schema/…/requirementset.schema.json` | `displayName` at three levels, optional everywhere |

Both directories already existed and the gate already validated whatever landed in them —
against kinds that had no schema. Anything written there failed with *"kind X has no schema"*.
Correct, and a dead end. This ends it.

## The properties enforced by schema rather than by review

**Every claim cites dated evidence.** A capability claim is an assertion about somebody else's
software. Undated, it rots without anyone noticing — so `evidence` with a `source` and a
`checked` date is `required`, and every capability and every gap references one.

**Capabilities and gaps partition each axis.** `aggregations` + `aggregationGaps`,
`comparisons` + `comparisonGaps`, and `names.unlisted` for the infinite complement of the name
lists. A combination in neither half is a defect of the description, catchable rather than
surprising.

**Unit conversion is an integer ratio, never a float.** Whether a threshold is *exactly*
representable in the target's numeric type decides whether it renders at all.

**Success by omission has no syntax.** One ordered `predicates` list rather than two, exactly
one entry per predicate, `oneOf` between `rendered` and `unrenderable`, `minItems: 1` on both
`assertions` and `reasons`. The counting rule holds by construction — a predicate that appears
twice, or in neither bucket, is unspellable.

**The pinned native text carries no `pattern`.** A pattern is the first line of a decoder, and
nothing interprets that string. When it disagrees with the structured fields beside it, the
literal is the finding and the fields are the bug.

## A field the earlier design did not have

`absentData` — where the target can report success having measured nothing. One surveyed target
has an assertion scope that exits *successful* when it matches nothing; nothing outside that
target's own description can discover it, and nothing downstream can prevent it.

## One defect, found by testing rather than after

`additionalProperties: false` in the shared `gap` definition rejected the very axis key the
composing schema adds, so `aggregationGaps` and `comparisonGaps` **could not be written at
all**. Composition now goes through a `gapFields` definition that closes nothing, with the
closed variants at the use sites.

This is the argument for instantiating a schema rather than reading it: the file was
well-formed, self-consistent, and unusable for two of its own fields.

## Verified, not asserted

Both schemas accept a plausible document. The target description rejects each of these:

| Probe | |
|---|---|
| a gap with no evidence | REJECTED |
| an undated source (`"August 2026"`) | REJECTED |
| a float unit ratio | REJECTED |
| an unknown gap reason | REJECTED |
| a ratio row with no `side` | REJECTED |

End to end through the gate: a valid description in `mappings/` reports
`ok  mappings/probe.yaml  [TargetDescription]`, and removing one gap's `evidence` turns it red
naming `spec/assertable/0/aggregationGaps/0`.

## Known, and not fixed here

The `unevaluatedProperties` collateral: a failing branch drops its annotations, so a real error
is followed by a second complaining that the *valid* sibling keys were unexpected. It is a
usability defect in how JSON Schema reports composition, it affects the existing requirement
schema equally, and curing it is its own concern.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #25` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally, and the new validation was proved able to fail
- [x] Terms reached `docs/GLOSSARY.md` **before** this schema — that ordering is Principle I, and it is why the vocabulary PR went first
- [x] No ADR contradicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)