### PR TITLE
One implementation of the checks, and the identity rule was wrong

### DIFF
--- a/scripts/opennfr_check.py
+++ b/scripts/opennfr_check.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""The checks, in one place.
+
+`scripts/verify.sh` is the gate and the conformance corpus is the test suite, and both
+need the same answers. If they each carried their own copy, the corpus would assert
+against a copy and prove nothing about the gate that actually runs — two sources for one
+rule, drifting, which is the failure this repository exists to prevent, reproduced inside
+its own tooling.
+
+So: one implementation, two callers. Every function here returns a list of findings and
+prints nothing; the caller decides how a finding is shown and what it costs.
+
+Runnable directly for one-off use:
+
+    python3 scripts/opennfr_check.py examples/*.yaml
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+import sys
+from typing import Any, Iterable, NamedTuple
+
+SCHEMA_DIR = "schema/opennfr.io/v1"
+
+# kind -> schema basename. A kind absent from this table has no schema, and a document
+# carrying it is a failure rather than a pass: nothing would validate it.
+KIND_SCHEMAS = {
+    "RequirementSet": "requirementset",
+    "TargetDescription": "targetdescription",
+    "Rendering": "rendering",
+}
+
+
+class Finding(NamedTuple):
+    """One thing wrong, in one place.
+
+    `gate` names which check produced it, so a caller can group or filter. `path` is a
+    document path (``spec/requirements/0/criteria/0``) where one applies, and empty where
+    the finding is about the file as a whole.
+    """
+
+    gate: str
+    file: str
+    path: str
+    message: str
+
+    def __str__(self) -> str:
+        where = f"{self.file}: {self.path}: " if self.path else f"{self.file}: "
+        return f"{where}{self.message}"
+
+
+class DependencyMissing(Exception):
+    """A check could not run. Never the same thing as a check that passed."""
+
+
+def _yaml():
+    try:
+        import yaml
+    except ImportError as e:  # pragma: no cover - environment-dependent
+        raise DependencyMissing(f"{e.name} not installed (pip install pyyaml)") from e
+    return yaml
+
+
+def _validator_cls():
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as e:  # pragma: no cover - environment-dependent
+        raise DependencyMissing(f"{e.name} not installed (pip install jsonschema)") from e
+    return Draft202012Validator
+
+
+# --------------------------------------------------------------------------- parsing
+
+
+def check_parses(path: str) -> list[Finding]:
+    """The file is YAML at all."""
+    yaml = _yaml()
+    try:
+        list(yaml.safe_load_all(open(path, encoding="utf-8")))
+    except Exception as e:
+        return [Finding("parse", path, "", str(e))]
+    return []
+
+
+def check_jsonable(path: str) -> list[Finding]:
+    """Every value maps onto JSON, and no anchor, alias or merge key is used.
+
+    ADR-0002 § D16. Both halves must happen at the event level, before ``safe_load_all``
+    resolves them away: by the time it returns, an alias is an ordinary dict and the
+    evidence is gone.
+    """
+    yaml = _yaml()
+    out: list[Finding] = []
+
+    for ev in yaml.parse(open(path, encoding="utf-8")):
+        if isinstance(ev, yaml.AliasEvent):
+            out.append(Finding("jsonable", path, "", f"alias *{ev.anchor} — ADR-0002 D16 forbids aliases"))
+        elif getattr(ev, "anchor", None):
+            out.append(Finding("jsonable", path, "", f"anchor &{ev.anchor} — ADR-0002 D16 forbids anchors"))
+        elif isinstance(ev, yaml.ScalarEvent) and ev.value == "<<":
+            out.append(Finding("jsonable", path, "", "merge key << — ADR-0002 D16 forbids merge keys"))
+
+    def walk(v: Any, where: str) -> None:
+        if v is None or isinstance(v, (bool, str, int)):
+            return
+        if isinstance(v, float):
+            if not math.isfinite(v):
+                out.append(Finding("jsonable", path, where, f"{v!r} has no JSON representation"))
+            return
+        if isinstance(v, dict):
+            for k, x in v.items():
+                if not isinstance(k, str):
+                    out.append(Finding("jsonable", path, where, f"non-string key {k!r}"))
+                walk(x, f"{where}/{k}")
+            return
+        if isinstance(v, list):
+            for i, x in enumerate(v):
+                walk(x, f"{where}/{i}")
+            return
+        out.append(Finding("jsonable", path, where, f"{type(v).__name__} has no JSON equivalent ({v!r})"))
+
+    for doc in yaml.safe_load_all(open(path, encoding="utf-8")):
+        walk(doc, "")
+    return out
+
+
+# ---------------------------------------------------------------------------- schema
+
+
+def load_validators() -> dict[str, Any]:
+    """One validator per kind whose schema exists. Missing files are not an error here —
+    a kind with no schema becomes a finding at the document, where the file can be named."""
+    V = _validator_cls()
+    out = {}
+    for kind, base in KIND_SCHEMAS.items():
+        p = os.path.join(SCHEMA_DIR, f"{base}.schema.json")
+        if os.path.exists(p):
+            schema = json.load(open(p, encoding="utf-8"))
+            V.check_schema(schema)
+            out[kind] = V(schema)
+    return out
+
+
+def check_schema(doc: Any, path: str, validators: dict[str, Any]) -> list[Finding]:
+    """The document satisfies the schema for its own kind."""
+    if not isinstance(doc, dict):
+        return [Finding("schema", path, "", f"top level is {type(doc).__name__}, expected a mapping")]
+    kind = doc.get("kind")
+    if kind not in validators:
+        return [Finding("schema", path, "", f"kind {kind!r} has no schema — nothing validates this file")]
+    out = []
+    for e in sorted(validators[kind].iter_errors(doc), key=lambda e: list(e.path)):
+        out.append(Finding("schema", path, "/".join(map(str, e.path)), e.message))
+    return out
+
+
+# -------------------------------------------------------------------------- identity
+
+
+def predicate_identity(predicate: dict) -> Any:
+    """A predicate's identity: its ``name`` if set, otherwise its ``aggregation``."""
+    return predicate.get("name") or predicate.get("aggregation")
+
+
+def check_predicate_identity(doc: Any, path: str) -> list[Finding]:
+    """No two predicates of one requirement share an identity.
+
+    Counted across ``criteria`` **and** ``guards`` together, not per section. A guard and
+    a criterion that both reduce by ``rate`` collide, and a per-section check waves that
+    through — which is what this repository's gate did until this function existed.
+
+    JSON Schema cannot express it: the key is computed, and uniqueness spans two arrays.
+    """
+    if not isinstance(doc, dict) or doc.get("kind") != "RequirementSet":
+        return []
+    out = []
+    for i, req in enumerate(doc.get("spec", {}).get("requirements", []) or []):
+        seen: dict[Any, str] = {}
+        for section in ("guards", "criteria"):
+            for j, p in enumerate(req.get(section, []) or []):
+                ident = predicate_identity(p)
+                where = f"spec/requirements/{i}/{section}/{j}"
+                if ident in seen:
+                    out.append(Finding(
+                        "identity", path, where,
+                        f"identity {ident!r} already used at {seen[ident]} — a rendering "
+                        f"could not tell these two predicates apart",
+                    ))
+                else:
+                    seen[ident] = where
+    return out
+
+
+# ----------------------------------------------------------------------------- files
+
+
+def check_file(path: str, validators: dict[str, Any], schema: bool = True) -> list[Finding]:
+    """Every check that applies to one file, in the order a reader wants them.
+
+    ``schema=False`` runs only the checks that bind every YAML file in the repository —
+    it parses, and it maps onto JSON. The sketches under ``docs/examples/`` are checked
+    that way on purpose: they illustrate constructs the format does not have, so holding
+    them to the schema would make them useless. Nothing else may opt out.
+    """
+    out = check_parses(path)
+    if out:
+        return out  # nothing below can run on a file that does not parse
+    out += check_jsonable(path)
+    if not schema:
+        return out
+    yaml = _yaml()
+    docs = [d for d in yaml.safe_load_all(open(path, encoding="utf-8"))]
+    if not docs or all(d is None for d in docs):
+        return out + [Finding("schema", path, "", "no document — a published file may not be empty")]
+    for doc in docs:
+        out += check_schema(doc, path, validators)
+        out += check_predicate_identity(doc, path)
+    return out
+
+
+def expand(patterns: Iterable[str]) -> list[str]:
+    files: list[str] = []
+    for pat in patterns:
+        files += glob.glob(pat, recursive=True)
+    return sorted(set(files))
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    schema = True
+    if args and args[0] == "--no-schema":
+        schema, args = False, args[1:]
+    if not args:
+        print(__doc__)
+        return 2
+    try:
+        validators = load_validators() if schema else {}
+    except DependencyMissing as e:
+        # A gate that skips itself reads exactly like a passing one.
+        print(f"  FAIL  {e}")
+        return 2
+    files = expand(args)
+    if not files:
+        print(f"  FAIL  no file matched {' '.join(args)} — nothing was checked")
+        return 2
+    rc = 0
+    for f in files:
+        try:
+            findings = check_file(f, validators, schema=schema)
+        except DependencyMissing as e:
+            print(f"  FAIL  {e}")
+            return 2
+        if findings:
+            rc = 1
+            for finding in findings:
+                print(f"  FAIL  {finding}")
+        else:
+            print(f"  ok    {f}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -24,176 +24,41 @@ ok()      { printf '  ok    %s\n' "$1"; }
 bad()     { printf '  FAIL  %s\n' "$1"; fail=1; }
 
 # ---------------------------------------------------------------------------
-section "YAML sketches parse"
+section "Documents parse, map onto JSON, and satisfy their schema"
+# One implementation, two callers: scripts/opennfr_check.py is what the conformance
+# corpus calls too. A corpus asserting against its own copy of these rules would prove
+# nothing about the gate that actually runs, and two copies drift — which is the failure
+# this repository exists to prevent, reproduced inside its own tooling.
+#
+# Exit codes from the module: 0 passed, 1 a document failed, 2 THE CHECK COULD NOT RUN.
+# The third is why there is no skip branch anywhere below.
 if ! command -v python3 >/dev/null 2>&1; then
-  bad "python3 not found — the YAML parse gate cannot run"
+  bad "python3 not found — the document gate cannot run"
 else
-  python3 - <<'PY'
-import glob, sys
-try:
-    import yaml
-except ImportError:
-    print("  FAIL  PyYAML not installed (pip install pyyaml)")
-    sys.exit(1)
-rc = 0
-files = sorted(glob.glob("examples/*.yaml") + glob.glob("docs/**/*.yaml", recursive=True))
-if not files:
-    print("  FAIL  no YAML document found to parse")
-    sys.exit(1)
-for f in files:
-    try:
-        list(yaml.safe_load_all(open(f, encoding="utf-8")))
-        print(f"  ok    {f}")
-    except Exception as e:
-        print(f"  FAIL  {f}: {e}")
-        rc = 1
-sys.exit(rc)
-PY
-  [ $? -eq 0 ] || fail=1
+  python3 scripts/opennfr_check.py \
+      'examples/*.yaml' 'mappings/*.yaml' 'conformance/**/*.yaml'
+  case $? in
+    0) : ;;
+    1) fail=1 ;;
+    *) bad "the document gate could not run" ;;
+  esac
 fi
 
 # ---------------------------------------------------------------------------
-section "Sketches map one-to-one onto JSON"
-# ADR-0002 D16: every object must map onto JSON, and anchors, aliases and merge
-# keys are forbidden outright. Both checks have to happen before safe_load_all
-# resolves them away: by the time it returns, an alias is an ordinary dict.
+section "Sketches parse and map onto JSON"
+# The sketches under docs/examples/ are held to ADR-0002 D16 like everything else, and
+# deliberately NOT to the schema: they illustrate constructs the format does not have,
+# so validating them would make them useless. Nothing else may opt out — see
+# AGENTS.md > Test Model.
 if ! command -v python3 >/dev/null 2>&1; then
-  bad "python3 not found — the JSON-mapping gate cannot run"
+  bad "python3 not found — the sketch gate cannot run"
 else
-  python3 - <<'JSONABLE' || fail=1
-import glob, math, sys
-try:
-    import yaml
-except ImportError:
-    print("  FAIL  PyYAML not installed (pip install pyyaml)"); sys.exit(1)
-rc = 0
-def scan_events(f):
-    """Anchors, aliases and merge keys, caught at the event level."""
-    global rc
-    for ev in yaml.parse(open(f, encoding="utf-8")):
-        if isinstance(ev, yaml.AliasEvent):
-            print(f"  FAIL  {f}: alias *{ev.anchor} — ADR-0002 D16 forbids aliases"); rc = 1
-        elif getattr(ev, "anchor", None):
-            print(f"  FAIL  {f}: anchor &{ev.anchor} — ADR-0002 D16 forbids anchors"); rc = 1
-        elif isinstance(ev, yaml.ScalarEvent) and ev.value == "<<":
-            print(f"  FAIL  {f}: merge key << — ADR-0002 D16 forbids merge keys"); rc = 1
-def walk(v, path, f):
-    global rc
-    if v is None or isinstance(v, (bool, str, int)):
-        return
-    if isinstance(v, float):
-        if not math.isfinite(v):
-            print(f"  FAIL  {f}: {path}: {v!r} has no JSON representation"); rc = 1
-        return
-    if isinstance(v, dict):
-        for k, x in v.items():
-            if not isinstance(k, str):
-                print(f"  FAIL  {f}: {path}: non-string key {k!r}"); rc = 1
-            walk(x, f"{path}/{k}", f)
-        return
-    if isinstance(v, list):
-        for i, x in enumerate(v):
-            walk(x, f"{path}/{i}", f)
-        return
-    print(f"  FAIL  {f}: {path}: {type(v).__name__} has no JSON equivalent ({v!r})")
-    rc = 1
-files = sorted(glob.glob("examples/*.yaml") + glob.glob("docs/examples/**/*.yaml", recursive=True))
-if not files:
-    print("  FAIL  no YAML document found to map onto JSON")
-    sys.exit(1)
-for f in files:
-    before = rc
-    scan_events(f)
-    for doc in yaml.safe_load_all(open(f, encoding="utf-8")):
-        walk(doc, "", f)
-    if rc == before:
-        print(f"  ok    {f}")
-sys.exit(rc)
-JSONABLE
-fi
-
-section "Examples validate against the schema"
-# The real gate. Every document in examples/, mappings/ and conformance/ must
-# satisfy the schema for its kind. The sketches under docs/examples/ are
-# deliberately outside it — see AGENTS.md > Test Model — because they illustrate
-# ideas the format does not have.
-#
-# LAYOUT.md § 6 warns that a document relocated into mappings/ silently stops
-# being checked. That hole is closed here rather than when the first file lands:
-# a kind with no schema is a FAIL, so the window in which something could arrive
-# unchecked never opens.
-if ! command -v python3 >/dev/null 2>&1; then
-  bad "python3 not found — the schema gate cannot run"
-else
-  python3 - <<'SCHEMA' || fail=1
-import glob, json, sys
-try:
-    import yaml
-    from jsonschema import Draft202012Validator
-except ImportError as e:
-    # A gate that skips itself reads exactly like a passing one.
-    print(f"  FAIL  {e.name} not installed (pip install jsonschema pyyaml)")
-    sys.exit(1)
-import os
-# kind -> validator. A kind absent from this table has no schema and is a failure,
-# never a pass. Entries appear as their schema files land.
-KINDS = {}
-for kind, name in (("RequirementSet", "requirementset"),
-                   ("TargetDescription", "targetdescription"),
-                   ("Rendering", "rendering")):
-    path = f"schema/opennfr.io/v1/{name}.schema.json"
-    if os.path.exists(path):
-        sch = json.load(open(path, encoding="utf-8"))
-        Draft202012Validator.check_schema(sch)
-        KINDS[kind] = Draft202012Validator(sch)
-rc = 0
-files = sorted(glob.glob("examples/*.yaml"))
-if not files:
-    print("  FAIL  examples/ holds no document to validate")
-    sys.exit(1)
-# mappings/ and conformance/ are validated too. They may hold only a README while
-# no YAML has landed yet, so an empty result here is not a failure — but any YAML
-# that does land is checked, or the FAIL below says nothing validates it.
-files += sorted(glob.glob("mappings/*.yaml") + glob.glob("conformance/**/*.yaml", recursive=True))
-for f in files:
-    docs = [d for d in yaml.safe_load_all(open(f, encoding="utf-8"))]
-    if not docs or all(d is None for d in docs):
-        print(f"  FAIL  {f}: no document — a published example may not be empty")
-        rc = 1
-        continue
-    for doc in docs:
-        if not isinstance(doc, dict):
-            print(f"  FAIL  {f}: top level is {type(doc).__name__}, expected a mapping")
-            rc = 1
-            continue
-        kind = doc.get("kind")
-        if kind not in KINDS:
-            print(f"  FAIL  {f}: kind {kind!r} has no schema — nothing validates this file")
-            rc = 1
-            continue
-        v = KINDS[kind]
-        errs = sorted(v.iter_errors(doc), key=lambda e: list(e.path))
-        for e in errs:
-            where = "/".join(map(str, e.path)) or "(root)"
-            print(f"  FAIL  {f}: {where}: {e.message}")
-        # criterionId is the name if set, otherwise the aggregation. The schema
-        # cannot express that fallback, so uniqueness is checked here.
-        for r in doc.get("spec", {}).get("requirements", []) or []:
-            for section in ("criteria", "guards"):
-                seen = set()
-                for p in r.get(section, []) or []:
-                    cid = p.get("name") or p.get("aggregation")
-                    if cid in seen:
-                        print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate criterionId {cid!r}")
-                        errs = errs or [1]
-                        rc = 1
-                    seen.add(cid)
-        if errs:
-            rc = 1
-        else:
-            print(f"  ok    {f}  [{kind}]")
-sys.exit(rc)
-SCHEMA
+  python3 scripts/opennfr_check.py --no-schema 'docs/**/*.yaml'
+  case $? in
+    0) : ;;
+    1) fail=1 ;;
+    *) bad "the sketch gate could not run" ;;
+  esac
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #27

## What changes

| File | Change |
|---|---|
| `scripts/opennfr_check.py` | **new** — parse, JSON-mappability, schema dispatch, predicate identity |
| `scripts/verify.sh` | three inline heredocs become two calls. **310 → 176 lines** |

## The substantive half: the identity rule was wrong

The `criterionId` uniqueness check reset its seen-set **per section**:

```python
for section in ("criteria", "guards"):
    seen = set()
```

So this passed:

```yaml
guards:
  - {aggregation: rate, op: gte, threshold: 200, unit: "{request}/s"}
criteria:
  - {aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}
```

Both identities are `rate`. Two predicates a rendering could not tell apart, waved through by
the gate that exists to catch exactly that — and the counting rule the rendering depends on
counts identities, so a collision makes the arithmetic meaningless before it is evaluated.

Identity is now counted across `criteria` **and** `guards` together, and the finding names both
positions. JSON Schema cannot express this: the key is computed and the uniqueness spans two
arrays, which is precisely why it lives in code and why that code must not exist twice.

## Why one module rather than two copies

The corpus needs the same answers as the gate. A corpus asserting against its own copy proves
nothing about the gate that actually runs, and two copies drift. That is the two-sources failure
this repository was founded on, pointed at its own tooling.

## Two design points worth a look

**`ran and failed` is not `could not run`.** The module exits `1` for the first and `2` for the
second, and `verify.sh` propagates both. There is no skip branch anywhere — that is the rule
four sections of this gate once did not have.

**The sketch exemption is now visible at the call site.** `--no-schema` runs parse and
JSON-mappability only. Sketches under `docs/examples/` are exempt from the schema and from
nothing else, because they illustrate constructs the format does not have. Putting the flag in
the command rather than in a glob means a reader sees the exemption instead of inferring it.

## Verified by mutation, seven for seven

| Mutation | |
|---|---|
| control, unmutated | exit 0 |
| schema violation in `examples/` | exit 1 |
| Cyrillic in `docs/` | exit 1 |
| anchor in a sketch | exit 1 |
| `examples/` emptied | exit 1 |
| dangling link | exit 1 |
| both dependencies removed | exit 1, **0 skip lines** |
| **guard/criterion identity clash** | exit 1 — the new one |

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #27` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally, and every check it performs was proved able to fail
- [x] No term changed
- [x] No ADR contradicted — ADR-0002 § D16's anchor/alias/merge-key rule is preserved verbatim, still scanned at the event level before `safe_load_all` resolves the evidence away

🤖 Generated with [Claude Code](https://claude.com/claude-code)