### PR TITLE
Describe Gatling as data, and publish the coverage bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 An attempt to work out what an open, tool-agnostic format for load testing requirements
 *could* look like. Right now this repository contains notes: a survey of existing
-solutions, a pile of naming arguments, and sketches of what a document might look like.
+solutions, a pile of naming arguments, a schema, and a first target described as data.
 
-> The vocabulary is not stable and there is no implementation. There is now a schema for
-> the requirement container — see [FORMAT.md](FORMAT.md) — but everything under `docs/` is
-> still notes. Every YAML block below is an illustration of an idea, not syntax —
-> field names change between sessions of thinking about them. Do not build anything on it
-> yet.
+> The vocabulary is not stable and nothing here renders. Three schemas exist — the
+> requirement container, a target's description, and what a correct rendering produces; see
+> [FORMAT.md](FORMAT.md) — and the examples under `examples/`, `mappings/` and
+> `conformance/` are validated against them on every commit. Everything under `docs/` is
+> still notes, and a YAML block there illustrates an idea rather than syntax. Do not build
+> anything on this yet.
 
 If you have opinions about any of this, that is exactly what the repository is for.
 
@@ -82,10 +83,14 @@ finding above. Whether that trade is worth it is not obvious.
 
 **A run that under-delivered load is not a pass.** If the generator never reached 200 rps,
 a latency threshold goes green and the verdict is a lie. This seems to be the most common
-failure mode in load testing reports, and none of the surveyed formats catches it. The
-sketch: preconditions that are checked like criteria but yield a third outcome —
-*inconclusive*, "the test did not happen" — rather than pass or fail. Whether it deserves
-to be a separate outcome or is just a fancy `fail` is arguable.
+failure mode in load testing reports, and none of the surveyed formats catches it. A
+requirement can state the condition, and it renders into an assertion the tool actually runs.
+
+It was going to be a third outcome — *inconclusive*, "the test did not happen". That was
+withdrawn: no surveyed tool has a third outcome, and a construct nothing can honour is a
+silent green of its own. The distinction survives in the rendering, which records which
+entries state a condition of the run rather than a property of the system, and which report
+line each will become.
 
 **Tool support as data, not code.** If integrating a tool means writing a mapping file
 rather than forking an implementation, the list of supported tools stops being capped by
@@ -97,49 +102,100 @@ and that is an open problem, not a solved one.
 rather than `"p95 < 500ms"`. More verbose, but no bespoke grammar has to be reimplemented
 in every backend. This is where Keptn and Taurus visibly struggle.
 
-## What a document might look like
+## What a document looks like
 
-Illustrative sketch. Field names are unstable.
+Not a sketch. This is [`examples/six-statements.yaml`](examples/six-statements.yaml), and
+`scripts/verify.sh` validates it against the schema on every commit — so the format cannot
+drift away from what this page teaches.
 
 ```yaml
 apiVersion: opennfr.io/v1
 kind: RequirementSet
 metadata:
-  name: checkout-perf
+  name: six-statements
 spec:
   requirements:
-    - name: checkout-latency
-      displayName: "Checkout responds quickly under target load"
+    - name: get-root-duration
+      displayName: Duration of GET /
       indicator:
         distribution:
-          metric: http.client.request.duration    # OTel semconv name, not ours
+          metric: http.client.request.duration   # an OpenTelemetry name, not ours
           selector:
-            http.request.method: POST
-            http.route: /api/v1/checkout
-      guards:                                     # violated -> inconclusive
-        - { aggregation: rate, op: gte, threshold: 190, unit: "{request}/s" }
-      criteria:                                   # violated -> fail
-        - { aggregation: p95, op: lte, threshold: 500,  unit: ms, severity: blocker }
-        - { aggregation: p99, op: lte, threshold: 1500, unit: ms, severity: warning }
+            loadtest.request.name: GET /
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 500, unit: ms}
+        - {displayName: Slowest,         aggregation: max, op: lte, threshold: 1000, unit: ms}
+
+    - name: all-requests-error-share
+      displayName: Share of failed requests
+      indicator:
+        ratio:                                   # a fraction, not a metric of its own
+          total:
+            metric: http.client.request.duration
+            selector: {}                         # {} is every request, said explicitly
+          bad:
+            metric: http.client.request.duration
+            selector:
+              error.type: "*"                    # the attribute is present, any value
+      criteria:
+        - {displayName: Failed share, aggregation: rate, op: lte, threshold: 5, unit: "%"}
 ```
+
+No tool is named anywhere in it — not in a field, a value, or a metric name.
+
+### What it becomes
+
+The document's job ends when it becomes the tool's own assertions. For Gatling, those two
+requirements render to:
+
+```scala
+setUp(...).assertions(
+  details("GET /").responseTime.percentile(99.0).lte(500),
+  details("GET /").responseTime.max.lte(1000),
+  global.failedRequests.percent.lte(5)
+)
+```
+
+The correspondence lives in [`mappings/gatling.yaml`](mappings/gatling.yaml) — how the target
+names things, **what it can and cannot assert**, how its units convert — with every claim
+carrying the source and the date it was checked. Adding a second tool is adding a second such
+file; the requirement document does not change.
+
+The expected output is pinned as data in
+[`conformance/render/six-statements/`](conformance/render/six-statements/), so any
+implementation, in any language, in any repository, has something to be checked against.
+
+### Two things the format refuses to do
+
+**It will not approximate.** Where a target cannot express a criterion exactly, the criterion
+is reported by name, with a reason, **before the run starts** — never replaced by the nearest
+thing the tool has. Every predicate is either rendered or named; there is no third bucket.
+
+**It will not name a derived quantity.** An error rate is a `ratio` over a metric that already
+exists, not a metric called `error_rate`. Throughput is `aggregation: rate`. A second
+vocabulary is a second source of truth, and the two diverge as soon as either changes.
 
 ## Known holes
 
 Not a roadmap — a list of things that are unresolved, some of which may sink the whole
 approach:
 
-- **Nothing is validated.** No JSON Schema exists, so the examples are prose that happens
-  to parse as YAML. The schema is the next thing to write, and it will expose whatever the
-  vocabulary leaves unsaid.
+- **A `ratio` names a metric it does not measure.** An error-rate requirement reads
+  `metric: http.client.request.duration`, because a histogram's count *is* the request count
+  and OpenTelemetry defines no HTTP client request counter. The document is correct and reads
+  as though it were about latency. Found by a reader; unsolved.
 - **Declaring "an error occurred" across tools.** k6 signals failure with a separate metric,
   JMeter with a boolean column, Gatling with KO. Expressing that declaratively without
   reinventing a rules DSL is unsolved.
+- **A target can pass on absent data, and nothing here can stop it.** One surveyed tool has an
+  assertion scope that exits *successfully* when it matches nothing. It is declared in that
+  target's description, because declaring it is the only move available.
 - **Percentiles come from histogram buckets**, so accuracy depends on bucket boundaries.
   Whether the format has to say anything about resolution is unclear.
-- **Whether load profiles belong here at all.** Describing the requirement is one thing;
-  describing the load that has to be generated is another, and it overlaps with what the
-  tools already do well. Currently out of scope, mostly out of caution.
-- **Baselines, time windows, streaming evaluation** — sketched, not thought through.
+- **Nothing here renders.** The corpus is an oracle: it says what a correct rendering produces
+  and is unfalsified until an implementation somewhere runs against it.
+- **Two targets do not prove the shape is neutral.** Any design drawn while looking at two
+  tools fits those two. The honest next probe is a third.
 
 ## Documents
 

--- a/conformance/render/six-statements/document.yaml
+++ b/conformance/render/six-statements/document.yaml
@@ -1,0 +1,69 @@
+# The coverage bar. Every statement the prior NFR-YAML could express, in one document,
+# with no tool named anywhere in it.
+#
+# The old format spelled these as six fixed keys — Russian sentences over a hardcoded
+# table — and could say nothing else. Here they are ordinary requirements, and a seventh
+# statement needs no change to anything.
+
+apiVersion: opennfr.io/v1
+kind: RequirementSet
+metadata:
+  name: six-statements
+  displayName: Everything the previous format could say
+
+spec:
+  requirements:
+
+    # 1-2. percentiles and the maximum, for one named request
+    - name: get-root-duration
+      displayName: Duration of GET /
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector:
+            loadtest.request.name: GET /
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 500, unit: ms}
+        - {displayName: 95th percentile, aggregation: p95, op: lte, threshold: 400, unit: ms}
+        - {displayName: 75th percentile, aggregation: p75, op: lte, threshold: 300, unit: ms}
+        - {displayName: Median,          aggregation: p50, op: lte, threshold: 200, unit: ms}
+        - {displayName: Slowest,         aggregation: max, op: lte, threshold: 1000, unit: ms}
+
+    # 3. the old composite key `MyGroup / MyRequest`, as two attributes on one selection
+    - name: checkout-submit-duration
+      displayName: Duration of the checkout submit, inside its group
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector:
+            loadtest.group.name: MyGroup
+            loadtest.request.name: MyRequest
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 900, unit: ms}
+
+    # 4. the old `all` key: an empty selector is every request, said explicitly
+    - name: all-requests-duration
+      displayName: Duration across every request
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector: {}
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 1000, unit: ms}
+        - {displayName: Slowest,         aggregation: max, op: lte, threshold: 2000, unit: ms}
+
+    # 5-6. the failed share. Not a metric of its own: a fraction of two selections over a
+    #      metric that already exists, which is why no `error_rate` name is coined.
+    - name: all-requests-error-share
+      displayName: Share of failed requests
+      indicator:
+        ratio:
+          total:
+            metric: http.client.request.duration
+            selector: {}
+          bad:
+            metric: http.client.request.duration
+            selector:
+              error.type: "*"
+      criteria:
+        - {displayName: Failed share, aggregation: rate, op: lte, threshold: 5, unit: "%"}

--- a/conformance/render/six-statements/rendering.gatling.yaml
+++ b/conformance/render/six-statements/rendering.gatling.yaml
@@ -1,0 +1,142 @@
+# What document.yaml becomes for this target. One entry per predicate, in document order:
+# for each requirement in order, its guards then its criteria. `rendered` and
+# `unrenderable` are projections of this one list — that is what makes the counting rule
+# hold by construction rather than by arithmetic.
+#
+# Each entry's `native.text` is dated evidence, not an authority. When it disagrees with
+# the normative tokens above it, the literal is the finding and the tokens are the bug.
+
+apiVersion: opennfr.io/v1
+kind: Rendering
+metadata:
+  name: six-statements-for-gatling
+
+spec:
+  document: six-statements
+  target:
+    description: gatling
+    version: "3.15.1"
+    checked: "2026-08-20"
+
+  predicates:
+
+    # ── get-root-duration ────────────────────────────────────────────────────────
+    - predicate: {requirement: get-root-duration, role: criterion, id: p99}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {request: GET /}
+            aggregation: percentile
+            percentile: 99
+            op: lte
+            threshold: 500
+            unit: ms
+            native:
+              text: 'details("GET /").responseTime.percentile(99.0).lte(500)'
+
+    - predicate: {requirement: get-root-duration, role: criterion, id: p95}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {request: GET /}
+            aggregation: percentile
+            percentile: 95
+            op: lte
+            threshold: 400
+            unit: ms
+            native:
+              text: 'details("GET /").responseTime.percentile(95.0).lte(400)'
+
+    - predicate: {requirement: get-root-duration, role: criterion, id: p75}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {request: GET /}
+            aggregation: percentile
+            percentile: 75
+            op: lte
+            threshold: 300
+            unit: ms
+            native:
+              text: 'details("GET /").responseTime.percentile(75.0).lte(300)'
+
+    - predicate: {requirement: get-root-duration, role: criterion, id: p50}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {request: GET /}
+            aggregation: percentile
+            percentile: 50
+            op: lte
+            threshold: 200
+            unit: ms
+            native:
+              text: 'details("GET /").responseTime.percentile(50.0).lte(200)'
+
+    - predicate: {requirement: get-root-duration, role: criterion, id: max}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {request: GET /}
+            aggregation: max
+            op: lte
+            threshold: 1000
+            unit: ms
+            native:
+              text: 'details("GET /").responseTime.max.lte(1000)'
+
+    # ── checkout-submit-duration — the old composite key, as a two-part path ──────
+    - predicate: {requirement: checkout-submit-duration, role: criterion, id: p99}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {group: MyGroup, request: MyRequest}
+            aggregation: percentile
+            percentile: 99
+            op: lte
+            threshold: 900
+            unit: ms
+            native:
+              text: 'details("MyGroup" / "MyRequest").responseTime.percentile(99.0).lte(900)'
+
+    # ── all-requests-duration — an empty selector is the whole run ────────────────
+    - predicate: {requirement: all-requests-duration, role: criterion, id: p99}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {}
+            aggregation: percentile
+            percentile: 99
+            op: lte
+            threshold: 1000
+            unit: ms
+            native:
+              text: 'global.responseTime.percentile(99.0).lte(1000)'
+
+    - predicate: {requirement: all-requests-duration, role: criterion, id: max}
+      rendered:
+        assertions:
+          - metric: responseTime
+            selector: {}
+            aggregation: max
+            op: lte
+            threshold: 2000
+            unit: ms
+            native:
+              text: 'global.responseTime.max.lte(2000)'
+
+    # ── all-requests-error-share ─────────────────────────────────────────────────
+    # The `bad` side's `error.type: "*"` is not a selection here: it is what makes the
+    # fraction the failed one, and this target has a statistic for exactly that. The
+    # selection comes from `total`, which is empty — the whole run.
+    - predicate: {requirement: all-requests-error-share, role: criterion, id: rate}
+      rendered:
+        assertions:
+          - metric: failedRequests
+            selector: {}
+            aggregation: percent
+            op: lte
+            threshold: 5
+            unit: "%"
+            native:
+              text: 'global.failedRequests.percent.lte(5)'

--- a/examples/six-statements.yaml
+++ b/examples/six-statements.yaml
@@ -1,0 +1,69 @@
+# The coverage bar. Every statement the prior NFR-YAML could express, in one document,
+# with no tool named anywhere in it.
+#
+# The old format spelled these as six fixed keys — Russian sentences over a hardcoded
+# table — and could say nothing else. Here they are ordinary requirements, and a seventh
+# statement needs no change to anything.
+
+apiVersion: opennfr.io/v1
+kind: RequirementSet
+metadata:
+  name: six-statements
+  displayName: Everything the previous format could say
+
+spec:
+  requirements:
+
+    # 1-2. percentiles and the maximum, for one named request
+    - name: get-root-duration
+      displayName: Duration of GET /
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector:
+            loadtest.request.name: GET /
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 500, unit: ms}
+        - {displayName: 95th percentile, aggregation: p95, op: lte, threshold: 400, unit: ms}
+        - {displayName: 75th percentile, aggregation: p75, op: lte, threshold: 300, unit: ms}
+        - {displayName: Median,          aggregation: p50, op: lte, threshold: 200, unit: ms}
+        - {displayName: Slowest,         aggregation: max, op: lte, threshold: 1000, unit: ms}
+
+    # 3. the old composite key `MyGroup / MyRequest`, as two attributes on one selection
+    - name: checkout-submit-duration
+      displayName: Duration of the checkout submit, inside its group
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector:
+            loadtest.group.name: MyGroup
+            loadtest.request.name: MyRequest
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 900, unit: ms}
+
+    # 4. the old `all` key: an empty selector is every request, said explicitly
+    - name: all-requests-duration
+      displayName: Duration across every request
+      indicator:
+        distribution:
+          metric: http.client.request.duration
+          selector: {}
+      criteria:
+        - {displayName: 99th percentile, aggregation: p99, op: lte, threshold: 1000, unit: ms}
+        - {displayName: Slowest,         aggregation: max, op: lte, threshold: 2000, unit: ms}
+
+    # 5-6. the failed share. Not a metric of its own: a fraction of two selections over a
+    #      metric that already exists, which is why no `error_rate` name is coined.
+    - name: all-requests-error-share
+      displayName: Share of failed requests
+      indicator:
+        ratio:
+          total:
+            metric: http.client.request.duration
+            selector: {}
+          bad:
+            metric: http.client.request.duration
+            selector:
+              error.type: "*"
+      criteria:
+        - {displayName: Failed share, aggregation: rate, op: lte, threshold: 5, unit: "%"}

--- a/mappings/gatling.yaml
+++ b/mappings/gatling.yaml
@@ -1,0 +1,309 @@
+# The first target description. Every claim below cites dated evidence, which the schema
+# enforces rather than trusts: an assertion about somebody else's software rots silently
+# without a date on it.
+#
+# Deliberately narrow. It covers one metric family, because a description enumerates
+# capability per combination and grows as metrics x path-kinds — see the open question in
+# docs/adr/0003-retire-conformance-levels.md. Adding a metric here is adding rows, and
+# nothing else in the repository changes.
+
+apiVersion: opennfr.io/v1
+kind: TargetDescription
+metadata:
+  name: gatling
+  displayName: Gatling — native assertions on the setUp DSL
+
+spec:
+  version: "3.15.1"
+
+  # ── EVIDENCE ────────────────────────────────────────────────────────────────────
+  evidence:
+    - id: assertion-support
+      source: "gatling/gatling — gatling-core/src/main/scala/io/gatling/core/assertion/AssertionSupport.scala @ v3.15.1"
+      checked: "2026-08-20"
+      states: >-
+        Three scopes exist and no more: AssertionPath.Global, AssertionPath.ForAll, and
+        AssertionPath.Details(parts). Only Details carries author strings.
+
+    - id: assertion-builders
+      source: "gatling/gatling — gatling-core/src/main/scala/io/gatling/core/assertion/AssertionBuilders.scala @ v3.15.1"
+      checked: "2026-08-20"
+      states: >-
+        The single construction site is Assertion(path, target, condition) — three fields,
+        no label. responseTime offers min, max, mean, stdDev and percentile(Double), typed
+        AssertionWithPathAndTarget[Int]. allRequests, failedRequests and successfulRequests
+        each offer count and percent; requestsPerSec is a Double target. Conditions are lt,
+        lte, gt, gte, between, around, deviatesAround, is and in. There is no abort.
+
+    - id: assertion-path-parts
+      source: "gatling/gatling — gatling-core/src/main/scala/io/gatling/core/assertion/AssertionPathParts.scala @ v3.15.1"
+      checked: "2026-08-20"
+      states: >-
+        AssertionPathParts(parts: List[String]) with a `/` method appending one part, so
+        details("A" / "B") is the two-element path [A, B].
+
+    - id: run-result-processor
+      source: "gatling/gatling — gatling-app/src/main/scala/io/gatling/app/RunResultProcessor.scala @ v3.15.1"
+      checked: "2026-08-20"
+      states: >-
+        The console line is AssertionMessage.message(assertionResult.assertion) — a function
+        of the assertion alone. No per-assertion metadata is threaded in.
+
+    - id: assertion-model-3-9-5
+      source: "gatling/gatling — gatling-commons-shared/src/main/scala/io/gatling/commons/stats/assertion/AssertionModel.scala @ v3.9.5"
+      checked: "2026-08-20"
+      states: >-
+        The last open-source definition of the type: final case class Assertion(path,
+        target, condition). Printable forms are constants per ADT case — Global prints
+        "Global", Details prints its parts joined. No case carries author text except
+        Details.
+
+    - id: units-doc
+      source: "opennfr — docs/units.md"
+      checked: "2026-08-21"
+      states: >-
+        Seconds are the canonical time unit; a threshold written in ms is converted before
+        comparison.
+
+  # ── WHAT A NATIVE ASSERTION IS MADE OF, HERE ────────────────────────────────────
+  # Declared per file so a third target with a different assertion shape needs no schema
+  # edit. This order is also the serialisation order, which is half of determinism.
+  native:
+    fields: [scope, path, statistic, reduce, percentile, condition, value]
+    evidence: [assertion-support, assertion-builders]
+
+  # ── HOW THIS TARGET BUILDS ITS OWN REPORT LINE ──────────────────────────────────
+  # Load-bearing: two predicates whose projections onto derivedFrom are equal are
+  # INDISTINGUISHABLE in this target's report. The corpus reports such a pair rather than
+  # failing on it — a collision is a fact about the target, not an error in the document.
+  report:
+    derivedFrom: [scope, selection, metric, aggregation, comparison, threshold]
+    carriesAuthorName: false
+    evidence: [assertion-builders, run-result-processor, assertion-model-3-9-5]
+
+  # ── WHERE THIS TARGET CAN PASS ON ABSENT DATA ───────────────────────────────────
+  absentData:
+    canPass: true
+    conditions:
+      - when: scope-expands-to-nothing
+        detail: >-
+          A ForAll assertion expands to the requests observed in the run. If none were
+          observed it yields zero results and the run exits successful — nothing failed
+          because nothing was checked. A rendering may pair such a predicate with a
+          companion assertion the target can fail; that is one predicate becoming two
+          assertions, which the counting rule expressly permits.
+      - when: selection-matched-nothing
+        detail: >-
+          A details(...) path that matches no recorded request fails with a resolution
+          error rather than passing — the opposite behaviour, and worth recording next to
+          the first so the difference is not read as an inconsistency in this file.
+    evidence: [assertion-support]
+
+  # ── UNITS, as exact ratios. Never floats: FR-013 needs exact representability, and a
+  #    floating-point conversion cannot decide it.
+  units:
+    - {from: s,  to: ms, multiplyBy: {numerator: 1000, denominator: 1}, evidence: [units-doc]}
+    - {from: ms, to: ms, multiplyBy: {numerator: 1, denominator: 1}, evidence: [units-doc]}
+    - {from: "1", to: "%", multiplyBy: {numerator: 100, denominator: 1}, evidence: [assertion-builders]}
+    - {from: "%", to: "%", multiplyBy: {numerator: 1, denominator: 1}, evidence: [assertion-builders]}
+    - {from: "{request}/s", to: "{request}/s", multiplyBy: {numerator: 1, denominator: 1}, evidence: [assertion-builders]}
+
+  # ── NAMES ───────────────────────────────────────────────────────────────────────
+  names:
+    metrics:
+      - canonical: http.client.request.duration
+        native: responseTime
+        evidence: [assertion-builders]
+    attributes:
+      - canonical: loadtest.request.name
+        native: request
+        evidence: [assertion-support, assertion-path-parts]
+      - canonical: loadtest.group.name
+        native: group
+        evidence: [assertion-support, assertion-path-parts]
+    # REQUIRED. Without it the infinite complement is undefined and an unlisted metric
+    # would fall through as supported — the wrong default under Principle III.
+    unlisted:
+      metric:
+        reason: no-such-metric
+        detail: >-
+          Assertions reach response time and request counts only. No other metric family
+          is addressable from the assertion DSL, including the request- and response-body
+          sizes the document can name.
+        evidence: [assertion-builders]
+      attribute:
+        reason: no-such-selection
+        detail: >-
+          Selection is a path of recorded group and request names. Nothing else is
+          addressable — not a route, not a method, not a status code, not an error type.
+        evidence: [assertion-support, assertion-path-parts]
+
+  # ── THE CAPABILITY TABLE ────────────────────────────────────────────────────────
+  # Exact-match lookup on (shape, metric, side, selections). Nothing is expanded by rule:
+  # there is no inference step for a reader to simulate. Capabilities and gaps partition
+  # each axis, so a combination in neither half is a defect of THIS FILE, caught by the
+  # corpus rather than discovered at render time.
+  assertable:
+
+    # ── latency, over the whole run or one identified request ──────────────────────
+    - shape: distribution
+      metric: http.client.request.duration
+      selections:
+        - []                                              # every request -> global
+        - [loadtest.request.name]                          # -> details("name")
+        - [loadtest.group.name, loadtest.request.name]     # -> details("group" / "name")
+      aggregations:
+        "p*":
+          parts:
+            - {field: scope,      value: {from: selection}}
+            - {field: statistic,  value: {literal: responseTime}}
+            - {field: reduce,     value: {literal: percentile}}
+            - {field: percentile, value: {from: percentile}}
+            - {field: condition,  value: {from: comparison}}
+            - {field: value,      value: {from: threshold}}
+          value:
+            unit: ms
+            # Int, so a fractional millisecond is NOT representable and its predicate is
+            # unrenderable rather than rounded. Rounding would move the bar silently.
+            domain: {kind: integer, minimum: 0, maximum: 2147483647}
+          evidence: [assertion-builders]
+        max:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: responseTime}}
+            - {field: reduce,    value: {literal: max}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: ms, domain: {kind: integer, minimum: 0, maximum: 2147483647}}
+          evidence: [assertion-builders]
+        min:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: responseTime}}
+            - {field: reduce,    value: {literal: min}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: ms, domain: {kind: integer, minimum: 0, maximum: 2147483647}}
+          evidence: [assertion-builders]
+        avg:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: responseTime}}
+            - {field: reduce,    value: {literal: mean}}    # `avg` here is `mean` there
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: ms, domain: {kind: integer, minimum: 0, maximum: 2147483647}}
+          evidence: [assertion-builders]
+        stddev:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: responseTime}}
+            - {field: reduce,    value: {literal: stdDev}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: ms, domain: {kind: integer, minimum: 0, maximum: 2147483647}}
+          evidence: [assertion-builders]
+        rate:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: requestsPerSec}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: "{request}/s", domain: {kind: real, minimum: 0}}
+          evidence: [assertion-builders]
+        count:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: allRequests}}
+            - {field: reduce,    value: {literal: count}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: "{request}", domain: {kind: integer, minimum: 0}}
+          evidence: [assertion-builders]
+      aggregationGaps:
+        - aggregation: sum
+          reason: no-such-aggregation
+          detail: >-
+            responseTime offers min, max, mean, stdDev and percentile. There is no sum, and
+            no arithmetic that would produce one from what the DSL exposes.
+          evidence: [assertion-builders]
+      comparisons: {lt: lt, lte: lte, gt: gt, gte: gte, eq: is}
+      comparisonGaps:
+        - op: neq
+          reason: no-such-comparison
+          detail: >-
+            Conditions are lt, lte, gt, gte, between, around, deviatesAround, is and in.
+            There is no negation, and `in` over the complement is not expressible for a
+            continuous quantity.
+          evidence: [assertion-builders]
+
+    # ── the failed share of requests ───────────────────────────────────────────────
+    - shape: ratio
+      metric: http.client.request.duration
+      side: bad
+      selections:
+        - []
+        - [loadtest.request.name]
+        - [loadtest.group.name, loadtest.request.name]
+      aggregations:
+        rate:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: failedRequests}}
+            - {field: reduce,    value: {literal: percent}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          # percent, 0..100 — not a 0..1 rate. The conversion is declared in units above.
+          value: {unit: "%", domain: {kind: real, minimum: 0, maximum: 100}}
+          evidence: [assertion-builders]
+        count:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: failedRequests}}
+            - {field: reduce,    value: {literal: count}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: "{request}", domain: {kind: integer, minimum: 0}}
+          evidence: [assertion-builders]
+      aggregationGaps: []
+      comparisons: {lt: lt, lte: lte, gt: gt, gte: gte, eq: is}
+      comparisonGaps:
+        - op: neq
+          reason: no-such-comparison
+          detail: "No negating condition exists."
+          evidence: [assertion-builders]
+
+    # ── the successful share of requests ───────────────────────────────────────────
+    - shape: ratio
+      metric: http.client.request.duration
+      side: good
+      selections:
+        - []
+        - [loadtest.request.name]
+        - [loadtest.group.name, loadtest.request.name]
+      aggregations:
+        rate:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: successfulRequests}}
+            - {field: reduce,    value: {literal: percent}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: "%", domain: {kind: real, minimum: 0, maximum: 100}}
+          evidence: [assertion-builders]
+        count:
+          parts:
+            - {field: scope,     value: {from: selection}}
+            - {field: statistic, value: {literal: successfulRequests}}
+            - {field: reduce,    value: {literal: count}}
+            - {field: condition, value: {from: comparison}}
+            - {field: value,     value: {from: threshold}}
+          value: {unit: "{request}", domain: {kind: integer, minimum: 0}}
+          evidence: [assertion-builders]
+      aggregationGaps: []
+      comparisons: {lt: lt, lte: lte, gt: gt, gte: gte, eq: is}
+      comparisonGaps:
+        - op: neq
+          reason: no-such-comparison
+          detail: "No negating condition exists."
+          evidence: [assertion-builders]


### PR DESCRIPTION
Closes #29

## What changes

| File | |
|---|---|
| `mappings/gatling.yaml` | **new** — the first target description |
| `conformance/render/six-statements/` | **new** — document + rendering |
| `examples/six-statements.yaml` | **new** — the same document, under the gate |
| `README.md` | its example taught a format that no longer exists |

## Six for six

Everything the previous NFR-YAML could express, in one document with no tool named in it:

| Old key | Now |
|---|---|
| four percentile keys | `aggregation: p99` / `p95` / `p75` / `p50` |
| maximum response time | `aggregation: max` |
| percent of failed requests | a `ratio` whose `bad` side selects `error.type: "*"` |
| `MyGroup / MyRequest` | two attributes on one selection — no composite string to parse |
| `all` | `selector: {}`, said explicitly |

Nine predicates, nine rendering entries, in document order, identities matching, no
report-line collisions. Checked, not asserted.

## Three declarations worth more than the capability table

**`report.carriesAuthorName: false`.** This target derives every printed string from the
assertion itself. Two predicates with equal projections onto `report.derivedFrom` are
indistinguishable in its output — declaring that is what makes a collision *reportable* instead
of a surprise.

**`absentData.canPass: true`.** A `ForAll` assertion that expands to nothing yields zero results
and **exits successful**. Nothing outside this file can discover it; nothing downstream can
prevent it. Its opposite is recorded beside it — a `details(...)` path matching nothing *fails*
— so the difference is not misread as an inconsistency in the file.

**Integer milliseconds.** Response-time thresholds are typed `Int`, so a fractional millisecond
makes its predicate unrenderable rather than rounded. Rounding would move the bar by half a
millisecond and nobody would ever know.

## The README was teaching the wrong format

Its example carried `severity: blocker` and guards that "yield inconclusive" — both now
forbidden — and *Known holes* still said "No JSON Schema exists". It is the first thing anyone
reads.

Rewritten around the validated example, the Scala it renders to, and the two things the format
refuses to do: it will not approximate, and it will not name a derived quantity. *Known holes*
now leads with the `ratio` readability defect a reader found — an error-rate requirement names
`http.client.request.duration`, a metric it does not measure — and states plainly that nothing
here renders.

## Deliberately narrow

One metric family. A description enumerates capability per combination and grows as *metrics ×
path-kinds*, which is the unanswered open question in ADR-0003. Adding a metric is adding rows
and nothing else — which is the claim `mappings/` exists to make, so it should be easy to check.

## Checklist

- [x] Milestone assigned (v0.2.0)
- [x] `Closes #29` points at an issue in the same milestone
- [x] `bash scripts/verify.sh` passes locally
- [x] No term changed — the vocabulary landed in #22
- [x] No ADR contradicted — ADR-0003's open question about description volume is cited in the file it is about

🤖 Generated with [Claude Code](https://claude.com/claude-code)