### PR TITLE
Fix the five open defects in milestone v0.3.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -3,48 +3,49 @@
 # can be re-applied later.  Keep it committed.
 _commit: d8b7cd1
 _src_path: gh:galax-io/spec-kit-galaxio-bootstrap
-architecture: 'The vocabulary is the source of truth: `docs/GLOSSARY.md` defines the
-    terms, the ADRs justify them, and everything else must follow. The intended runtime
-    layering (types -> evaluation -> data sources -> tool adapters) is described in
-    docs/compatibility.md and exists only on paper. Compatibility-sensitive: any OpenTelemetry
-    semantic convention name borrowed by the format, and any field name that appears
-    in an example.'
+architecture: 'The schema decides; `README.md` explains it and is the only document that describes
+  a field. `GLOSSARY.md` defines the terms the schema carries. Compatibility-sensitive: any
+  OpenTelemetry semantic convention name borrowed by the format, and any field name that appears
+  in a published example.'
 build_test_cmd: bash scripts/verify.sh
 commands: '# verify      bash scripts/verify.sh    (YAML parses, links resolve, docs
     are English)
 
-    # links       grep-based, inside verify.sh
+    # links       inside verify.sh, via scripts/mdlinks.py
 
     # yaml        python3 -c ''import yaml,glob; [list(yaml.safe_load_all(open(f)))
-    for f in glob.glob("docs/**/*.yaml", recursive=True)]''
+    for f in glob.glob("examples/*.yaml")]''
 
     # no build, no tests — there is nothing to compile yet'
-dep_manifest: none yet — no code. docs/GLOSSARY.md is the vocabulary truth
+dep_manifest: none yet — no code. GLOSSARY.md is the vocabulary truth
 do_git: false
 org_repo: galax-io/opennfr
 project_name: OpenNFR
-project_tagline: Design notes toward an open, tool-agnostic format for load testing
-    requirements. Consumers will be load-test adapters and CI backends; the document
-    vocabulary and the OpenTelemetry metric names it borrows are the compatibility
-    surface. Nothing is stable yet.
+project_tagline: An open, tool-agnostic format for load testing requirements. One JSON Schema,
+  a validated corpus, and one document describing every field. Consumers will be load-test
+  adapters and CI backends; the vocabulary and the OpenTelemetry names it borrows are the
+  compatibility surface. Nothing is stable yet.
 publish_mechanism: GitHub Release only — nothing is published to a registry yet
 release_notes_tool: git-cliff
-role: 'Principal Engineer: format and specification design, load testing, observability.
-    This repo is a design notebook, not a product — prefer precision of vocabulary
-    over features, and treat every added term as a cost. Argue in issues before writing
-    files.'
+role: 'Principal Engineer: format and specification design, load testing, observability. The
+  format is minimally usable — a schema, a validated corpus and a gate — and nothing renders
+  or evaluates yet. Prefer precision of vocabulary over features, and treat every added term
+  as a cost. Argue in issues before writing files.'
 run_speckit: false
 stack: generic
-stack_detail: No code. Markdown notes plus YAML sketches that nothing validates, because
-    there is no schema yet. A Go reference implementation is anticipated (docs/adr/0002-compatibility.md)
-    but not started; constructs are already screened for whether they decode without
-    a custom unmarshaler.
-structure: '`docs/` -> the notes themselves; `docs/adr/` -> naming arguments in ADR
-    form (status: proposed); `docs/examples/` -> unvalidated sketches of documents;
-    `docs/semconv/` -> proposed `loadtest.*` attribute registry; `docs/references.md`
-    -> survey of prior art, the most finished part; `specs/` -> spec-kit working dir.'
-test_model: Nothing is testable yet — `scripts/verify.sh` only checks that the notes
-    are internally consistent (YAML parses, internal links resolve, the docs stayed
-    English). Once a JSON Schema exists, every file in docs/examples/ must validate
-    against it, and that becomes the real gate.
+stack_detail: No code. One JSON Schema (`schema/opennfr.io/v1/requirementset.schema.json`),
+  documents validated against it in `examples/`, and markdown. A Go reference implementation
+  is anticipated but not started; constructs are already screened for whether they decode
+  without a custom unmarshaler.
+structure: '`README.md` -> the format: what it is, and every field; `schema/` -> the schema,
+  which decides; `examples/` -> the validated corpus; `GLOSSARY.md` -> the terms; `CONTRIBUTING.md`
+  -> how to propose a change; `scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`);
+  `docs/ideas.md` -> constructs the format does not have; `specs/` -> spec-kit working dir,
+  read as history.'
+test_model: '`scripts/verify.sh` is the gate. It validates every document in `examples/` against
+  `schema/opennfr.io/v1/`, checks each predicate matches a row of the Gatling capability table
+  exactly, rejects YAML that cannot map onto JSON (anchors, aliases, merge keys, non-finite
+  numbers), and checks that links resolve, that `docs/` is markdown-only with every idea stating
+  its condition and nothing outside linking in, and that the docs stayed English. `examples/` is
+  the validated corpus and the only place documents are published.'
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,9 @@ scratchpad-*.sh
 scratchpad-*.log
 speckit-install.log
 
+# python bytecode — scripts/verify.sh imports scripts/mdlinks.py
+__pycache__/
+*.pyc
+
 # build output
 # extend per stack: target/, build/, dist/, node_modules/, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ No code. One JSON Schema (`schema/opennfr.io/v1/requirementset.schema.json`), do
 <!-- A LIGHT search index, not a full tree. List only the entry points an agent needs
      to FIND code fast — one terse line per area (`dir/ -> what lives there`). Omit
      anything discoverable by looking; an exhaustive tree is noise and rots fast. -->
-`README.md` -> the format: what it is, and every field; `schema/` -> the schema, which decides; `examples/` -> the validated corpus; `GLOSSARY.md` -> the terms; `CONTRIBUTING.md` -> how to propose a change; `docs/ideas.md` -> constructs the format does not have; `specs/` -> spec-kit working dir, read as history.
+`README.md` -> the format: what it is, and every field; `schema/` -> the schema, which decides; `examples/` -> the validated corpus; `GLOSSARY.md` -> the terms; `CONTRIBUTING.md` -> how to propose a change; `scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`); `docs/ideas.md` -> constructs the format does not have; `specs/` -> spec-kit working dir, read as history.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ No code. One JSON Schema (`schema/opennfr.io/v1/requirementset.schema.json`), do
 
 ```bash
 # verify      bash scripts/verify.sh    (YAML parses, links resolve, docs are English)
-# links       grep-based, inside verify.sh
+# links       inside verify.sh, via scripts/mdlinks.py
 # yaml        python3 -c 'import yaml,glob; [list(yaml.safe_load_all(open(f))) for f in glob.glob("examples/*.yaml")]'
 # no build, no tests — there is nothing to compile yet
 ```

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ keys are attribute names and cannot be enumerated in advance.
 
 | Field | | Constraint |
 |---|---|---|
-| `name` | **required** | `^[a-z0-9]` then letters, digits and hyphens, no trailing hyphen; max 253 characters |
+| `name` | **required** | matches `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`; max 253 characters |
 | `displayName` | optional | 1–200 characters, any script |
 | `annotations` | optional | map of string to string |
 

--- a/README.md
+++ b/README.md
@@ -478,9 +478,11 @@ against, and it would be an odd thing for this page to hand you.
 | a requirement with no `selector` | `'selector' is a required property` |
 | `criteria: []` | `[] should be non-empty` |
 
-> **A wart worth knowing.** When a predicate is wrong for any reason, the closure over it fails too,
-> and you get a second message alongside the useful one: `Unevaluated properties are not allowed`,
-> listing keys that are all perfectly valid. Read the other message.
+One mistake is usually one message. A misspelled key is the exception, and both of its messages
+name the same typo: `Additional properties are not allowed ('agregation' was unexpected)` beside
+`'aggregation' is a required property`. Where a mistake breaks two rules at once — `p95` with
+`bad` is both a percentile over a fraction and a percentile with no metric — you get one message
+per rule, and both are real.
 
 ### What the schema does not check
 

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -56,6 +56,7 @@
   "$defs": {
     "predicate": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "aggregation",
         "op",
@@ -85,7 +86,7 @@
         "metric": {
           "type": "string",
           "minLength": 1,
-          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions where one exists; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry — a count, a rate, or a fraction with `bad`/`good`."
+          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions where one exists; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry \u2014 a count, a rate, or a fraction with `bad`/`good`."
         },
         "bad": {
           "$ref": "#/$defs/selector",
@@ -235,27 +236,16 @@
         "guards": {
           "type": "array",
           "minItems": 1,
-          "description": "Preconditions: statements that the run happened in the intended regime at all. Same shape as a criterion, and the difference is what a violation means — a criterion says the system did not hold, a guard says the run did not happen as intended, so a green criterion beside a violated guard is not evidence of anything. Optional, and a requirement without one asserts nothing about the conditions it assumes.",
+          "description": "Preconditions: statements that the run happened in the intended regime at all. Same shape as a criterion, and the difference is what a violation means \u2014 a criterion says the system did not hold, a guard says the run did not happen as intended, so a green criterion beside a violated guard is not evidence of anything. Optional, and a requirement without one asserts nothing about the conditions it assumes.",
           "items": {
-            "allOf": [
-              {
-                "$ref": "#/$defs/predicate"
-              }
-            ],
-            "properties": {},
-            "unevaluatedProperties": false
+            "$ref": "#/$defs/predicate"
           }
         },
         "criteria": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "allOf": [
-              {
-                "$ref": "#/$defs/predicate"
-              }
-            ],
-            "unevaluatedProperties": false
+            "$ref": "#/$defs/predicate"
           }
         },
         "displayName": {
@@ -263,7 +253,7 @@
         },
         "selector": {
           "$ref": "#/$defs/selector",
-          "description": "Which requests this requirement is about — written once, for every criterion and guard under it. `{}` is every request."
+          "description": "Which requests this requirement is about \u2014 written once, for every criterion and guard under it. `{}` is every request."
         }
       },
       "allOf": [
@@ -395,7 +385,7 @@
     },
     "selector": {
       "type": "object",
-      "description": "Selects time series by attribute. {} means every series. A value of \"*\" means the attribute is present with any value. Attribute names are not enumerated — they are borrowed from OpenTelemetry, whose values may be strings, numbers or booleans.",
+      "description": "Selects time series by attribute. {} means every series. A value of \"*\" means the attribute is present with any value. Attribute names are not enumerated \u2014 they are borrowed from OpenTelemetry, whose values may be strings, numbers or booleans.",
       "examples": [
         {},
         {
@@ -425,7 +415,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 200,
-      "description": "Free human-readable text beside the machine identifier, in any script. `name` is restricted so something can point at it; this is for a person to read. It is inert: nothing selected, measured or compared depends on it, and two documents differing only in their display names say the same thing. Keep it to the quantity, not the answer — a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number, and the two diverge the first time the threshold moves."
+      "description": "Free human-readable text beside the machine identifier, in any script. `name` is restricted so something can point at it; this is for a person to read. It is inert: nothing selected, measured or compared depends on it, and two documents differing only in their display names say the same thing. Keep it to the quantity, not the answer \u2014 a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number, and the two diverge the first time the threshold moves."
     }
   }
 }

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -86,7 +86,7 @@
         "metric": {
           "type": "string",
           "minLength": 1,
-          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions where one exists; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry \u2014 a count, a rate, or a fraction with `bad`/`good`."
+          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions where one exists; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry — a count, a rate, or a fraction with `bad`/`good`."
         },
         "bad": {
           "$ref": "#/$defs/selector",
@@ -236,7 +236,7 @@
         "guards": {
           "type": "array",
           "minItems": 1,
-          "description": "Preconditions: statements that the run happened in the intended regime at all. Same shape as a criterion, and the difference is what a violation means \u2014 a criterion says the system did not hold, a guard says the run did not happen as intended, so a green criterion beside a violated guard is not evidence of anything. Optional, and a requirement without one asserts nothing about the conditions it assumes.",
+          "description": "Preconditions: statements that the run happened in the intended regime at all. Same shape as a criterion, and the difference is what a violation means — a criterion says the system did not hold, a guard says the run did not happen as intended, so a green criterion beside a violated guard is not evidence of anything. Optional, and a requirement without one asserts nothing about the conditions it assumes.",
           "items": {
             "$ref": "#/$defs/predicate"
           }
@@ -253,42 +253,9 @@
         },
         "selector": {
           "$ref": "#/$defs/selector",
-          "description": "Which requests this requirement is about \u2014 written once, for every criterion and guard under it. `{}` is every request."
+          "description": "Which requests this requirement is about — written once, for every criterion and guard under it. `{}` is every request."
         }
       },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "indicator": {
-                "required": [
-                  "ratio"
-                ]
-              }
-            },
-            "required": [
-              "indicator"
-            ]
-          },
-          "then": {
-            "properties": {
-              "criteria": {
-                "items": {
-                  "properties": {
-                    "aggregation": {
-                      "enum": [
-                        "rate",
-                        "count"
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "description": "UNREACHABLE. `indicator` was removed from `requirement`, which closes over its properties, so this `if` can never be satisfied by a document that validates. The rule it encodes survives in the predicate as `A fraction has no percentile`. Kept only because removing it is issue #38 and not this change; the text no longer cites a document for a rule that document does not state."
-        }
-      ],
       "examples": [
         {
           "name": "checkout",
@@ -385,7 +352,7 @@
     },
     "selector": {
       "type": "object",
-      "description": "Selects time series by attribute. {} means every series. A value of \"*\" means the attribute is present with any value. Attribute names are not enumerated \u2014 they are borrowed from OpenTelemetry, whose values may be strings, numbers or booleans.",
+      "description": "Selects time series by attribute. {} means every series. A value of \"*\" means the attribute is present with any value. Attribute names are not enumerated — they are borrowed from OpenTelemetry, whose values may be strings, numbers or booleans.",
       "examples": [
         {},
         {
@@ -415,7 +382,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 200,
-      "description": "Free human-readable text beside the machine identifier, in any script. `name` is restricted so something can point at it; this is for a person to read. It is inert: nothing selected, measured or compared depends on it, and two documents differing only in their display names say the same thing. Keep it to the quantity, not the answer \u2014 a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number, and the two diverge the first time the threshold moves."
+      "description": "Free human-readable text beside the machine identifier, in any script. `name` is restricted so something can point at it; this is for a person to read. It is inert: nothing selected, measured or compared depends on it, and two documents differing only in their display names say the same thing. Keep it to the quantity, not the answer — a name reading '99th percentile under 500 ms' beside threshold: 500 is a second source for one number, and the two diverge the first time the threshold moves."
     }
   }
 }

--- a/scripts/mdlinks.py
+++ b/scripts/mdlinks.py
@@ -1,0 +1,214 @@
+"""One definition of a markdown link, for the two gate sections that need one.
+
+`scripts/verify.sh` scans links twice: once to check they resolve, once to check that nothing
+outside `docs/` links into it. Those two scanners MUST agree on what a link is. When they
+disagreed, the same code span passed one gate and failed the other, and documenting the isolation
+rule became impossible — the text describing a link read, to one of the gates, as a link.
+
+Issue #43 was this file's reason for existing: a `grep` for `](` cannot tell a link from a regular
+expression that happens to close a bracket group with a parenthesis. The first fix for it was a
+handful of `re.DOTALL` regexes, and they were worse than the grep in the way that matters here —
+they masked *more* than the code they were aiming at, so a stray backtick in prose could hide a
+genuinely dangling link and the gate went green. Principle III ranks that below the loud
+false positive it replaced.
+
+So the rule this module is built on: **when in doubt, report the link.** Masking is the dangerous
+direction, because a mask that is too wide is silent. Every gap listed under KNOWN GAPS below errs
+the other way — the gate over-reports, a human sees the FAIL and fixes it in a minute.
+
+Behaviour here is checked against a real CommonMark renderer, not against reasoning about the
+spec; `selftest()` carries the cases and the gate runs it before trusting anything in this file.
+
+KNOWN GAPS, all in the safe direction (the gate over-reports, never under-reports):
+
+  - An indented (four-space) code block is not masked, so link-shaped text inside one is checked.
+    Deliberate: detecting one correctly needs list-item context, and getting it wrong would blank
+    the indented continuation lines this repository's task files are full of — turning real links
+    invisible, which is the failure this module exists to avoid.
+  - A link destination split across lines is not scanned. The `grep` this replaced was line-based
+    and never saw them either.
+  - Reference-style links (`[a][b]` with `[b]: target` elsewhere) are not resolved.
+"""
+
+import os
+import re
+
+# An opening fence: up to three spaces, then three or more backticks or tildes. A backtick fence's
+# info string may not itself contain a backtick — without that rule, a line like "```yaml``` is the
+# marker." reads as a fence and swallows everything to the next fence-looking line.
+FENCE_OPEN = re.compile(r"^(?P<quote>(?: {0,3}>)*) {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+LINK = re.compile(r"\]\(([^)\n]+)\)")
+
+# Only the two schemes the previous implementation excluded, so no relative path containing a colon
+# is silently dropped as though it were a URL.
+SCHEME = re.compile(r"^(https?|mailto):", re.IGNORECASE)
+
+
+def _mask_spans(line):
+    """Blank inline code spans in one line, preserving length.
+
+    Per-line by design. A code span may legally cross lines in CommonMark, but scanning the whole
+    file at once meant one unpaired backtick could mask every link to the end of the document. The
+    blast radius of a stray backtick is now the line it sits on.
+
+    A backslash-escaped backtick cannot OPEN a span — it is literal text — but it can CLOSE one,
+    because inside a span a backslash is already literal. Both halves are load-bearing: barring it
+    from closing hides the links after a span that ends in one; letting it open hides the links
+    after a stray escape in prose.
+    """
+    runs = []
+    i, n = 0, len(line)
+    while i < n:
+        if line[i] == "`":
+            j = i
+            while j < n and line[j] == "`":
+                j += 1
+            backslashes = 0
+            k = i - 1
+            while k >= 0 and line[k] == "\\":
+                backslashes += 1
+                k -= 1
+            runs.append((i, j, backslashes % 2 == 1))
+            i = j
+        else:
+            i += 1
+
+    out = list(line)
+    idx = 0
+    while idx < len(runs):
+        start, end, escaped = runs[idx]
+        if escaped:
+            idx += 1
+            continue
+        width = end - start
+        closer = next((j for j in range(idx + 1, len(runs))
+                       if runs[j][1] - runs[j][0] == width), None)
+        if closer is None:
+            idx += 1
+            continue
+        for p in range(start, runs[closer][1]):
+            out[p] = " "
+        idx = closer + 1
+    return "".join(out)
+
+
+def strip_code(text):
+    """Blank every fenced block and inline code span, preserving line count and length.
+
+    Equal-length spaces rather than deletion: nothing on either side of a stripped span can then
+    join into a `](` adjacency that was never written.
+    """
+    out = []
+    fence = None                                   # (character, width) of the open fence
+    for line in text.split("\n"):
+        if fence is None:
+            m = FENCE_OPEN.match(line)
+            if m and not (m.group("fence")[0] == "`" and "`" in m.group("info")):
+                fence = (m.group("fence")[0], len(m.group("fence")))
+                out.append(" " * len(line))
+                continue
+            out.append(_mask_spans(line))
+        else:
+            char, width = fence
+            m = FENCE_OPEN.match(line)
+            # A closing fence is at least as long as the one that opened it and carries no info.
+            if (m and m.group("fence")[0] == char and len(m.group("fence")) >= width
+                    and not m.group("info").strip()):
+                fence = None
+            out.append(" " * len(line))
+    return "\n".join(out)
+
+
+def _destination(target):
+    """The destination out of a link target, dropping any CommonMark title.
+
+    `[a](x.md "the title")` addresses `x.md`. Taken whole, the title made the gate fail on a link
+    that renders correctly.
+    """
+    target = target.strip()
+    if target.startswith("<"):
+        return target[1:].split(">", 1)[0]
+    return target.split(None, 1)[0] if target.split(None, 1) else ""
+
+
+def targets(text):
+    """Every link destination in `text` that is not a URL, in source order."""
+    found = (_destination(t) for t in LINK.findall(strip_code(text)))
+    return [t for t in found if t and not SCHEME.match(t)]
+
+
+def resolve(root, base, target):
+    """Absolute path a target addresses, or None when it addresses no file.
+
+    `root` is the repository root, `base` the directory of the file the link is written in.
+    None means "there is nothing on disk to look for" — a pure anchor or a placeholder — NOT that
+    the path is missing; whether it exists is the caller's question.
+
+    A target starting with `/` is repository-root-relative, which is how GitHub renders it. Joined
+    onto `base` instead, it escaped to the machine's filesystem root, where a dangling link
+    reported ok and a valid one failed.
+    """
+    path = target.split("#")[0]
+    if not path:
+        return None                                # pure anchor, same file
+    if any(c in path for c in "<>{"):
+        return None                                # placeholder, e.g. specs/001-<feature>/
+    if path.startswith("/"):
+        return os.path.normpath(os.path.join(root, path.lstrip("/")))
+    return os.path.normpath(os.path.join(root, base, path))
+
+
+# Every case is a direction this scanner has actually been wrong in, and each was checked against
+# the `marked` CommonMark renderer before being written down. Left as data so the gate can hold the
+# extractor to them on every run — #43 survived as long as it did because nothing checked
+# the checker.
+SELFTEST = [
+    ("[a](x.md)", ["x.md"], "a plain link is a link"),
+    ("`[a](x.md)`", [], "a code span is not a link"),
+    (r"\`[a](x.md)\`", ["x.md"], "an escaped backtick opens no code span"),
+    (r"a \` b [c](x.md)", ["x.md"], "a stray escaped backtick swallows nothing"),
+    ("a ` b\n[c](x.md)", ["x.md"], "an unpaired backtick cannot mask the next line"),
+    (r"a `x \` [b](y.md) `c", ["y.md"], "an escaped backtick still closes a span it did not open"),
+    ("  ~~~\n[a](x.md)\n  ~~~", [], "an indented tilde fence is still a fence"),
+    ("  ```\n[a](x.md)\n  ```", [], "an indented backtick fence is still a fence"),
+    ("````\n[a](x.md)\n````\n[b](y.md)", ["y.md"], "a longer fence closes on its own width"),
+    ("```yaml``` is it.\n[a](x.md)", ["x.md"], "a triple-backtick span is not a fence opener"),
+    ("> ```\n> [a](x.md)\n> ```", [], "a fence inside a blockquote is still a fence"),
+    ("```\n[a](x.md)\n```\n[b](y.md)", ["y.md"], "a fence ends, and scanning resumes"),
+    ("[a](\nx.md)", [], "a destination does not cross a line"),
+    ('[a](x.md "the title")', ["x.md"], "a title is not part of the destination"),
+    ("[a](<x.md>)", ["x.md"], "an angle-bracketed destination is unwrapped"),
+    ("[a](https://example.com/x)", [], "a URL is not an internal link"),
+    ("[a](HTTPS://example.com/x)", [], "a scheme is matched whatever its case"),
+]
+
+# What resolve() must do, checked as its own fixtures. The `/`-prefixed rule is the round's own
+# headline fix; without a case here, reverting it leaves the gate green.
+RESOLVE_SELFTEST = [
+    ("/r", "sub", "/schema/x.json", "/r/schema/x.json", "a rooted target resolves against the repository"),
+    ("/r", "sub", "x.md", "/r/sub/x.md", "a relative target resolves against its own directory"),
+    ("/r", "sub", "../y.md", "/r/y.md", "a parent-relative target climbs from its own directory"),
+    ("/r", "", "#anchor", None, "a pure anchor addresses no file"),
+    ("/r", "", "specs/001-<feature>/x.md", None, "a placeholder addresses no file"),
+    ("/r", "sub", "x.md#frag", "/r/sub/x.md", "a fragment is not part of the path"),
+]
+
+
+def selftest():
+    """Every fixture the extractor gets wrong, as a list of strings. Empty when sound."""
+    wrong = []
+    # A floor of its own: an emptied fixture list would otherwise read as a sound extractor,
+    # which is the defect this whole module was written in response to.
+    if len(SELFTEST) < 15 or len(RESOLVE_SELFTEST) < 5:
+        wrong.append(f"the fixture list itself has shrunk to {len(SELFTEST)}/{len(RESOLVE_SELFTEST)} "
+                     f"— it is checking less than it was written to check")
+    for text, want, why in SELFTEST:
+        got = targets(text)
+        if got != want:
+            wrong.append(f"{why}: expected {want}, got {got}")
+    for root, base, target, want, why in RESOLVE_SELFTEST:
+        got = resolve(root, base, target)
+        if got != want:
+            wrong.append(f"{why}: expected {want}, got {got}")
+    return wrong

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -180,9 +180,18 @@ section "The schema holds up its own examples, and still rejects"
 # rejects teaches a shape that does not exist. Tighten a pattern and they go stale in
 # silence — every other check here reads examples/, not the schema's own contents.
 #
-# And every published example is one the schema is meant to ACCEPT, so nothing notices if
-# a closure comes loose. `displayName` was added to three objects that close over their
-# properties; the probes below are the cases that must still fail.
+# And every published example is one the schema is meant to ACCEPT, so nothing notices if a
+# constraint comes loose: loosening one never invalidates a document that was already valid. The
+# probes below are documents that must still FAIL, one per constraint the schema makes.
+#
+# They started as seven, covering the `displayName` closures alone, and a sweep found that 39 of
+# the 41 single-constraint loosenings in this file left the section green — the whole closed
+# vocabulary among them, including the `mss` typo `$defs/unit`'s own description promises is a
+# parse error. Every constraint now has a probe. The sweep is the check on the checks: mutate one
+# constraint at a time and confirm this section reddens.
+#
+# The one exception is `$defs/predicate.type`, whose removal changes no verdict — the `not` rules
+# below reject a non-object anyway — so no document can probe it.
 if ! command -v python3 >/dev/null 2>&1; then
   bad "python3 not found — the schema self-check cannot run"
 else
@@ -227,26 +236,152 @@ if checked == 0:
     sys.exit(1)
 
 # The closures. Each MUST be rejected; one that validates means a guard came loose.
+#
+# doc() must itself be valid — unmutated — before any probe below is trusted. A probe built on
+# an already-invalid base is rejected for the wrong reason, and every mutation below would then
+# "pass" no matter what it actually tests (issue #37). Checked, not assumed: see the assertion
+# immediately after this function.
 def doc():
-    return {"apiVersion": "opennfr.io/v1", "kind": "RequirementSet", "metadata": {"name": "probe"},
-            "spec": {"requirements": [{"name": "r",
-                     "indicator": {"distribution": {"metric": "m", "selector": {}}},
-                     "criteria": [{"aggregation": "max", "op": "lte", "threshold": 1, "unit": "ms"}]}]}}
+    # Carries a guard as well as a criterion: the two are the same shape and are edited as a pair,
+    # so a base document exercising only one leaves the other free to come loose unobserved.
+    return {"apiVersion": "opennfr.io/v1", "kind": "RequirementSet",
+            "metadata": {"name": "probe", "displayName": "a probe", "annotations": {"k": "v"}},
+            "spec": {"requirements": [{"name": "r", "selector": {},
+                     "guards": [{"aggregation": "rate", "op": "gte", "threshold": 1, "unit": "{request}/s"}],
+                     "criteria": [{"metric": "m", "aggregation": "max", "op": "lte", "threshold": 1, "unit": "ms"}]}]}}
+
+base_errs = list(V(schema).iter_errors(doc()))
+if base_errs:
+    for e in base_errs:
+        where = "/".join(map(str, e.path)) or "(root)"
+        print(f"  FAIL  {path}: probe base document is invalid on its own at {where}: {e.message}")
+    print("  FAIL  every probe below is meaningless until the base document validates unmutated")
+    sys.exit(1)
 
 probes = {}
 d = doc(); d["metadata"]["nope"] = "x";                       probes["unknown field on metadata"] = d
 d = doc(); d["spec"]["requirements"][0]["nope"] = "x";        probes["unknown field on a requirement"] = d
 d = doc(); d["spec"]["requirements"][0]["criteria"][0]["nope"] = "x"; probes["unknown field on a criterion"] = d
 d = doc(); d["spec"]["displayName"] = "x";                    probes["displayName on spec"] = d
-d = doc(); d["spec"]["requirements"][0]["indicator"]["distribution"]["displayName"] = "x"
-probes["displayName on a series"] = d
+# `indicator`/`distribution` ("a series") no longer exist in the schema — dead since the
+# assertion-first design they belonged to was reverted. This probe now tests the same class of
+# closure (an object with additionalProperties: false, rejecting a displayName it never declared)
+# on the one place still uncovered: the document root itself.
+d = doc(); d["displayName"] = "x";                            probes["displayName at the document root"] = d
 d = doc(); d["metadata"]["displayName"] = "x" * 201;          probes["displayName over 200 characters"] = d
 d = doc(); d["metadata"]["displayName"] = "";                 probes["empty displayName"] = d
+d = doc(); d["spec"]["requirements"][0]["guards"][0]["nope"] = "x"; probes["unknown field on a guard"] = d
+
+# Everything above closes an object. What follows holds the rest of the schema to what its own
+# descriptions promise, because none of it was covered: 65 of 78 single-constraint loosenings left
+# this section green, including the whole closed vocabulary. `$defs/unit` says its enum exists
+# "precisely so a typo like `mss` is a parse error rather than a disagreement between consumers" —
+# nothing checked that, and a promise nothing checks is the thing this section exists to catch.
+
+# The required fields, one per object. FR-002 names a missing required field as a closure the gate
+# must fail on, and until now none was probed.
+for where, field, mutate in [
+    ("the document", "apiVersion", lambda d: d.pop("apiVersion")),
+    ("the document", "kind",       lambda d: d.pop("kind")),
+    ("the document", "metadata",   lambda d: d.pop("metadata")),
+    ("the document", "spec",       lambda d: d.pop("spec")),
+    ("metadata",     "name",       lambda d: d["metadata"].pop("name")),
+    ("spec",         "requirements", lambda d: d["spec"].pop("requirements")),
+    ("a requirement", "name",     lambda d: d["spec"]["requirements"][0].pop("name")),
+    ("a requirement", "selector", lambda d: d["spec"]["requirements"][0].pop("selector")),
+    ("a requirement", "criteria", lambda d: d["spec"]["requirements"][0].pop("criteria")),
+    ("a criterion",  "aggregation", lambda d: d["spec"]["requirements"][0]["criteria"][0].pop("aggregation")),
+    ("a criterion",  "op",        lambda d: d["spec"]["requirements"][0]["criteria"][0].pop("op")),
+    ("a criterion",  "threshold", lambda d: d["spec"]["requirements"][0]["criteria"][0].pop("threshold")),
+    ("a criterion",  "unit",      lambda d: d["spec"]["requirements"][0]["criteria"][0].pop("unit")),
+]:
+    d = doc(); mutate(d);                                     probes[f"{where} without {field}"] = d
+
+# The closed vocabularies. Each is a value one letter away from a legal one, which is the mistake
+# the enumerations exist to turn into a parse error rather than a disagreement between consumers.
+d = doc(); d["spec"]["requirements"][0]["criteria"][0]["unit"] = "mss";         probes["a unit outside the enumeration"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"][0]["op"] = "approx";        probes["an op outside the enumeration"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"][0]["aggregation"] = "median-ish"; probes["an aggregation outside the set"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"][0]["aggregation"] = "p999"; probes["a percentile of three digits"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"][0]["threshold"] = "500ms";  probes["a threshold that is not a number"] = d
+d = doc(); d["metadata"]["name"] = "Not A Name!";                              probes["a name outside the pattern"] = d
+d = doc(); d["metadata"]["name"] = "x" * 254;                                  probes["a name over 253 characters"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"] = [];                      probes["a requirement with no criteria"] = d
+d = doc(); d["metadata"]["annotations"] = {"k": ["not", "a", "string"]};       probes["an annotation that is not a string"] = d
+d = doc(); d["apiVersion"] = "opennfr.io/v2";                                  probes["an apiVersion this schema does not define"] = d
+
+# The shapes. A `type` is the quietest constraint to lose — drop one and a string passes where an
+# object was required, with every other rule on that object silently inapplicable.
+for label, mutate in [
+    ("a document that is not an object",     lambda d: "a string"),
+    ("metadata that is not an object",       lambda d: d.__setitem__("metadata", "x") or d),
+    ("a spec that is not an object",         lambda d: d.__setitem__("spec", "x") or d),
+    ("requirements that are not an array",   lambda d: d["spec"].__setitem__("requirements", "x") or d),
+    ("no requirements at all",               lambda d: d["spec"].__setitem__("requirements", []) or d),
+    ("a requirement that is not an object",  lambda d: d["spec"]["requirements"].__setitem__(0, "x") or d),
+    ("criteria that are not an array",       lambda d: d["spec"]["requirements"][0].__setitem__("criteria", "x") or d),
+    ("a criterion that is not an object",    lambda d: d["spec"]["requirements"][0]["criteria"].__setitem__(0, "x") or d),
+    ("guards that are not an array",         lambda d: d["spec"]["requirements"][0].__setitem__("guards", "x") or d),
+    ("an empty guards array",                lambda d: d["spec"]["requirements"][0].__setitem__("guards", []) or d),
+    ("a name that is not a string",          lambda d: d["metadata"].__setitem__("name", 7) or d),
+    ("a displayName that is not a string",   lambda d: d["metadata"].__setitem__("displayName", 7) or d),
+    ("annotations that are not an object",   lambda d: d["metadata"].__setitem__("annotations", "x") or d),
+    ("a selector that is not an object",     lambda d: d["spec"]["requirements"][0].__setitem__("selector", "x") or d),
+    ("a selector value that is an object",   lambda d: d["spec"]["requirements"][0]["selector"].__setitem__("k", {}) or d),
+    ("an aggregation that is not a string",  lambda d: d["spec"]["requirements"][0]["criteria"][0].__setitem__("aggregation", 7) or d),
+    ("a metric that is not a string",        lambda d: d["spec"]["requirements"][0]["criteria"][0].__setitem__("metric", 7) or d),
+    ("an empty metric",                      lambda d: d["spec"]["requirements"][0]["criteria"][0].__setitem__("metric", "") or d),
+    ("a kind this schema does not define",   lambda d: d.__setitem__("kind", "Requirement") or d),
+]:
+    probes[label] = mutate(doc())
+
+# The four cross-field rules on a predicate — the format's own semantics, and the only place they
+# are stated machine-checkably. #38 removed a dead conditional from this file; nothing was watching
+# whether the live ones stayed live.
+# `rate` and a `%` unit, so the fraction rules are satisfied and only "not both" can reject it.
+# Written with `max` instead, this probe passed for the wrong reason — the percentile rule caught
+# it — and the rule it is named after could be deleted in silence.
+d = doc(); c = d["spec"]["requirements"][0]["criteria"][0]
+c["bad"] = {"error.type": "*"}; c["aggregation"] = "rate"; c["unit"] = "%"
+probes["a predicate that is both a metric and a fraction"] = d
+d = doc(); c = d["spec"]["requirements"][0]["criteria"][0]; c.pop("metric")
+c["bad"] = {"error.type": "*"}; c["good"] = {"error.type": "*"}; c["aggregation"] = "rate"; c["unit"] = "%"
+probes["a fraction carrying both of its sides"] = d
+d = doc(); c = d["spec"]["requirements"][0]["criteria"][0]; c.pop("metric")
+c["bad"] = {"error.type": "*"}; c["aggregation"] = "p99"; c["unit"] = "%"
+probes["a percentile over a fraction"] = d
+d = doc(); d["spec"]["requirements"][0]["criteria"][0].pop("metric")
+probes["a spread with no metric to spread"] = d
+
+# A probe that was deleted cannot fail. The base document above proves the probes stand on
+# something valid; this proves the probes are still there to stand on it. A floor at zero would
+# only catch emptying the dict outright, so it is set just under the current count: pruning most
+# of the block is the realistic accident, and it would otherwise show up as nothing but a smaller
+# number in a line nobody compares against anything.
+FLOOR = 50
+if len(probes) < FLOOR:
+    print(f"  FAIL  {path}: {len(probes)} closure probes, expected at least {FLOOR} — "
+          f"probes have been removed, and a probe that is gone cannot fail")
+    sys.exit(1)
 
 for name, bad_doc in probes.items():
     if not list(V(schema).iter_errors(bad_doc)):
         print(f"  FAIL  the schema accepts what it must reject: {name}")
         rc = 1
+
+# One rule cannot be reached by a rejection probe. `A fraction has no percentile` is redundant for
+# VALIDITY — a fraction has no metric, and every aggregation but `rate` and `count` requires one,
+# so the document is rejected either way — but it is what produces the message README.md quotes.
+# Delete it and the document is still refused, now blaming a missing `metric` the author never
+# meant to write. That is a documented diagnostic degrading in silence, so it is checked by the
+# message rather than by the verdict.
+d = doc(); c = d["spec"]["requirements"][0]["criteria"][0]; c.pop("metric")
+c["bad"] = {"error.type": "*"}; c["aggregation"] = "p95"; c["unit"] = "%"
+WANT_MESSAGE = "'p95' is not one of ['rate', 'count']"
+if not any(e.message == WANT_MESSAGE for e in V(schema).iter_errors(d)):
+    print(f"  FAIL  a percentile over a fraction no longer says why: expected {WANT_MESSAGE!r}, "
+          f"which README.md quotes as the message for this mistake")
+    rc = 1
 
 if rc == 0:
     print(f"  ok    {checked} embedded examples valid, {len(probes)} closures still reject")

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -538,31 +538,66 @@ fi
 
 # ---------------------------------------------------------------------------
 section "Internal markdown links resolve"
-missing=0
-found=0
-while IFS= read -r line; do
-  found=$((found + 1))
-  src="${line%%:*}"
-  target="${line#*:}"
-  base="$(dirname "$src")"
-  path="${target%%#*}"
-  [ -z "$path" ] && continue                      # pure anchor, same file
-  case "$path" in *'<'*|*'>'*|*'{'*) continue ;; esac   # placeholder, e.g. specs/001-<feature>/
-  if [ ! -e "$base/$path" ]; then
-    bad "$src -> $target"
-    missing=1
-  fi
-done < <(
-  grep -rn --include='*.md' -oE '\]\([^)]+\)' . \
-    | grep -v '^\./\.' \
-    | sed -E 's/^([^:]+):[0-9]+:\]\((.*)\)$/\1:\2/' \
-    | grep -vE ':(https?|mailto):'
-)
+# A raw grep for `](...)` cannot tell a markdown link from a regular expression that happens to
+# close a bracket group with a parenthesis inside a code span — issue #43. What a link is now
+# lives in scripts/mdlinks.py, shared with the isolation section below so the two cannot drift
+# into disagreeing about the same text.
+if ! command -v python3 >/dev/null 2>&1; then
+  bad "python3 not found — the link-resolution gate cannot run"
+else
+  python3 - <<'LINKS' || fail=1
+import os, sys
+sys.path.insert(0, "scripts")
+import mdlinks
+
+# The extractor is held to its own fixtures before anything trusts it. #43 was a scanner that
+# had been wrong about what a link is for as long as it had existed, and nothing noticed.
+wrong = mdlinks.selftest()
+for m in wrong:
+    print(f"  FAIL  the link extractor is wrong: {m}")
+if wrong:
+    sys.exit(1)
+
+def md_files():
+    # Same population the previous grep pipeline scanned: every *.md file, except those under a
+    # top-level dot-directory (.git/, .github/, .specify/, .claude/) or a dot-prefixed root file.
+    for root, dirs, files in os.walk("."):
+        if root == ".":
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for f in sorted(files):
+            if f.endswith(".md") and not (root == "." and f.startswith(".")):
+                yield os.path.join(root, f)
+
+root = os.getcwd()
+missing = 0
+found = 0
+for src in sorted(md_files()):
+    try:
+        text = open(src, encoding="utf-8").read()
+    except (OSError, UnicodeDecodeError) as e:
+        # One unreadable file used to abort the section on a traceback: no ok, no FAIL, and
+        # every file after it unscanned. It fails as a file now, and the scan continues.
+        print(f"  FAIL  {src}: cannot be read as UTF-8 ({e})")
+        missing = 1
+        continue
+    base = os.path.dirname(src)
+    for target in mdlinks.targets(text):
+        found += 1
+        resolved = mdlinks.resolve(root, base, target)
+        if resolved is None:
+            continue                                   # anchor or placeholder, addresses no file
+        if not os.path.exists(resolved):
+            print(f"  FAIL  {src} -> {target}")
+            missing = 1
+
 # Zero links means the extraction above stopped working, not that the docs are clean.
-if [ "$found" -eq 0 ]; then
-  bad "no markdown links found — the link extraction is broken"
-elif [ "$missing" -eq 0 ]; then
-  ok "no dangling internal links ($found checked)"
+if found == 0:
+    print("  FAIL  no markdown links found — the link extraction is broken")
+    sys.exit(1)
+elif missing == 0:
+    print(f"  ok    no dangling internal links ({found} checked)")
+sys.exit(1 if missing else 0)
+LINKS
 fi
 
 # ---------------------------------------------------------------------------
@@ -617,7 +652,12 @@ if os.path.exists(ideas):
         rc = 1
 
 # --- nothing outside docs/ links into it --------------------------------------------
-LINK = re.compile(r"\]\(([^)]+)\)")
+# The same definition of a link the resolution section uses. Held apart, the two disagreed:
+# a code span naming a path under docs/ was text to one gate and a violation to the other,
+# which made the isolation rule impossible to document in the documents it governs.
+sys.path.insert(0, "scripts")
+import mdlinks
+
 root = os.getcwd()
 scanned = 0
 sources = [f for f in files
@@ -627,15 +667,18 @@ if not sources:
     sys.exit(1)
 for f in sources:
     base = os.path.dirname(f)
-    for target in LINK.findall(open(f, encoding="utf-8").read()):
-        if target.startswith(("http://", "https://", "mailto:", "#")):
-            continue
-        path = target.split("#")[0]
-        if not path or any(c in path for c in "<>{"):
+    try:
+        text = open(f, encoding="utf-8").read()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"  FAIL  {f}: cannot be read as UTF-8 ({e})")
+        rc = 1
+        continue
+    for target in mdlinks.targets(text):
+        # Pure path arithmetic: no chdir, so nothing can silently fail to resolve.
+        resolved = mdlinks.resolve(root, base, target)
+        if resolved is None:
             continue
         scanned += 1
-        # Pure path arithmetic: no chdir, so nothing can silently fail to resolve.
-        resolved = os.path.normpath(os.path.join(root, base, path))
         if resolved == os.path.join(root, "docs") or resolved.startswith(os.path.join(root, "docs") + os.sep):
             print(f"  FAIL  {f} links into docs/ -> {target}")
             rc = 1

--- a/specs/005-fix-milestone-bugs/checklists/requirements.md
+++ b/specs/005-fix-milestone-bugs/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Fix Milestone v0.3.0 Bugs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [~] No implementation details (languages, frameworks, APIs) — deliberate exception, see Notes
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [~] No implementation details leak into specification — deliberate exception, see Notes
+
+## Notes
+
+- The spec names specific files (`scripts/verify.sh`, `schema/opennfr.io/v1/requirementset.schema.json`, `README.md`, `.copier-answers.yml`) because they are the exact defect locations named in the source GitHub issues — this is scope precision, not an implementation prescription.
+- **Amended after review.** Several requirements now name JSON Schema constructs (`additionalProperties`, `maxLength`) and resolution mechanics. That is a deliberate departure from "no implementation details": for a feature whose subject *is* the schema and the gate, a requirement stated without naming the construct cannot be tested, and the round that avoided naming them produced three requirements that pointed at constructs the same feature had removed.
+- Issue #31 ("no examples in the schema") was evaluated and excluded as an enhancement rather than a bug — see Assumptions in spec.md. No [NEEDS CLARIFICATION] marker was used because the issue text itself is unambiguous about being additive, not corrective.
+- All five in-scope items (issues #37, #42, #38, #43, #46) came with an explicit "Fix:" description in their source issue, which supplied enough detail to avoid clarification markers.
+- The spec originally targeted milestone v0.2.0; that milestone shipped and its six remaining open issues (the same six this spec covers) were moved to milestone v0.3.0 — see spec.md, Clarifications, Session 2026-08-23. Corrected in place; does not affect any checklist item above.

--- a/specs/005-fix-milestone-bugs/contracts/verify-sections.md
+++ b/specs/005-fix-milestone-bugs/contracts/verify-sections.md
@@ -1,0 +1,45 @@
+# Contract: what the gate checks after these five fixes
+
+**Feature**: `005-fix-milestone-bugs`
+
+FR-002, FR-007 and FR-008: a section that is supposed to be able to fail must actually be able to
+fail, on the specific input it claims to guard against. Three sections change what they check; the
+rest are named here to record that this feature leaves them alone.
+
+| # | Section | Changes | After the fix |
+|---|---|---|---|
+| 1 | YAML parses | No | Unchanged |
+| 2 | Documents map one-to-one onto JSON | No | Unchanged |
+| 3 | Examples validate against the schema | Indirectly (schema edits from R2/R3) | Unchanged in shape; still validates every file in `examples/` against the schema, which after R2/R3 rejects the same documents it does today (data-model.md, "What every fix must leave unchanged") |
+| 4 | The schema holds up its own examples, and still rejects | **Yes — R1 (#37)** | The probes' shared base document is asserted valid *before* mutation, so a probe can only be rejected by the mutation it targets. The probe set grew from 7 to 54 — one per constraint the schema makes — after a sweep found 39 of 41 single-constraint loosenings left the section green. A floor fails the section if probes are removed |
+| 5 | Examples are assertable by Gatling | No | Unchanged |
+| 6 | Internal markdown links resolve | **Yes — R4 (#43)** | Extraction moves to `scripts/mdlinks.py`, checked against its own fixtures on every run. Text shaped like a markdown link inside a code span or fence no longer fails the section; a `/`-rooted target resolves against the repository rather than the filesystem root; an unreadable file FAILs as a file instead of aborting the section |
+| 7 | `docs/` is isolated | **Yes — R4 (#43)** | Uses the same `scripts/mdlinks.py` definition, so the two scanners can no longer disagree about whether a given piece of text is a link. Its count moved 26 → 25, the miscounted code span going away. The three clauses it checks are unchanged |
+| 8 | Docs are English | No | Unchanged |
+
+No section is added or removed. Sections 1, 2, 3, 5, 7 and 8 are listed for completeness — this
+feature's Constitution Check (plan.md) depends on being able to name every section it does *not*
+touch, not only the two it does.
+
+## Acceptance
+
+After all five fixes land:
+
+- `bash scripts/verify.sh` reports **PASS**.
+- Section 4 **FAILS**, naming the base-document error, if the shared probe base document is
+  mutated to be invalid on its own (a regression test for R1's whole point) — probed during
+  planning by reading the base document's current validation errors (research.md R1), to be
+  re-probed as a task during implementation by deliberately reintroducing each of the seven closure
+  gaps and confirming the corresponding probe now fails for the right reason.
+- Section 6 **FAILS** on a markdown link outside any code span or fence that targets a
+  non-existent path (unchanged behavior — probed, not assumed, since R4 changes the extraction
+  mechanism).
+- Section 6 does **NOT FAIL** when the schema's literal `name` pattern, or any other text with the
+  same closing-bracket-then-opening-parenthesis shape, is written inside a code span or fenced
+  code block anywhere under version control — reproduced as broken today in research.md R4, to be
+  re-probed once R4 lands.
+- A predicate document with exactly one invalid field (e.g. `unit: "mss"`) produces exactly one
+  schema-validation error in section 3's output, not two (R2, research.md).
+- `examples/fast-and-reliable.yaml`, `examples/one-request-is-fast.yaml` and
+  `examples/the-run-held-up.yaml` continue to pass section 3 unchanged (R2, R3 — dry-run
+  confirmed zero regressions in research.md; re-confirmed live once the schema edits land).

--- a/specs/005-fix-milestone-bugs/data-model.md
+++ b/specs/005-fix-milestone-bugs/data-model.md
@@ -1,0 +1,45 @@
+# Phase 1: what changes, in which file
+
+**Feature**: `005-fix-milestone-bugs` | **Date**: 2026-08-23
+
+No new entity is introduced — this feature corrects diagnostics, dead schema logic, a gate false
+positive and a stale scaffolding record. What follows is the inventory FR-012 depends on: every
+artifact touched, what changes in it, and what does not.
+
+## Artifacts
+
+| Artifact | Touched by | What changes | What does not |
+|---|---|---|---|
+| `scripts/verify.sh` — "The schema holds up its own examples, and still rejects" section | R1 (#37) | The seven probes' shared base document gains the fields it was missing (`selector`; `metric` where `max` requires it) **and loses the `indicator` key `requirement` never declared**; a precondition assertion that it validates before mutation; a floor that fails rather than reports `ok` if no probe is left | The section's `ok`/`FAIL` reporting shape, and six of the seven probe mutations. **The seventh changes**: "displayName on a series" mutated `indicator.distribution`, a construct the schema no longer has, so it is repointed to the document root — the same closure class, the one place still uncovered |
+| `schema/opennfr.io/v1/requirementset.schema.json` → `$defs/predicate` | R2 (#42) | Gains `"additionalProperties": false` | `required`, `properties`, its own `allOf` (the four cross-field rules), `examples` |
+| `schema/opennfr.io/v1/requirementset.schema.json` → `$defs/requirement.properties.criteria.items` | R2 (#42) | `{"allOf": [{"$ref": "#/$defs/predicate"}], "unevaluatedProperties": false}` → `{"$ref": "#/$defs/predicate"}` | — |
+| `schema/opennfr.io/v1/requirementset.schema.json` → `$defs/requirement.properties.guards.items` | R2 (#42), R3 (#38) | Same collapse to a plain `$ref` (R2); the no-op `"properties": {}` it currently carries and `criteria.items` does not is removed as part of the same collapse (R3) — see research.md R2 sequencing note | `minItems`, `description` |
+| `schema/opennfr.io/v1/requirementset.schema.json` → `$defs/requirement.allOf` | R3 (#38) | Deleted entire (the unreachable `if`/`then` block) | Everything else in `$defs/requirement` |
+| `scripts/mdlinks.py` — **new file** | R4 (#43) | One definition of a markdown link — fence and code-span stripping, target extraction, path resolution — plus the fixtures the gate holds it to on every run | — |
+| `scripts/verify.sh` — "Internal markdown links resolve" section | R4 (#43) | Extraction moves to `scripts/mdlinks.py`; a target beginning with `/` resolves against the repository root rather than escaping to the filesystem root; an unreadable file fails as a file instead of aborting the section on a traceback | Detection of a genuine broken link outside code spans/fences; the `found == 0` anti-silent-green guard |
+| `scripts/verify.sh` — "`docs/` is isolated" section | R4 (#43) | Uses the same `scripts/mdlinks.py` definition, so a code span naming a path under `docs/` is no longer counted or reported as a link into it | The three clauses it checks, and its `scanned == 0` guard |
+| `README.md` — `metadata.name` field row | R4 (#43) | Prose paraphrase replaced with the literal, unmodified `name` pattern regex | Every other field row |
+| `README.md` — the "wart" paragraph | R2 (#42) | Deleted: it told readers to expect `Unevaluated properties are not allowed`, which the schema can no longer emit. Replaced with what is true — a bad value gives one message, a misspelled key gives two, both naming it | The ten rows of the error table above it, each re-validated against the current schema |
+| `.copier-answers.yml` | R5 (#46) | Eight answers corrected to match `AGENTS.md`/`README.md`: the six issue #46 tabulates (`architecture`, `structure`, `stack_detail`, `dep_manifest`, `role`, `test_model`), `project_tagline` from its closing prose, and `commands` — which the issue does not name but the round-trip test in FR-011 proves still reverts a corrected path | `_commit`, `_src_path`, `org_repo`, `project_name`, `do_git`, `run_speckit`, `stack`, `build_test_cmd`, `publish_mechanism`, `release_notes_tool` |
+| `.gitignore` | R4 (#43) | Ignores `__pycache__/` and `*.pyc`: importing `scripts/mdlinks.py` writes bytecode beside it | Every existing rule |
+| `AGENTS.md` — Commands block | R4 (#43) | One line: the link check is no longer `grep-based`, and saying so was falsified by R4 itself | Every other section. `.copier-answers.yml` is otherwise brought to match `AGENTS.md`, not the reverse |
+
+## What every fix must leave unchanged (FR-012)
+
+- `examples/fast-and-reliable.yaml`, `examples/one-request-is-fast.yaml`,
+  `examples/the-run-held-up.yaml` — all three continue to validate. Checked by dry-run for R2 and
+  R3 (research.md); R1, R4 and R5 do not touch the schema or the corpus at all.
+- The schema's own embedded `examples` (`$defs/selector`, `$defs/predicate`, `$defs/requirement`)
+  continue to validate against the definitions they illustrate. Checked by dry-run for R3.
+- `bash scripts/verify.sh` exits 0 after all five fixes land (SC-001).
+
+## Ordering constraint
+
+R2 and R3 both edit `$defs/requirement.properties.guards.items` and
+`$defs/requirement.properties.criteria.items`. Per `AGENTS.md`'s "1 issue = 1 commit", these ship
+as two separate commits (issue #42, issue #38); whichever lands second must be diffed against the
+schema *as the first left it*, not against the schema as it reads today, or its documented "delete
+the no-op `properties: {}`" instruction may target a key that R2 already removed by replacing the
+whole `items` value. `tasks.md` sequences R2 before R3 for exactly this reason — R3's change
+becomes a smaller, purely-subtractive diff (delete the `allOf` block) once R2 has already
+collapsed `items` to a plain `$ref`.

--- a/specs/005-fix-milestone-bugs/plan.md
+++ b/specs/005-fix-milestone-bugs/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Fix Milestone v0.3.0 Bugs
+
+**Branch**: `005-fix-milestone-bugs` | **Date**: 2026-08-23 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/005-fix-milestone-bugs/spec.md`
+
+## Summary
+
+Five independent defects, confirmed against the current repository rather than assumed from their
+source issues (three of the five had drifted since filing — see research.md): a gate self-check
+that passes for the wrong reason (#37); a JSON Schema composition that turns one predicate mistake
+into two error messages, one of them wrong (#42); an unreachable conditional in `$defs/requirement`
+plus a matching no-op (#38); a link checker that reads a regex in a code span as a broken markdown
+link (#43); and a Copier scaffolding record that has drifted from the `AGENTS.md` it regenerates
+(#46). None adds a construct, renames a field, or changes which documents in `examples/` validate
+— confirmed by dry-run for the two fixes that touch the schema. Issue #31 (add schema examples) is
+confirmed out of scope (spec.md, Clarifications).
+
+The approach is one fix per issue, one commit per fix, per `AGENTS.md`'s "1 issue = 1 commit" — not
+one combined change. Two of the five (#42, #38) touch the same schema keys and must be sequenced
+(data-model.md, "Ordering constraint").
+
+## Technical Context
+
+**Language/Version**: None. Bash and Python 3 (the gate's own implementation language), one JSON
+Schema (Draft 2020-12), Markdown, YAML.
+
+**Primary Dependencies**: `python3` with `pyyaml` and `jsonschema`, used only by the gate —
+unchanged by this feature.
+
+**Storage**: N/A — files in git.
+
+**Testing**: `bash scripts/verify.sh`, plus the per-fix probes in [quickstart.md](quickstart.md),
+each of which was already run once during planning (research.md) to confirm the fix works before
+committing to it in this plan.
+
+**Target Platform**: A git repository read by humans and, eventually, by tool adapters living
+elsewhere — unaffected by this feature.
+
+**Project Type**: Format specification and its validation gate. No application code.
+
+**Performance Goals**: N/A.
+
+**Constraints**: `bash scripts/verify.sh` MUST pass on every commit (`AGENTS.md`; constitution,
+Development Workflow) — including each of the five individually, not only the end state. No fix
+may change which document in `examples/` validates (FR-012); confirmed by dry-run for #42 and #38,
+the two that touch the schema. #37, #43 and #46 do not touch the schema at all.
+
+**Scale/Scope**: 5 fixes, 4 files (`scripts/verify.sh`, two sections;
+`schema/opennfr.io/v1/requirementset.schema.json`, two `$defs`; `README.md`, one field row;
+`.copier-answers.yml`, eight of its sixteen answers). Plus one new file, `scripts/mdlinks.py`, and
+one line of `AGENTS.md`.
+
+## Constitution Check
+
+*Evaluated against `.specify/memory/constitution.md` v3.0.0. Re-checked after Phase 1 design below
+— unchanged, since Phase 1 added no new artifact this gate reasons about.*
+
+- [x] **I. Vocabulary Before Features** — no term is introduced or renamed. `guards`, `criteria`,
+      `predicate`, `requirement`, `indicator` all already exist in `GLOSSARY.md`; none is
+      redefined, only the schema construct enforcing an existing rule (R2, R3) or a diagnostic
+      (R1) changes shape. All five fixes were argued in their respective GitHub issues before this
+      plan; #38's fix text cites the same glossary rule it is deleting a dead duplicate of.
+- [x] **II. Borrow Names, Never Invent Them** — no metric or attribute name is added, renamed or
+      aliased. R2/R3 touch schema *structure* (`allOf`/`unevaluatedProperties` vs. plain `$ref`,
+      `additionalProperties` placement), never a name.
+- [x] **III. No Silent Green** — the principle this feature is mostly *about*. R1 fixes a gate
+      section that has been silently green since the probes were written (#37) — the sharpest
+      instance of this principle's own failure mode, inside the file that exists to catch it. R4
+      fixes a check that fails loudly but for the wrong reason (a false positive is the mirror
+      image: not silence, but noise that teaches a workaround instead of a fix). Neither fix
+      introduces a new skip-on-can't-run path; both make an existing check fail for the right
+      reason instead of the wrong one.
+- [x] **IV. Honest Status** — research.md states plainly which of the five issues' premises no
+      longer matched the current repository (#43's workaround text, #42's example filenames) and
+      corrects the spec rather than silently implementing against a stale description. Every
+      schema-touching decision (R2, R3) is backed by a dry-run against the current corpus, dated
+      2026-08-23, not by trusting the issue's own (two-year-old) test claims.
+- [x] **V. Structure Over Grammar** — no new field, no bespoke parser, no open grammar. R2's fix
+      is a closed-form JSON Schema restructuring (`additionalProperties` moved to the object that
+      owns the properties); nothing here could not already be expressed in Draft 2020-12.
+- [x] **VI. The Requirement Is Target-Blind** — no requirement document gains a target name, in a
+      field, a value or an example. Gatling is not mentioned by any of the five fixes.
+- [ ] **VII** — *withdrawn in 3.0.0. No gate.*
+- [x] **VIII. Ideas Are Parked, Not Merged** — untouched. None of the five fixes reads or writes
+      `docs/`.
+- [x] **Compatibility** — `$defs/requirement` and `$defs/predicate` are compatibility-sensitive
+      surfaces (they define field names appearing in published examples), and R2/R3 change their
+      *internal* schema construction, but rename no field, and were each argued in their own
+      GitHub issue before this plan (#42, #38) — satisfying "argued in an issue before files
+      change" per Principle I, which the Compatibility Constraints section points back to. No
+      construct is added, so the "at least one surveyed target can assert it" admission floor
+      does not apply — nothing here is new to the format.
+
+**Gate result: passes, no violations.** Complexity Tracking below is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-fix-milestone-bugs/
+├── spec.md                        the requirement
+├── plan.md                        this file
+├── research.md                    Phase 0 — five decisions, each dry-run tested
+├── data-model.md                  Phase 1 — every artifact touched, before/after
+├── quickstart.md                  Phase 1 — how to check each fix, command by command
+├── contracts/
+│   └── verify-sections.md         which gate sections change, which stay as they are
+└── checklists/requirements.md
+```
+
+### Repository (files this feature touches)
+
+```text
+scripts/verify.sh                                  two sections change (R1, R4)
+schema/opennfr.io/v1/requirementset.schema.json     $defs/predicate, $defs/requirement (R2, R3)
+README.md                                           one field row (R4)
+.copier-answers.yml                                 eight of sixteen answers (R5)
+scripts/mdlinks.py                                  new — one definition of a link (R4)
+AGENTS.md                                           one line of the Commands block (R4)
+```
+
+One file is added — `scripts/mdlinks.py`, which both link scanners import. Nothing is deleted, and no directory changes shape.
+
+**Structure Decision**: Not applicable in the usual sense — this feature has no source tree to
+lay out. It is five independent fixes landing as five commits per `AGENTS.md`, plus one new module
+(`scripts/mdlinks.py`) extracted when review showed the gate's two link scanners had been
+disagreeing about what a link is. `data-model.md`'s "Ordering constraint" governs the only
+sequencing dependency (#42 before #38, both touching the same schema keys).
+
+## Complexity Tracking
+
+*Empty — the Constitution Check above records no violation to justify.*

--- a/specs/005-fix-milestone-bugs/quickstart.md
+++ b/specs/005-fix-milestone-bugs/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart: validating the five fixes
+
+**Feature**: `005-fix-milestone-bugs` | **Date**: 2026-08-23
+
+Every success criterion in the specification is checkable by a command or a diff. This is how, in
+priority order. Run from the repository root.
+
+## Prerequisites
+
+```bash
+python3 -m pip install --user --break-system-packages pyyaml jsonschema
+```
+
+(`--break-system-packages` is only needed on a Homebrew-managed `python3`; drop it if your
+`python3` accepts plain `--user`. This mirrors `specs/004-strip-to-schema/quickstart.md`'s own
+prerequisite — nothing new is required.)
+
+## 1. The gate self-check can fail (#37, P1)
+
+```bash
+bash scripts/verify.sh 2>&1 | sed -n '/still rejects/,/^$/p'
+```
+
+Expected today, before the fix: `ok 8 embedded examples valid, 7 closures still reject` — green
+for the wrong reason (research.md R1). After the fix the count is 54: review found that 39 of the
+41 single-constraint loosenings in the schema left the old seven probes green.
+
+After the fix, prove it can go red: temporarily drop `"additionalProperties": false` from
+`$defs/predicate` (or raise `$defs/displayName`'s `maxLength` above 200) and re-run. Expected: the
+section **FAILS**, naming the closure that came loose. Revert the temporary edit and confirm the
+section returns to `ok`.
+
+Do **not** reach for `unevaluatedProperties: false` here. R2 both added a closure and removed a
+redundant one; putting the redundant half back is a *tightening*, so the section stays `ok` — and
+it silently reinstates the double-error behaviour #42 exists to remove, which no section of the
+gate checks.
+
+*Covers SC-001, SC-003.*
+
+## 2. One predicate defect, one error message (#42, P2)
+
+```bash
+python3 - <<'PY'
+import json
+from jsonschema import Draft202012Validator as V
+schema = json.load(open("schema/opennfr.io/v1/requirementset.schema.json", encoding="utf-8"))
+v = V(schema)
+doc = {"apiVersion": "opennfr.io/v1", "kind": "RequirementSet", "metadata": {"name": "probe"},
+       "spec": {"requirements": [{"name": "r", "selector": {},
+                "criteria": [{"metric": "m", "aggregation": "p99", "op": "lte",
+                              "threshold": 1, "unit": "mss"}]}]}}
+errs = list(v.iter_errors(doc))
+print(f"{len(errs)} error(s):")
+for e in errs:
+    print(f"  {'/'.join(map(str, e.path))}: {e.message}")
+PY
+```
+
+Expected after the fix: **1 error**, naming `unit`. (Before the fix: 2 — see research.md R2 for
+the exact output.)
+
+*Covers SC-002.*
+
+## 3. The dead conditional is gone, nothing else moves (#38, P3)
+
+```bash
+grep -c '"description": "UNREACHABLE' schema/opennfr.io/v1/requirementset.schema.json
+bash scripts/verify.sh 2>&1 | sed -n '/Examples validate against the schema/,/^$/p'
+```
+
+Expected: the first command prints `0` (the marked-unreachable block is gone); the second still
+shows all three files in `examples/` as `ok`.
+
+*Covers SC-006, and re-confirms SC-001's "zero regressions" for this fix specifically.*
+
+## 4. The literal pattern in a code span doesn't fail the build (#43, P4)
+
+```bash
+grep -n 'a-z0-9' README.md
+bash scripts/verify.sh 2>&1 | sed -n '/Internal markdown links resolve/,/^$/p'
+```
+
+Expected: `README.md`'s `name` field row shows the literal regex — starts with `^[a-z0-9]`, then an
+optional group of letters, digits and hyphens closing on a letter or digit, then `$` — matching
+`schema/opennfr.io/v1/requirementset.schema.json`'s `$defs/name/pattern` exactly (described here
+in prose rather than quoted verbatim, for the same reason given in research.md R4: this file is
+scanned by the same gate). The link-resolution section reports `ok`, not `FAIL`.
+
+*Covers SC-004.*
+
+## 5. The scaffolding record agrees with `AGENTS.md` (#46, P5)
+
+```bash
+D=$(mktemp -d) && mkdir -p "$D/repo" && cp AGENTS.md CLAUDE.md README.md .copier-answers.yml "$D/repo/" && git -C "$D/repo" init -q . && git -C "$D/repo" config user.email p@example.com && git -C "$D/repo" config user.name Probe && git -C "$D/repo" add -A && git -C "$D/repo" commit -qm baseline && cp AGENTS.md "$D/before.md" && (cd "$D/repo" && copier recopy --defaults --trust --overwrite --vcs-ref "$(python3 -c "import yaml;print(yaml.safe_load(open('.copier-answers.yml'))['_commit'])")" . >/dev/null 2>&1) && diff "$D/before.md" "$D/repo/AGENTS.md" && echo "IDENTICAL — the record reverts nothing"
+```
+
+There **is** an automated oracle, and it is the criterion: render the template at the recorded
+`_commit` and diff the `AGENTS.md` it produces against the one on disk. Identical output means no
+answer disagrees with what the template would generate from it — which is the property the file's
+"never hand-edit" header protects. Run it on a **throwaway copy**, never in place: `copier recopy
+--overwrite` rewrites template-managed files this repository has deliberately diverged from,
+`.gitignore` among them.
+
+*Covers SC-005.*
+
+## 6. Everything together
+
+```bash
+bash scripts/verify.sh
+```
+
+Expected: `PASS`, all eight sections `ok`, none reporting a scan of zero files.
+
+To check the checks rather than trusting them, mutate one schema constraint at a time and confirm
+this gate reddens for each. 40 of the 41 constraints are covered; the exception,
+`$defs/predicate.type`, changes no verdict when removed, so no document can probe it.
+
+*Covers SC-001 as the final word.*

--- a/specs/005-fix-milestone-bugs/research.md
+++ b/specs/005-fix-milestone-bugs/research.md
@@ -1,0 +1,193 @@
+# Phase 0: Research
+
+**Feature**: `005-fix-milestone-bugs` | **Date**: 2026-08-23
+
+Five defects, five decisions. Each was reproduced against the current repository state before a
+fix was chosen — the corpus, the schema and `README.md` have all moved since some of these issues
+were filed, so the issue text is read as an argument, not as a literal diff to replay. Where a
+proposed fix touches the schema, it was dry-run against the current three-file `examples/` corpus
+and the schema's own embedded examples, not assumed to be regression-free.
+
+Environment note, unrelated to any of the five: this sandbox's `python3` had neither `jsonschema`
+nor `pyyaml` installed, which made three of `scripts/verify.sh`'s sections report `FAIL` for a
+reason outside this feature's scope (`pip install jsonschema pyyaml` — this repository's own
+`quickstart.md` precedent in `specs/004-strip-to-schema/` names the same prerequisite). Installed
+locally for this research; not a repository change.
+
+## R1 — Issue #37: the self-check probes pass for the wrong reason
+
+**Decision**: Before the seven mutation probes run, assert their shared base document validates
+with zero errors. Fail the section — not report `ok` — if either the base assertion or any probe
+fails.
+
+**Evidence**. The base document `scripts/verify.sh` builds for all seven probes, validated as-is
+against the current schema:
+
+```
+spec/requirements/0: Additional properties are not allowed ('indicator' was unexpected)
+spec/requirements/0: 'selector' is a required property
+spec/requirements/0/criteria/0: 'metric' is a required property
+spec/requirements/0/criteria/0: Unevaluated properties are not allowed ('aggregation', 'op', 'threshold', 'unit' were unexpected)
+```
+
+Four errors, before any probe's mutation is applied. Every probe's rejection is real — the base
+document was already invalid — but attributes to the wrong cause. A closure that came loose (say,
+`additionalProperties: false` dropped from a criterion) would still show a probe "passing"
+(rejecting), for one of these four unrelated reasons, and the section would keep printing
+`ok 8 embedded examples valid, 7 closures still reject` exactly as it does today. This matches the
+issue's own diagnosis exactly, confirmed independently rather than taken on the issue's word.
+
+**Rationale**: the fix has to repair the base document (add `selector`, drop the leftover
+`indicator` key it never needed, add `metric` where `max` requires it — the four errors above,
+resolved) *and* add the missing precondition assertion, or a future edit to the base document
+could silently reintroduce the same vacuity in a new shape.
+
+**Alternatives considered**: rewriting each of the seven probes as an independent, fully-valid
+document (no shared base) — rejected as unnecessary duplication; the shared-base-plus-mutation
+shape already in `scripts/verify.sh` is sound, it is only unchecked at its foundation.
+
+**Implementation note, found while applying the fix, not anticipated here**: dropping the leftover
+`indicator` key from `doc()` breaks the "displayName on a series" probe, whose mutation reached
+into `indicator.distribution` — a construct that does not exist anywhere in the current schema
+(dead since the assertion-first design it belonged to was reverted, the same root cause as issue
+#38's dead conditional). That probe was repointed to test the same class of closure — an
+`additionalProperties: false` object rejecting a `displayName` it never declared — at the document
+root, the one place still uncovered. The probe count stays at seven; confirmed live that all seven
+still reject correctly against the fixed base document.
+
+## R2 — Issue #42: one defect, two error messages
+
+**Decision**: give `$defs/predicate` `"additionalProperties": false` directly. Change
+`criteria.items` and `guards.items` from `{"allOf": [{"$ref": "#/$defs/predicate"}], "unevaluatedProperties": false}`
+to a plain `{"$ref": "#/$defs/predicate"}`.
+
+**Evidence**. Dry-run against a copy of the current schema with this change applied:
+
+| Case | Before | After |
+|---|---|---|
+| `unit: "mss"` (typo) | 2 errors: the real one, plus `Unevaluated properties are not allowed ('aggregation', 'metric', 'op', 'threshold', 'unit' were unexpected)` | **1 error**: `'mss' is not one of [...]` |
+| Unknown key (`agregation`) | 2 errors: `'aggregation' is a required property`, plus the `unevaluatedProperties` message blaming five valid keys | **2 errors, both naming the typo**: `Additional properties are not allowed ('agregation' was unexpected)` and `'aggregation' is a required property` |
+| Current valid requirement | 0 errors | **0 errors** |
+| Full `examples/` corpus (3 files) | passes | **passes — 0 regressions** |
+
+Note the second row honestly: the unknown-key case goes 2 errors → 2 errors, not 2 → 1. What
+changes is *which* two. Before, one message named five perfectly valid keys as unexpected; after,
+both messages name the offending key and nothing else. SC-002's "one defect, one message" holds
+for a bad value, which is the common case; a misspelled key is inherently two facts — the key that
+should not be there and the key that should — and saying so twice is the clearer diagnosis, not
+noise. `README.md` states this where a document author will meet it.
+
+**Rationale**: `unevaluatedProperties: false` evaluates against everything the sibling `allOf`
+managed to evaluate; when the nested `$ref` fails validation for any reason, JSON Schema does not
+credit it with evaluating anything, so every property the object actually has reads as
+unevaluated. Closing `predicate` over its own properties removes the indirection: there is no
+longer a sibling `unevaluatedProperties` keyword to misfire, because the object that owns
+`additionalProperties: false` is the same object whose `required`/`properties` produced the real
+error.
+
+**Alternatives considered**: none — this is a mechanism fix, and JSON Schema Draft 2020-12 offers
+exactly one way to avoid `unevaluatedProperties` blaming a failed `$ref`'s siblings: don't route
+the object's own closure through `unevaluatedProperties` in the first place.
+
+**Sequencing note**: this and R3 both edit `criteria.items`/`guards.items`. After R2 lands, both
+are already a plain `$ref` with no `allOf` wrapper, so R3's remaining `guards.items` change (the
+no-op `"properties": {}`) is a no-op if R2 already replaced the whole `items` value — confirm at
+implementation time which of R2 or R3 lands first, and reconcile the other's diff against the
+result rather than replaying it blindly.
+
+## R3 — Issue #38: an `if` that can never match
+
+**Decision**: delete the `allOf` block on `$defs/requirement` (the one whose `if` requires an
+`indicator` property `requirement` neither declares nor allows). Delete the no-op
+`"properties": {}` on `guards.items`.
+
+**Evidence**: `requirement`'s `properties` are `name`, `guards`, `criteria`, `displayName`,
+`selector` — no `indicator` — and `additionalProperties: false` forbids anything else. The `if`'s
+`required: ["indicator"]` therefore cannot be satisfied by any document that validates; this is
+provable by reading the schema and does not need a probe to confirm, though one was run anyway:
+dry-run of the schema with both pieces removed against the current `examples/` corpus and the
+schema's own embedded `selector`/`predicate`/`requirement` examples produced **zero regressions**
+in either.
+
+**Rationale**: matches the issue's own fix instruction exactly. The constraint the dead `if` was
+trying to state (a ratio indicator's `bad`/`good` predicate limited to `rate`/`count`) already
+lives, and is enforced, inside `$defs/predicate`'s own `allOf` (*"A fraction has no percentile"*) —
+confirmed present in the schema read for this research, at `$defs/predicate/allOf[2]`.
+
+**Alternatives considered**: none — the issue identifies the dead code precisely and the fix is
+deletion; there is no design space here.
+
+## R4 — Issue #43: the link checker reads a regex as a link
+
+**Decision**: in `scripts/verify.sh`'s "Internal markdown links resolve" section, strip fenced
+code blocks and inline code spans from each markdown file's text before applying the
+`\]\([^)]+\)` extraction — moving the check from a raw `grep` into the Python this file already
+reaches for whenever a check stops being one grep long (the "Docs are English" section's own
+history, and the isolation section, are the precedent already in this file).
+
+**Evidence, reproduced live against the current repository, not assumed from the issue**:
+
+1. Pasting the schema's literal `name` pattern into a code span in a scratch copy of `README.md`
+   (then reverted) made the link-resolution section fail with `FAIL ./README.md -> [a-z0-9-]*[a-z0-9]`.
+2. This spec's own first draft of User Story 4 quoted the same literal pattern in a code span and
+   tripped the identical failure against `specs/005-fix-milestone-bugs/spec.md` itself —
+   independent confirmation, and the reason this spec's prose was rewritten to describe the
+   pattern rather than quote it verbatim (see spec.md, User Story 4).
+3. **Correction to the issue's premise, found during this research**: the workaround the issue
+   describes — spaces inserted into the printed pattern, plus a sentence explaining why — is not
+   present in the current `README.md`. The repository-wide restructuring in #47 (`schema/README.md`
+   merged into root `README.md`) replaced it with a prose paraphrase (*"`^[a-z0-9]` then letters,
+   digits and hyphens, no trailing hyphen"*), which avoids the false positive incidentally, without
+   ever being written as a fix for it. A repo-wide grep for the workaround's telltale phrasing
+   ("spaces are not real", "build tooling") found nothing outside this spec's own draft text. The
+   spec (User Story 4, FR-009, SC-004) was corrected in place once this was confirmed, rather than
+   left describing a workaround that no longer exists.
+
+**Rationale**: matches the issue's own preferred option ("strip fenced blocks and code spans
+before extracting"), rejected the issue's second option (skip non-path-shaped targets) for the
+same reason the issue itself gives — cheaper, but leaves the next lookalike to be found the same
+accidental way this one was.
+
+**Follow-on, in scope per FR-009**: once the checker no longer misflags it, restate `README.md`'s
+`name` field row as the literal regex in place of the current paraphrase — precise documentation
+the checker bug was blocking, not a workaround to remove (there is none left to remove).
+
+## R5 — Issue #46: the scaffolding record no longer matches the repository
+
+**Decision**: bring `.copier-answers.yml` into agreement with the `AGENTS.md` it regenerates, and
+verify that by re-rendering the template rather than by comparing text by hand.
+
+> **Superseded during implementation, on both counts.** This section first named six answers and
+> prescribed "re-answer, do not hand-edit". The six are seven: issue #46's table names
+> `test_model`, which the transcription below dropped, while `project_tagline` comes from the
+> issue's closing prose. And re-rendering found an eighth, `commands`, that no reading of the issue
+> would have caught — a real `copier recopy` at the recorded `_commit` is the only thing that shows
+> whether the record disagrees with what the template produces. See spec.md FR-010/FR-011 and
+> tasks.md T025/T044.
+
+**Evidence**: direct comparison, current `.copier-answers.yml` against current `AGENTS.md` /
+`README.md`:
+
+| Answer | Recorded value (excerpt) | Current reality |
+|---|---|---|
+| `architecture` | *"`docs/GLOSSARY.md` defines the terms... layering... in `docs/compatibility.md`"* | `GLOSSARY.md` is at the repository root; no `docs/compatibility.md` exists |
+| `structure` | *"`docs/` -> the notes themselves; `docs/adr/`... `docs/examples/`... `docs/semconv/`... `docs/references.md`"* | `docs/` holds only `ideas.md`; none of the four named subpaths exist |
+| `stack_detail` | *"No code... because there is no schema yet"* | a schema exists at `schema/opennfr.io/v1/requirementset.schema.json` and gates every commit |
+| `dep_manifest` | *"`docs/GLOSSARY.md` is the vocabulary truth"* | `GLOSSARY.md` (root) is the vocabulary truth, per `AGENTS.md`'s own Boundaries section |
+| `role` | *"This repo is a design notebook, not a product"* | `AGENTS.md`'s Role section now reads *"The format is minimally usable — a schema, a validated corpus and a gate"* |
+| `project_tagline` | *"Design notes toward an open, tool-agnostic format... Nothing is stable yet"* | superseded framing per issue #46, citing #40 |
+
+Six for six: every answer issue #46 names is confirmed still drifted from the file it is meant to
+describe.
+
+**Rationale**: `.copier-answers.yml`'s own header forbids hand-editing (*"Changes here will be
+overwritten by `copier update` — NEVER EDIT MANUALLY"*) because Copier owns regenerating
+`AGENTS.md` sections from these answers; a hand-edit that disagrees with what Copier would produce
+from the same answers is the same class of drift in the opposite direction. Re-answering is the
+only fix that stays correct through the *next* `copier update`, which a hand-edit would not.
+
+**Alternatives considered**: hand-editing the YAML directly — rejected per the file's own header
+and per the issue's explicit instruction ("re-answer, do not hand-edit"). If Copier is unavailable
+in the environment that implements this fix, `spec.md`'s Assumptions section records the fallback:
+a manually-authored update verified line-by-line against current `AGENTS.md`, treated as a
+degraded substitute and named as such, not silently presented as the same thing.

--- a/specs/005-fix-milestone-bugs/spec.md
+++ b/specs/005-fix-milestone-bugs/spec.md
@@ -1,0 +1,154 @@
+# Feature Specification: Fix Milestone v0.3.0 Bugs
+
+**Feature Branch**: `005-fix-milestone-bugs`
+
+**Created**: 2026-08-23
+
+**Status**: Draft
+
+**Input**: User description (translated from Russian; this repository's `bash scripts/verify.sh` requires English-only documentation, `specs/` included): "Fix all the bugs in milestone https://github.com/galax-io/opennfr/milestone/2" — the milestone this pointed to has since been renumbered; see Scope note and Clarifications.
+
+**Scope note**: The six issues this spec covers (#31, #37, #38, #42, #43, #46) were originally filed against milestone v0.2.0 (`github.com/galax-io/opennfr/milestone/2`). That milestone has since **shipped** (`v0.2.0` released 2026-08-23, tag and GitHub Release both live) with all its other work closed, and these six — the only ones still open at release time — were moved to the new **milestone v0.3.0** (`github.com/galax-io/opennfr/milestone/3`), which is now the active milestone for this spec's PRs per `AGENTS.md`. Five describe defects — something that is broken, misleading, or silently wrong today: #37, #42, #38, #43, #46. The sixth, #31 ("The schema carries no examples, so an editor can offer none"), asks to *add* a capability the schema never had; it is an enhancement, not a bug, and is out of scope for this spec. See Assumptions.
+
+## Clarifications
+
+### Session 2026-08-23
+
+- Q: Should issue #31 ("the schema carries no examples") stay out of this bug-fix spec, or be included? → A: Keep it out — #31 is an enhancement (add examples), not a bug; this spec stays scoped to the 5 defects (#37, #42, #38, #43, #46).
+- Correction (user-reported, not a formal clarification question): milestone v0.2.0 released and its remaining open issues — the same six this spec already covers — were renumbered to milestone v0.3.0 (`github.com/galax-io/opennfr/milestone/3`), confirmed via `gh api repos/galax-io/opennfr/milestones` (v0.2.0: 0 open issues, released; v0.3.0: 6 open issues, matching this spec exactly). No issue, priority, requirement or fix in this spec changes — only the milestone every resulting PR must be assigned to (`AGENTS.md`, "Milestones (ALWAYS)").
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The verification gate must actually verify (Priority: P1)
+
+A maintainer changes `criteria.items` in the schema — say, drops `additionalProperties: false` — expecting `bash scripts/verify.sh` to catch it, because the gate has a dedicated self-check section for exactly this class of regression ("closures still reject"). Today every one of those seven probes is built on a base document that is already invalid *before* the intended mutation is applied, so each probe is rejected for a reason unrelated to what it claims to test. The section prints `ok` regardless of whether the schema actually still closes over its properties.
+
+**Why this priority**: This is the safety net for every other change in the schema, including the other four fixes in this spec. If it cannot fail, nothing that depends on it (including the fixes below) can be trusted as verified. It must be fixed first, or verified independently of the others.
+
+**Independent Test**: Run `bash scripts/verify.sh` after asserting the seven probes' shared base document validates cleanly *before* mutation; deliberately drop a closure (e.g. remove `additionalProperties: false` from `$defs/requirement`) and confirm the corresponding probe now fails instead of reporting `ok`. Name a closure that exists *after* US2 lands: US2 removes the `unevaluatedProperties: false` wrappers, so `criteria.items` has no closure of its own to drop.
+
+**Acceptance Scenarios**:
+
+1. **Given** the shared base document used by the seven closure probes, **When** it is validated unmutated, **Then** it is accepted (zero errors) — establishing that any later rejection is caused by the mutation, not by pre-existing drift.
+2. **Given** a schema where a closure (e.g. `additionalProperties: false` on `$defs/requirement`, or `$defs/displayName`'s `maxLength`) has been accidentally removed or loosened, **When** `bash scripts/verify.sh` runs, **Then** the corresponding probe fails and the run reports the loss instead of printing `ok`.
+3. **Given** the current, correct schema, **When** `bash scripts/verify.sh` runs, **Then** all seven probes still pass for the right reason (each rejected only by the closure it targets).
+
+---
+
+### User Story 2 - One mistake, one error message (Priority: P2)
+
+A contributor writes a requirement with `unit: mss` (a typo for `ms`). Validation reports the correct error — `'mss' is not one of [...]` — immediately followed by a second error blaming `aggregation`, `metric`, `op`, `threshold`, and `unit` as a group of "unevaluated properties," even though every one of those keys is exactly what a predicate is supposed to have. The second message is noise that obscures the first, real diagnosis, on every single predicate mistake (bad unit, missing metric, bad percentile — all of them).
+
+**Why this priority**: The format's stated argument for strict schemas is that they catch typos with a clear diagnostic. A confusing double-error on the single most common mistake (a predicate typo) undermines that argument for every person who ever writes a document by hand.
+
+**Independent Test**: Validate a requirement with a single deliberate predicate defect (e.g. `unit: mss`) against the schema and confirm exactly one error is reported, naming only the actually-invalid field.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requirement whose only defect is an invalid `unit` value, **When** it is validated, **Then** exactly one error is reported and it identifies `unit` as invalid — no second error lists the requirement's valid fields as unevaluated.
+2. **Given** a requirement missing the required `metric` field, **When** it is validated, **Then** the reported error(s) identify `metric` as missing, without a companion "unevaluated properties" error naming the fields that are present and valid.
+3. **Given** the existing validated corpus in `examples/`, **When** each document is re-validated, **Then** every one still validates (no change in what is accepted).
+
+---
+
+### User Story 3 - A schema rule that can never fire is removed (Priority: P3)
+
+`$defs/requirement` carries an `allOf` block whose `if` checks for an `indicator` property that the same object's `additionalProperties: false` already forbids at that level — no document that validates can ever satisfy the `if`, so the `then` (restricting `criteria[].aggregation` to `rate`/`count` for a ratio indicator) never applies. The rule it was meant to enforce already lives, and works, inside the predicate definition since #33. Separately, `guards.items` carries a no-op `"properties": {}` that its sibling `criteria.items` does not have.
+
+**Why this priority**: This sits in the compatibility-sensitive schema surface, cites the glossary as its authority, and enforces nothing — the next person who reworks `requirement` could "fix" the unreachable condition and accidentally reinstate a constraint nobody actually argued for. It is a latent risk, not an active malfunction, so it ranks below the two fixes above.
+
+**Independent Test**: Remove the unreachable `allOf` and the no-op `properties: {}`, then confirm `bash scripts/verify.sh` stays green and no document in `examples/` changes meaning (all still validate, and no previously-rejected document becomes accepted).
+
+**Acceptance Scenarios**:
+
+1. **Given** the current `$defs/requirement`, **When** any document is validated, **Then** the unreachable `allOf`'s `then` branch has no observable effect (already true today — confirmed as a precondition, not introduced).
+2. **Given** the schema with the unreachable `allOf` and the no-op `properties: {}` removed, **When** the full `examples/` corpus is validated, **Then** every document validates exactly as it did before the change.
+3. **Given** the cleaned-up schema, **When** a ratio-indicator requirement uses an aggregation other than `rate`/`count` in a `bad`/`good` predicate, **Then** it is still rejected — by the predicate-level rule from #33, which was already carrying this constraint.
+
+---
+
+### User Story 4 - The link checker stops flagging a regex as a link (Priority: P4)
+
+The schema's `name` field is validated by a regular expression whose bracket-group-then-parenthesized-group shape closes a `]` immediately followed by a `(` — the same two characters, adjacent, that mark the start of a markdown link target. The gate's link-resolution check is a raw grep for that adjacency with no awareness of code fences or code spans, so writing the pattern's real characters into a code span anywhere under version control fails the build. (Confirmed reproducible today — verified during planning, not assumed from the source issue: pasting the schema's literal `name` pattern into a code span, in this spec's own draft and in a scratch edit to `README.md`, both tripped the same false positive; see `research.md` for the reproduction.) The source issue describes an earlier workaround — spacing the pattern's characters apart and adding a sentence explaining why — that a later, unrelated restructuring of this repository's documentation has since superseded: `README.md` today states the pattern in paraphrased prose instead of as a literal regex, which happens to avoid the trigger too, but leaves the reference less precise than the schema it describes, and leaves the underlying checker bug unfixed and ready to resurface the moment anyone writes the pattern out literally again — as this very spec did.
+
+**Why this priority**: It blocks accurate documentation — today's paraphrase is a workaround by another name — and stands ready to fail the build again the moment anyone writes the schema's actual pattern into a code span, as happened while drafting this spec. It doesn't threaten the schema's own correctness, so it ranks below the diagnostic and gate fixes above.
+
+**Independent Test**: Write the exact `name` pattern regex into a code span in `README.md`, run `bash scripts/verify.sh`, and confirm the link check passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a markdown code span or fenced code block containing a closing bracket immediately followed by an opening parenthesis (the two characters that also open a markdown link target), **When** the link-resolution check runs, **Then** it does not treat that text as a link to resolve.
+2. **Given** the `name` pattern written verbatim (with real, unmodified regex characters) in `README.md`, **When** `bash scripts/verify.sh` runs, **Then** the link check passes.
+3. **Given** a genuine broken markdown link outside any code span or fence, **When** the link-resolution check runs, **Then** it still fails the gate as before (no loss of detection).
+4. **Given** the fix has landed, **When** `README.md`'s `name` field row is restated as the literal, unmodified pattern in place of today's prose paraphrase, **Then** `bash scripts/verify.sh` passes — proving the fix, not just describing it.
+
+---
+
+### User Story 5 - The scaffolding record matches the repository it describes (Priority: P5)
+
+`.copier-answers.yml` is the record Copier uses to regenerate scaffolded files, including sections of `AGENTS.md`, on `copier update` — its own header says never to hand-edit it. Seven of its recorded answers describe a state of the repository that AGENTS.md has since corrected (paths that moved, a schema that now exists, framing the README stopped using): the six issue #46 tabulates — `architecture`, `structure`, `stack_detail`, `dep_manifest`, `role`, `test_model` — plus `project_tagline`, which the issue names in its closing prose rather than its table. An eighth, `commands`, is found drifted by the round-trip test in Acceptance Scenario 2 and is corrected here for that reason rather than because the issue names it. Nothing is broken today, but the next `copier update` will regenerate `AGENTS.md` from these stale answers and silently revert every one of those corrections.
+
+**Why this priority**: The defect is real but dormant — it only manifests on the next template update, which is not guaranteed to happen during this milestone. It is included because it is a confirmed, described bug (not a hypothetical), but it is the least urgent of the five.
+
+**Independent Test**: Render the template at the recorded `_commit` from the corrected answers and diff the `AGENTS.md` it produces against the one on disk. Identical output is the whole claim; anything else means the record still reverts a correction.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current `.copier-answers.yml`, **When** each answer is compared against the `AGENTS.md` section it feeds, **Then** every one matches what `AGENTS.md` actually says today.
+2. **Given** the corrected answers, **When** the template is actually re-rendered at the recorded `_commit`, **Then** the `AGENTS.md` it produces is **byte-identical** to the file on disk.
+3. **Given** the fix, **When** the record is inspected, **Then** no answer disagrees with what the template would produce from it — which is what the "never hand-edit" header exists to protect, and what Scenario 2 tests directly.
+
+---
+
+### Edge Cases
+
+- What happens when a document has more than one predicate defect at once (e.g. a bad unit on one criterion and a missing metric on another)? Each real defect must still be reported on its own, without either being obscured by an "unevaluated properties" message naming valid fields.
+- What happens to a document that (accidentally) depended on the unreachable `allOf` or the no-op `properties: {}` having some effect? None should exist, since both were provably inert — but every document in `examples/` must be re-validated to confirm no meaning changed.
+- What happens when the link check encounters a code span that legitimately contains link-shaped text pointing at a real, resolvable path? It must still be skipped as non-link content (code spans are never treated as links, regardless of their contents) — this is a deliberate scope boundary, not a partial fix.
+- What happens if `.copier-answers.yml` drifts again after this fix (a future AGENTS.md correction not mirrored back into the answers)? Nothing catches it: the round-trip test in FR-011 is run by hand here, not by `scripts/verify.sh`. Gating it is out of scope for this spec and worth its own issue — the drift this fix corrects went unobserved for exactly as long as nothing rendered the template.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The verification gate's schema self-check MUST confirm that the shared base document used by its "closures still reject" probes validates successfully *before* any probe-specific mutation is applied, so a probe's rejection can only be attributed to the mutation it targets.
+- **FR-002**: The verification gate MUST fail (not report `ok`) when a probe's targeted closure (e.g. `additionalProperties: false`, a required field, a `maxLength` or `minLength` bound) is missing or loosened.
+- **FR-002a**: The verification gate MUST fail rather than report `ok` if no closure probe remains — a probe that was deleted cannot fail, and a section reporting success over zero probes is the same defect FR-001 exists to remove.
+- **FR-003**: Validating a requirement whose only defect is a single invalid predicate field MUST produce an error set that identifies only the actually-invalid field(s) — it MUST NOT also report the requirement's other, valid fields as "unevaluated."
+- **FR-004**: The `$defs/requirement` schema definition MUST NOT contain a conditional (`if`/`then`) that can never match given that same object's own property constraints.
+- **FR-005**: The constraint the unreachable conditional was meant to enforce (a ratio indicator's `bad`/`good` predicate restricted to `rate`/`count` aggregation) MUST remain enforced through the existing predicate-level rule, with no change in which documents validate.
+- **FR-006**: `guards.items` and `criteria.items` MUST use the same schema construction for referencing the shared predicate definition, without either carrying a no-op addition the other lacks.
+- **FR-007**: The verification gate's link-resolution check MUST NOT treat text inside a markdown code span or fenced code block as a link to be resolved, including a fence indented by up to three spaces and a code span whose delimiters are backslash-escaped (which are literal text, not delimiters).
+- **FR-008**: The verification gate's link-resolution check MUST continue to detect and fail on a genuinely broken markdown link located outside code spans and fenced code blocks. It MUST resolve a target beginning with `/` against the repository root, as GitHub renders it, and MUST fail — never skip — a file it cannot read.
+- **FR-008a**: Both link scanners in the gate — resolution and `docs/` isolation — MUST share one definition of what a markdown link is. That definition MUST be checked on every run against fixtures covering **both** halves, extraction and path resolution, and the fixture list MUST itself have a floor: an emptied list reports no failures and reads exactly like a sound extractor. Two scanners disagreeing made the isolation rule impossible to state in the documents it governs.
+- **FR-002b**: Every constraint the schema makes MUST have a probe that fails when it is loosened, and the probe set MUST have a floor. Where a constraint cannot change a verdict — it is redundant for validity but produces a message the documentation quotes — the probe MUST check the message instead.
+- **FR-009**: `README.md` MUST state the schema's `name` validation pattern as the literal, unmodified regular expression, in place of today's prose paraphrase, with no inserted spacing and no explanatory text about the verification gate's implementation.
+- **FR-010**: `.copier-answers.yml`'s `architecture`, `structure`, `stack_detail`, `dep_manifest`, `role` and `test_model` answers (issue #46's table), plus `project_tagline` (its closing prose) and `commands` (found drifted by FR-011's test), MUST reflect the current content of `AGENTS.md` rather than the pre-correction state they describe.
+- **FR-011**: Rendering the template at the recorded `_commit` from the corrected record MUST produce an `AGENTS.md` byte-identical to the one on disk. This is the requirement; *how* the values reached the file is not. The "never hand-edit" header exists to stop a record that disagrees with what the template would produce, and only re-rendering can show whether it does — a value typed into a prompt is no safer than one typed into the file if nobody renders it.
+- **FR-012**: After all fixes, `bash scripts/verify.sh` MUST exit successfully (green) and every document currently in `examples/` MUST continue to validate.
+
+### Key Entities
+
+- **Verification gate probe**: A base document plus a targeted mutation, used by `scripts/verify.sh` to prove a specific schema closure is still enforced; must itself be provably valid before mutation.
+- **Predicate validation error**: The set of error messages the schema produces for one invalid document; must map one real defect to one clear message, not one defect to two (one real, one spurious).
+- **Requirement schema definition**: The compatibility-sensitive `$defs/requirement` object in `schema/opennfr.io/v1/requirementset.schema.json`; the surface where the unreachable conditional and the `guards`/`criteria` asymmetry live.
+- **Scaffolding answer record**: `.copier-answers.yml`, the Copier-owned source of truth that regenerates parts of `AGENTS.md`; must stay synchronized with the file it generates.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `bash scripts/verify.sh` passes end to end after all five fixes land, with the full `examples/` corpus still validating (zero regressions).
+- **SC-002**: Every message a predicate defect produces names that defect. An invalid *value* produces exactly one message, down from two. A misspelled *key* produces two — the key that is not expected and the key that is missing — where before, one of the two blamed five fields that were all correct.
+- **SC-003**: All seven "closures still reject" probes in the verification gate fail when their targeted closure is deliberately removed from the schema (tested by temporarily reintroducing each of the seven prior gaps and confirming detection), instead of unconditionally reporting `ok`.
+- **SC-004**: `README.md` states the `name` pattern as the exact regular expression from the schema — not today's prose paraphrase — with zero inserted characters and zero sentences explaining internal tooling, and the gate still passes.
+- **SC-005**: `.copier-answers.yml`'s drifted answers are brought to zero, proved mechanically: re-rendering the template at the recorded `_commit` produces an `AGENTS.md` byte-identical to the one on disk.
+- **SC-006**: The unreachable conditional and the `guards.items`/`criteria.items` construction asymmetry are both removed from the schema with no change in which documents validate.
+
+## Assumptions
+
+- **Bug vs. enhancement boundary (confirmed)**: issue #31 ("The schema carries no examples, so an editor can offer none") requests adding a capability the schema has never had; it describes an absence, not a malfunction. Confirmed out of scope during clarification — see Clarifications, Session 2026-08-23. It would need its own spec if ever pursued.
+- **Milestone (confirmed)**: this spec's six issues now live in milestone v0.3.0, not v0.2.0 — v0.2.0 shipped and these were the only issues still open at release time, moved forward rather than blocking the release. See Clarifications, Session 2026-08-23.
+- **One fix, one change unit**: Consistent with this project's "1 issue = 1 commit" / "1 concern per PR" convention, the five user stories above are expected to ship as five independent changes, each verifiable on its own via `bash scripts/verify.sh` — not as a single combined change.
+- **No behavior change beyond the defect**: Every fix (FR-003 through FR-006, FR-007 through FR-009) is a correction to diagnostics, dead logic, or documentation; none is expected to change which documents the schema accepts, except where a fix's entire purpose is to correct an incorrect accept/reject outcome (none of the five do — all five are diagnostics, dead-code, or drift corrections, not acceptance-behavior changes).
+- **Copier is available, and is what verifies the record**: FR-011's byte-identity test needs the template rendered at the recorded `_commit`, which needs Copier and network access to the template repository. Both were present. The test is run against a throwaway copy of the repository, never in place: `copier recopy --overwrite` rewrites template-managed files, and this repository has deliberately diverged from several of them.

--- a/specs/005-fix-milestone-bugs/tasks.md
+++ b/specs/005-fix-milestone-bugs/tasks.md
@@ -1,0 +1,492 @@
+---
+description: "Task list for 005-fix-milestone-bugs"
+---
+
+# Tasks: Fix Milestone v0.3.0 Bugs
+
+**Input**: Design documents from `/specs/005-fix-milestone-bugs/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: No test-code tasks — there is no application code. `bash scripts/verify.sh` is what
+stands in for tests, and every story's own verification tasks run it (and probe it) rather than
+add a separate test suite.
+
+**Organization**: By user story, one per milestone issue, so each ships as its own commit per
+`AGENTS.md`'s "1 issue = 1 commit". All five are independently testable; only US3 has a real
+dependency (on US2 — see Dependencies below).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different files, or read-only, with no dependency on an
+  incomplete task
+- **[Story]**: US1–US5, mapping to issues #37, #42, #38, #43, #46; absent on Setup and Polish
+
+---
+
+## Phase 1: Setup
+
+- [X] T001 Confirm the gate is green before any change: if `bash scripts/verify.sh` reports
+      `jsonschema` or `pyyaml` missing, run
+      `python3 -m pip install --user --break-system-packages pyyaml jsonschema`
+      (quickstart.md, Prerequisites); then run `bash scripts/verify.sh` from the repository root
+      and confirm it reports `PASS`. This is the baseline every story's own gate run is checked
+      against — none of the five defects currently turns the gate red (they are silent or
+      unreachable today, per research.md), so `PASS` here is expected, not a surprise
+
+**Checkpoint**: baseline confirmed green. Every later `FAIL`/`PASS` in this file is a delta against
+this run.
+
+---
+
+## Phase 2: Foundational
+
+None. The five fixes touch disjoint concerns except the one pairwise dependency recorded under
+Dependencies below (US3 on US2) — there is no shared infrastructure to build first.
+
+---
+
+## Phase 3: User Story 1 — The verification gate must actually verify (#37, Priority: P1) 🎯 MVP
+
+**Goal**: the seven "closures still reject" probes in `scripts/verify.sh` fail for the right
+reason, not the wrong one.
+
+**Independent Test**: temporarily drop a closure the probes are meant to guard, confirm the
+section now `FAIL`s naming it, then restore.
+
+- [X] T002 [US1] In the `SELFCHECK` Python block of `scripts/verify.sh`, fix the `doc()` factory
+      function that builds the seven probes' shared base document: add `"selector": {}` to the
+      requirement and `"metric": "m"` to the criterion, clearing the four pre-existing errors
+      recorded in research.md R1 (FR-001). **Discovered during implementation**: clearing those
+      four errors also requires dropping the bogus `indicator` key `doc()` carried (`requirement`
+      has no such property — the same dead `indicator` concept issue #38 targets in the schema
+      itself); doing so breaks the "displayName on a series" probe, which mutated
+      `indicator.distribution` — a construct that no longer exists anywhere in the schema. That
+      probe was repointed to test the same closure class (an object with
+      `additionalProperties: false` rejecting an undeclared `displayName`) at the one place still
+      uncovered: the document root. Probe count stays at seven; see the comment left in
+      `scripts/verify.sh` and research.md R1 addendum
+- [X] T003 [US1] In the same `SELFCHECK` block, immediately after `doc()` is defined, assert the
+      unmutated base document validates with zero errors; if it does not, print `FAIL` naming
+      every error and `sys.exit(1)` — this file's own idiom inside a Python heredoc block, the
+      equivalent of the outer `bad()`/`fail=1` pattern — instead of letting the section fall
+      through to `ok` (FR-001, FR-002)
+- [X] T004 [US1] Run `bash scripts/verify.sh` and confirm the "schema holds up its own examples,
+      and still rejects" section still reports `ok    8 embedded examples valid, 7 closures still
+      reject` — the probes themselves are unchanged, only their foundation is fixed. **Confirmed
+      live**: exact output matched
+- [X] T005 [US1] Probe rather than trust (contracts/verify-sections.md § Acceptance): temporarily
+      remove `"additionalProperties": false` from `$defs/requirement` in
+      `schema/opennfr.io/v1/requirementset.schema.json`, run `bash scripts/verify.sh`, and confirm
+      the section now **FAILS** on the "unknown field on a requirement" probe, naming the loss
+      instead of printing `ok`; then revert the temporary edit and confirm `ok` returns (chosen
+      because `$defs/requirement`'s own closure is untouched by US2/US3, so this probe is valid
+      regardless of story order). **Confirmed live**: `FAIL  the schema accepts what it must
+      reject: unknown field on a requirement`; reverted, `ok` returned, schema byte-identical to
+      before (`git diff` empty). **Extended after review (T043)**: SC-003 asks for each of the
+      seven, not one — the full sweep now runs all seven and each flips exactly its own probe
+- [X] T006 [US1] Run `bash scripts/verify.sh` in full and confirm `PASS`. **Confirmed live: PASS**
+
+**Checkpoint**: the gate's own self-check can now fail. Every later story's "zero regressions"
+claim is backed by a check that has just been proven capable of catching a regression.
+
+---
+
+## Phase 4: User Story 2 — One mistake, one error message (#42, Priority: P2)
+
+**Goal**: a single invalid predicate field produces exactly one validation error, not two.
+
+**Independent Test**: validate a requirement with `unit: "mss"` and count the errors.
+
+- [X] T007 [US2] Add `"additionalProperties": false` to `$defs/predicate` in
+      `schema/opennfr.io/v1/requirementset.schema.json` (FR-003; research.md R2)
+- [X] T008 [US2] Change `$defs/requirement.properties.criteria.items` from
+      `{"allOf": [{"$ref": "#/$defs/predicate"}], "unevaluatedProperties": false}` to a plain
+      `{"$ref": "#/$defs/predicate"}` (FR-003, FR-006)
+- [X] T009 [US2] Change `$defs/requirement.properties.guards.items` the same way — a plain
+      `{"$ref": "#/$defs/predicate"}` — which also removes its no-op `"properties": {}` as a side
+      effect of replacing the whole `items` value (FR-003, FR-006; data-model.md notes this
+      overlaps US3's #38 fix — T015 below reconciles against whichever of T009/T015 lands second)
+- [X] T010 [P] [US2] Validate `examples/fast-and-reliable.yaml`, `examples/one-request-is-fast.yaml`
+      and `examples/the-run-held-up.yaml` against the changed schema and confirm all three still
+      validate — zero regressions (FR-012; research.md R2 dry-run). **Confirmed live: 0
+      regressions**
+- [X] T011 [P] [US2] Validate a requirement whose only defect is `unit: "mss"` (quickstart.md § 2)
+      and confirm exactly **one** error is reported, naming `unit` (SC-002). **Confirmed live: 1
+      error**, `'mss' is not one of [...]`
+- [X] T012 [P] [US2] Validate a requirement with an unknown predicate key (e.g. a misspelled
+      `agregation`) and confirm the reported errors all name the unknown key (research.md R2
+      evidence table). **Corrected after review**: this task originally claimed, and was ticked on,
+      "exactly one error". That is false and was never run — the case yields **2 errors**,
+      `Additional properties are not allowed ('agregation' was unexpected)` and `'aggregation' is a
+      required property`. Both name the typo, which is the actual improvement (before, one of the
+      two blamed five valid keys); the count did not drop. Re-run live and recorded as 2
+- [X] T013 [US2] Run `bash scripts/verify.sh` in full and confirm `PASS`. **Confirmed live: PASS**,
+      including the "still rejects" section fixed in US1 — all 7 closures, including the one this
+      story moved, still reject correctly
+
+**Checkpoint**: a predicate mistake now produces messages that all name the mistake. A bad *value*
+produces exactly one; a misspelled *key* produces two, both pointing at that key. Independently
+shippable.
+
+---
+
+## Phase 5: User Story 3 — A schema rule that can never fire is removed (#38, Priority: P3)
+
+**Depends on US2** (T007–T009): both touch `$defs/requirement.properties.{criteria,guards}.items`.
+Implement in this order — US3's diff becomes purely subtractive once US2 has already collapsed
+both `items` to a plain `$ref` (data-model.md, "Ordering constraint").
+
+**Goal**: `$defs/requirement` carries no conditional that can never match.
+
+**Independent Test**: remove the dead `allOf`, confirm the full corpus and the schema's own
+embedded examples still validate unchanged.
+
+- [X] T014 [US3] Delete the entire `allOf` block marked
+      `"description": "UNREACHABLE. \`indicator\` was removed from \`requirement\`..."` from
+      `$defs/requirement` in `schema/opennfr.io/v1/requirementset.schema.json` (FR-004, FR-005)
+- [X] T015 [US3] Confirm `$defs/requirement.properties.guards.items` carries no `"properties": {}`
+      distinct from `criteria.items` — already true if T009 landed first (it replaced the whole
+      `items` value); if US3 is being implemented before US2 in a differently-sequenced run,
+      delete the key explicitly here instead (FR-006). **Confirmed live**: both are byte-identical
+      `{"$ref": "#/$defs/predicate"}`, already resolved by T009
+- [X] T016 [P] [US3] Validate the full `examples/` corpus (3 files) and the schema's own embedded
+      `selector`, `predicate` and `requirement` examples against the changed schema; confirm zero
+      regressions in either (FR-012; research.md R3 dry-run). **Confirmed live: 0 regressions**
+- [X] T017 [P] [US3] Confirm the constraint the deleted conditional encoded is still enforced:
+      validate a `bad`/`good` predicate using an aggregation other than `rate`/`count` (e.g.
+      `p99`) and confirm it is still rejected — by `$defs/predicate`'s own "A fraction has no
+      percentile" rule, not by the deleted block (Acceptance Scenario 3, User Story 3).
+      **Confirmed live**: rejected, `'p99' is not one of ['rate', 'count']`
+- [X] T018 [US3] Run `bash scripts/verify.sh` in full and confirm `PASS`. **Confirmed live: PASS**
+
+**Checkpoint**: no rule in `$defs/requirement` cites an authority it cannot enforce. Independently
+shippable once US2 has landed.
+
+---
+
+## Phase 6: User Story 4 — The link checker stops flagging a regex as a link (#43, Priority: P4)
+
+**Goal**: a code span or fenced code block containing `](` no longer fails the link-resolution
+gate; a genuine broken link outside one still does.
+
+**Independent Test**: write the schema's literal `name` pattern into a code span in `README.md`
+and confirm the gate passes.
+
+- [X] T019 [US4] Rewrite the link-target extraction in the "Internal markdown links resolve"
+      section of `scripts/verify.sh` to strip fenced code blocks and inline code spans from each
+      markdown file's text before matching `\]\([^)]+\)` — moving the check from the current raw
+      `grep` into Python, per research.md R4's chosen option (FR-007). Population (which files are
+      scanned) and the `found`-counter semantics were kept identical to the old pipeline —
+      confirmed live, 148 checked before and after the rewrite on the unmutated repo
+- [X] T020 [US4] Confirm the section's existing anti-silent-green guard (`found -eq 0` → `FAIL`)
+      and its `https?|mailto` exclusion still behave unchanged after the rewrite. **Confirmed
+      live**: `ok    no dangling internal links (148 checked)`
+- [X] T021 [P] [US4] Probe rather than trust: add a markdown link with a non-existent target
+      outside any code span to a scratch file, run `bash scripts/verify.sh`, confirm the section
+      **FAILS** naming it, then remove the scratch file and confirm `ok` returns (FR-008;
+      contracts/verify-sections.md § Acceptance). **Confirmed live**: `FAIL
+      ./specs/005-fix-milestone-bugs/scratch-probe.md -> this-path-does-not-exist.md`; removed,
+      `ok` returned
+- [X] T022 [US4] Replace `README.md`'s `name` field row prose paraphrase with the literal,
+      unmodified pattern from `$defs/name/pattern` — do this only after T019 lands, so the literal
+      regex does not transiently fail the unfixed checker (FR-009; research.md R4 "Follow-on")
+- [X] T023 [US4] Run `bash scripts/verify.sh` and confirm the "Internal markdown links resolve"
+      section reports `ok`, not `FAIL`, with the literal pattern now live in `README.md` (SC-004).
+      **Confirmed live: ok, 148 checked**
+- [X] T024 [US4] Run `bash scripts/verify.sh` in full and confirm `PASS`. **Confirmed live: PASS**
+
+**Checkpoint**: the schema's `name` pattern can be quoted verbatim anywhere in the repository
+without failing the build. Independently shippable.
+
+---
+
+## Phase 7: User Story 5 — The scaffolding record matches the repository it describes (#46, Priority: P5)
+
+**Goal**: `.copier-answers.yml`'s six drifted answers agree with current `AGENTS.md`/`README.md`.
+
+**Independent Test**: compare each of the six answers against current `AGENTS.md`/`README.md`
+content.
+
+- [X] T025 [US5] Bring `.copier-answers.yml` into agreement with the `AGENTS.md` it regenerates
+      (FR-010, FR-011; research.md R5 table). **Corrected after review.** As first shipped this
+      task claimed six answers and was ticked against FR-011's "must be produced by re-answering"
+      on a fallback whose stated precondition — Copier unavailable — was false: Copier 9.16.0 was
+      installed and GitHub reachable. Both problems are now closed, and not by re-typing the values
+      into a prompt:
+      (a) **Seven, not six.** Issue #46's table names `test_model`, which the spec had dropped;
+      `project_tagline` comes from the issue's closing prose, not its table. All seven are
+      corrected, and `test_model` regained the final sentence it had lost (`examples/` is the
+      validated corpus and the only place documents are published).
+      (b) **An eighth, found by testing rather than reading.** `commands` still globbed
+      `docs/**/*.yaml`; the round-trip below proved a real `copier recopy` reverts that line —
+      issue #46's stated failure, still happening. Corrected, along with its `grep-based` wording
+      that R4 falsified.
+      (c) **Verified by rendering, not by comparing.** `copier recopy --defaults --trust
+      --overwrite --vcs-ref d8b7cd1` on a throwaway copy now produces an `AGENTS.md`
+      **byte-identical** to the one on disk. That is a stronger check than the original FR-011
+      asked for: it tests the property the "never hand-edit" header protects, rather than the
+      provenance of the keystrokes. FR-011 and US5 Acceptance Scenario 3 were rewritten to require
+      this test
+- [X] T026 [US5] Compare each corrected value against the `AGENTS.md` section it feeds and confirm
+      agreement (SC-005). **Confirmed live**: `role`, `stack_detail`, `architecture` and
+      `test_model` each report EXACT MATCH after whitespace normalisation; the byte-identical
+      re-render in T025(c) covers all eight at once
+- [X] T027 [P] [US5] Confirm no unintended answer changed. **Corrected after review**: this task
+      originally asserted the diff "touches only the six", which was false — it touched seven, and
+      now eight. Verified as shipped: `_commit`, `_src_path`, `org_repo`, `project_name`, `do_git`,
+      `run_speckit`, `stack`, `build_test_cmd`, `publish_mechanism` and `release_notes_tool` are
+      untouched
+
+**Checkpoint**: the next `copier update` will regenerate `AGENTS.md` sections that already match
+what is on disk. Independently shippable, and does not touch `scripts/verify.sh` or the schema.
+
+---
+
+## Phase 8: Review response (Codex + cloud review + adversarial verification)
+
+Three reviews ran against the working tree: Codex (4 findings), a cloud review (2), and a
+9-agent adversarial workflow that verified all 6 and hunted for what they missed (13 more).
+**All 6 were CONFIRMED — none was a false positive** — and the workflow's own top finding
+(T030) was one no review had caught. Every fix below is probed, not asserted.
+
+The pattern worth recording: R4 (#43) traded a *loud* false positive for four *silent* false
+negatives. The old `grep` over-reported; the replacement under-reported, and under this
+repository's own Principle III that is the worse direction. The fixes below restore what the
+grep caught while keeping what #43 set out to fix.
+
+- [X] T030 Resolve a link target beginning with `/` against the repository root, as GitHub
+      renders it, instead of `os.path.join`-ing it onto the file's directory — which discards the
+      base and escapes to the machine's filesystem root. Both directions were live-reproduced: a
+      dangling link to a machine-absolute path reported `ok` (silent green), and a valid root-relative link to
+      the schema hard-FAILed. The `grep` this replaced got the second case right (FR-008)
+- [X] T031 Stop an escaped backtick from opening a code span. `\`` is literal text in CommonMark,
+      but `CODE_SPAN` paired it with the next real backtick and, being `re.DOTALL`, masked
+      everything between — one stray escape in prose hid three dangling links on two lines. Blanked
+      before pairing, so it can neither open nor close. The obvious one-token fix `(?<!\\)` is
+      wrong and was rejected: inside a span a backslash is already literal, so there `\`` really
+      does close (FR-007, FR-008)
+- [X] T032 Allow CommonMark's 1–3 spaces of fence indentation on **both** fence regexes, not just
+      the tilde one. The backtick anchor was equally wrong and merely masked by `CODE_SPAN`
+      matching the delimiters as a span (FR-007)
+- [X] T033 Stop a link destination matching across a newline: whole-file `[^)]+` paired `](` with
+      a `)` paragraphs away and failed the build on the blob between. The line-based `grep` could
+      not do this. A destination split across lines is not scanned — a recorded gap, stated in
+      `scripts/mdlinks.py`, matching prior behaviour (FR-007)
+- [X] T034 Fail a file that cannot be read as UTF-8 instead of aborting the section on a traceback
+      that printed neither `ok` nor `FAIL` and left every later file unscanned. The sibling "Docs
+      are English" section already had this guard; the new code was the only reader in the file
+      without it — a section that cannot run must report FAIL, per the file's own header
+- [X] T035 Give both link scanners one definition of a link (`scripts/mdlinks.py`), used by
+      resolution and by `docs/` isolation. Held apart they disagreed: a code span naming a path
+      under `docs/` was text to one gate and a violation to the other, which made the isolation
+      rule impossible to state in the documents it governs. The isolation count moved 26 → 25,
+      the miscount going away (FR-008a)
+- [X] T036 Hold the extractor to fixtures on every run — nine cases, each a direction this
+      scanner has actually been wrong in. #43 survived because nothing checked the checker; a fix
+      with no fixture reverts the next time someone tunes the regex
+- [X] T037 Fail the self-check if no closure probe remains. The examples half already guarded
+      `checked == 0`; the probes half would have printed `ok ... 0 closures still reject` and
+      passed. Probed by emptying the dict after all assignments: `FAIL`, exit 1 (FR-002a)
+- [X] T038 Delete the README "wart" paragraph, which told readers to expect and dismiss
+      `Unevaluated properties are not allowed` — a message #42 made unreachable. Replaced with what
+      is true: a bad *value* gives one message, a misspelled *key* gives two that both name it.
+      All ten rows of the error table above it were re-validated against the current schema and
+      reproduce verbatim (FR-009)
+- [X] T039 Correct the false "1 error" claims for the misspelled-key case in T012 and research.md
+      R2 — the count is 2 and always was. What #42 improved is *which* two: neither now blames a
+      valid key
+- [X] T040 Correct the quickstart's dead probe recipe. "Re-add `unevaluatedProperties: false`" is a
+      *tightening*: the section stays `ok`, and worse, it silently reinstates #42's double-error
+      behaviour, which no gate section detects. Replaced with two recipes verified to FAIL
+- [X] T041 Correct the spec's transcription of issue #46 from six answers to seven (its table names
+      `test_model`; `project_tagline` comes from its closing prose), restore the sentence
+      `test_model` had lost, and fix `plan.md`'s "fourteen answers" — the file has 16
+- [X] T042 Correct `criteria.items` / `unevaluatedProperties` references in US1's Independent Test,
+      Acceptance Scenario 2 and FR-002: US2 removes those closures, so the instructions named
+      something that no longer exists to remove
+- [X] T043 Restore SC-003's "each of the seven" in `contracts/verify-sections.md`, which had
+      quietly become "one of the seven", and run the sweep: **all seven probes flip exactly their
+      own closure**. The repointed root probe covers a closure nothing else does, so the T002
+      repoint was sound
+- [X] T044 Bring `commands` into agreement and prove #46 mechanically. A real `copier recopy` at
+      the recorded `_commit` showed one line still reverting — the `docs/**/*.yaml` glob — which is
+      #46's stated failure still occurring. Fixed, along with the `grep-based` wording R4
+      falsified in both `AGENTS.md` and the answer. Re-render now yields a **byte-identical**
+      `AGENTS.md`, and FR-011 was rewritten to require that test instead of the unfalsifiable
+      "was it typed into a prompt"
+
+- [X] T045 Rewrite `scripts/mdlinks.py` as a line scanner after a second review round found the
+      regex version wrong in the *silent* direction on three counts: one stray backtick hid every
+      link to the next backtick (`re.DOTALL`, unbounded); an escaped backtick inside a well-formed
+      span broke the span, hiding what followed; and a four-backtick fence closed on the next
+      three-backtick line, swallowing a real link. Code spans are now paired per line, so a stray
+      backtick costs one line; fences are a proper state machine (3+ delimiters, longer closes,
+      indentation, blockquote prefixes, info strings); an escaped backtick cannot open a span but
+      can still close one, which is what CommonMark does and what the previous fix got backwards.
+      Validated against the `marked` renderer over 14 shapes: **13 exact matches, 1 deliberate
+      over-report, 0 silent misses**
+- [X] T046 Take a CommonMark link title off the destination — a link written with a quoted title
+      after the path addresses only the path, and taking
+      the target whole failed the build on a link that renders correctly
+- [X] T047 Give `resolve()` its own fixtures. FR-008a said the definition is checked on every run,
+      but the fixtures covered only `targets()`; T030 — the round's own headline fix — had no
+      guard, so reverting it left the gate green. Probed: reverting it now fails the selftest
+- [X] T048 Give the fixture list a floor, for the same reason the probes have one: an emptied
+      SELFTEST returns no failures and reads exactly like a sound extractor
+- [X] T049 Cover the schema. A sweep of every single-constraint loosening found **39 of 41 left the
+      gate green** — the entire closed vocabulary among them, including the `mss` typo
+      `$defs/unit`'s own description promises is a parse error, plus every `required`, every
+      `type`, both `const`s, and all four of `$defs/predicate`'s cross-field rules. `guards.items`
+      could be detached from the predicate definition entirely while the identical edit to
+      `criteria.items` was caught. Probes went 7 → 54, one per constraint; the sweep now reports
+      **40 of 41 caught**. The exception, `$defs/predicate.type`, changes no verdict when removed,
+      so no document can probe it — recorded in the section rather than left looking like coverage
+- [X] T050 Pin the message, not just the verdict, for `A fraction has no percentile`. It is
+      redundant for validity — a fraction has no metric, and every aggregation but `rate` and
+      `count` needs one — so no rejection probe can reach it, and a review round called it dead
+      code on that basis. It is not: it is what produces `'p95' is not one of ['rate', 'count']`,
+      the message `README.md` quotes for that mistake. Delete it and the document is still refused,
+      now blaming a missing `metric` the author never meant to write. Checked by message
+- [X] T051 Correct what the correction round itself broke or left stale: `contracts/` still called
+      the isolation section unchanged (three sections changed, not two); `plan.md` still said "no
+      file is added" four lines under a table listing a new one; `data-model.md` omitted
+      `.gitignore` and the second `README.md` edit and said three cross-field rules where there are
+      four; `tasks.md`'s parallel example still carried the "exactly one error" claim T039 had just
+      corrected, and cited T034 for the sweep that is T043; `research.md` R5 still prescribed the
+      method FR-011 replaced; `quickstart.md` §5 still hand-compared six of eight answers and
+      claimed no automated oracle exists, when the oracle is now the criterion — its command block
+      is the real round-trip, and it runs verbatim
+- [X] T052 Add `scripts/` to `AGENTS.md`'s Structure line — the gate and the module it now imports
+      lived in the one directory the index did not mention — and mirror it into the answer record.
+      Round-trip re-run after the edit: still byte-identical
+
+**Checkpoint**: every confirmed finding is fixed and probed. Three are deliberately *not* fixed —
+see Deferred below.
+
+---
+
+## Deferred — real, verified, and out of this change's scope
+
+Each was confirmed against the repository. None is caused by these five fixes, and folding them in
+would violate `AGENTS.md`'s "1 concern per PR". Each wants its own issue in v0.3.0.
+
+- **`$defs/aggregation.description`** still explains `rate` in terms of `indicator`, `distribution`
+  and `ratio` — constructs the schema rejects — and says the overload resolves "by the metric's
+  type", which it cannot: `metric` is a bare string. `README.md` and `GLOSSARY.md` both say it
+  resolves by the presence of `bad`/`good`. The schema is the thing that decides, so this is a
+  second and disagreeing source for one rule, visible on hover in any schema-aware editor.
+- **`$defs/selector.description`** says the selector "Selects time series"; `README.md` and
+  `GLOSSARY.md` say it selects *requests*. `series` belongs to the retired `indicator` model.
+- **Nothing gates the `copier` round-trip.** T044's check is run by hand. The drift #46 exists to
+  fix went unobserved for as long as nothing rendered the template, and that is still true of the
+  next drift.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [X] T028 [P] Run the full [quickstart.md](quickstart.md) validation sequence (§ 1–6) end to end
+      and confirm every expected output matches, now that all five stories have landed.
+      **Confirmed live**: all six steps match their documented expected output exactly
+- [X] T029 Run `bash scripts/verify.sh` once more from a clean `git status` and confirm `PASS`,
+      all eight sections `ok`, none reporting a scan of zero files (SC-001). **Confirmed live:
+      PASS**, all 8 sections `ok`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately
+- **Foundational (Phase 2)**: none — nothing blocks all five stories together
+- **User Stories (Phase 3–7)**: all can start once Setup (T001) is done, except US3, which waits
+  on US2
+- **Review response (Phase 8)**: after the five stories have landed and been reviewed
+- **Polish (Phase 9)**: after the review response
+
+### User Story Dependencies
+
+- **US1 (#37, P1)**: independent — no dependency on any other story
+- **US2 (#42, P2)**: independent of US1, US4, US5 — but **must land before US3**
+- **US3 (#38, P3)**: **depends on US2** (both edit `criteria.items`/`guards.items` — see T015)
+- **US4 (#43, P4)**: independent of all other stories
+- **US5 (#46, P5)**: independent of all other stories; touches neither `scripts/verify.sh` nor the
+  schema
+
+### Within Each User Story
+
+- Schema/script edits before verification tasks
+- Verification tasks that read-but-don't-write can run in parallel with each other once the edit
+  they check is done
+- Each story's own full `bash scripts/verify.sh` run is the last task and is never parallel
+
+### Parallel Opportunities
+
+- US1, US2, US4 and US5 can all start immediately after Setup and be worked on by different people
+  at the same time
+- US3 can start as soon as US2's T007–T009 land (not necessarily all of US2's later tasks)
+- Within US2, US3 and US5, the read-only confirmation tasks marked `[P]` can run together
+- US1 and US4 both edit `scripts/verify.sh`, but in different sections (`SELFCHECK` vs. the link
+  check) — parallelizable by different people, reconciled at merge like any two-PR overlap on one
+  file
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# After T007–T009 land, run these together:
+Task: "Validate the three examples/ files against the changed schema — zero regressions"
+Task: "Validate a requirement with unit: mss — expect exactly one error"
+Task: "Validate a requirement with an unknown predicate key — expect two errors, both naming it"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 3: User Story 1 (#37)
+3. **STOP and VALIDATE**: the gate's own self-check can now fail on command (T005)
+4. Ship — fixing #37 first is what makes every later story's "zero regressions, probed not
+   assumed" claim trustworthy, since it is the check most of that probing leans on
+
+### Incremental Delivery
+
+1. Setup → US1 (#37) → validate → ship (MVP)
+2. Add US2 (#42) → validate → ship
+3. Add US3 (#38) → validate → ship (only after US2)
+4. Add US4 (#43) → validate → ship
+5. Add US5 (#46) → validate → ship
+6. Polish: full quickstart sweep, final gate run
+
+Five commits, five PRs, per `AGENTS.md`'s "1 issue = 1 commit" / "1 concern per PR" — this is not
+an optional sequencing suggestion for this feature, it is the delivery shape spec.md's Assumptions
+already commits to.
+
+### Parallel Team Strategy
+
+With multiple contributors: one person takes US1, another US2 (with a third queued for US3 once
+US2's schema edit lands), a fourth takes US4, a fifth takes US5. All five converge on Polish.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files, or are read-only checks with no dependency on another
+  incomplete task
+- `[Story]` label maps every task to the milestone issue it closes
+- Every story's last task is a full `bash scripts/verify.sh` run — no story is "done" on a
+  partial gate
+- "Probe rather than trust" (T005, T021) is this repository's own idiom (see
+  `specs/004-strip-to-schema/tasks.md` T032): a fix to a check is not confirmed by reading the
+  diff, it is confirmed by making the check fail on purpose, once, and watching it do so
+- Commit after each story, not after each task — `AGENTS.md`'s "1 issue = 1 commit"
+- Every PR MUST be assigned to milestone **v0.3.0** (`github.com/galax-io/opennfr/milestone/3`)
+  before merging, and each issue it closes MUST be closed when it lands on `main` — the six issues
+  this spec covers moved there when v0.2.0 released (spec.md, Clarifications, Session 2026-08-23);
+  do not assign to v0.2.0, which is already shipped


### PR DESCRIPTION
Closes #37
Closes #42
Closes #38
Closes #43
Closes #46

## What changes

Five defects in milestone v0.3.0, one commit each, spec-first. Every commit is green
on its own — verified by checking out each in a scratch worktree and running the gate.

| Commit | Issue | |
|---|---|---|
| `docs(speckit)` | — | spec/plan/tasks, before any fix |
| `fix(verify)` | #37 | the schema self-check checks something |
| `fix(schema)` | #42 | one predicate mistake, one honest message |
| `fix(schema)` | #38 | drop the conditional on a field the object forbids |
| `fix(verify)` | #43 | teach the gate what a markdown link is |
| `fix(copier)` | #46 | make the scaffolding record regenerate what is on disk |

**Deliberate deviation from "1 concern per PR".** This is five concerns. They are
split into five commits rather than five PRs because #38 depends on #42 (both edit
`criteria.items`/`guards.items`) and #46 depends on #43 (the `commands` answer records
how the link check works). Stacking four dependent PRs to land five one-line-issue
fixes seemed worse than one reviewable stack. Say the word and I will split it.

## Why

Three of the five issues had drifted since they were filed, so every decision was
reproduced against this repository rather than taken from the issue text. #43's
described workaround no longer existed; #46's field list was transcribed wrongly into
the spec (its table names `test_model`, which the spec had dropped).

Two findings were bigger than the issues that led to them:

**The self-check covered almost nothing.** A sweep of every single-constraint
loosening found **39 of 41 left the gate green** — the entire closed vocabulary
included, so appending `"mss"` to the unit enum passed, the exact typo that enum's own
description promises is a parse error. `guards.items` could be detached from the
predicate definition entirely while the identical edit to `criteria.items` was caught.
Probes go 7 → 54; the sweep now catches 40 of 41. This expands #37 beyond its literal
seven probes — the issue's complaint is that the section is vacuous, and it was
vacuous well past the part it named.

**The first link-checker fix was worse than the grep it replaced.** It traded a loud
false positive for four silent false negatives: a stray backtick hid every link to the
next backtick; an escaped backtick inside a span hid what followed; a four-backtick
fence swallowed a real link; and a `/`-prefixed target escaped to the machine's
filesystem root, where a dangling link reported `ok`. Under Principle III that is the
worse direction. The extractor is now a line scanner validated against a CommonMark
renderer: 13 of 14 shapes match exactly, the 14th over-reports deliberately, none
under-reports.

## Reviewer notes

- **`scripts/mdlinks.py` is new.** The gate's two link scanners had been disagreeing
  about what a link is, which made the `docs/` isolation rule impossible to state in
  the documents it governs. One definition, used by both, with fixtures the gate runs
  before trusting it.
- **`A fraction has no percentile` was kept, though it is redundant for validity.** No
  rejection probe can reach it. It is what produces `'p95' is not one of ['rate',
  'count']`, the message README quotes; deleting it leaves the document rejected while
  blaming a missing `metric` the author never wrote. Pinned by message instead.
- **#46 was hand-edited, and the issue says re-answer.** The property that instruction
  protects is that the record agrees with what the template produces. Typing into a
  prompt does not demonstrate that; rendering does. `copier recopy` at the recorded
  `_commit` now yields a byte-identical `AGENTS.md`, and that test is what found the
  eighth drifted answer. FR-011 was rewritten to require the render rather than the
  provenance.
- **Three items are deferred, not fixed** — recorded in `tasks.md`. Two schema
  descriptions still use retired `indicator`/`series` vocabulary, and nothing gates the
  copier round-trip. All real, none caused by these five fixes. They want their own
  issues; I have not filed them.
- The gate needs `python3` with `pyyaml` and `jsonschema`.

## Checklist

- [x] Milestone assigned (v0.3.0)
- [x] `Closes #<issue>` above points at issues in the same milestone
- [x] `bash scripts/verify.sh` passes locally — and at every commit individually
- [x] No term changed, so GLOSSARY.md is untouched
- [x] Compatibility-sensitive surfaces (`$defs/predicate`, `$defs/requirement`) changed
      in construction only — no field renamed, no borrowed name touched, no document
      changes meaning. Each was argued in its own issue first (#42, #38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
