### PR TITLE
fix(ci): give git-cliff-action a repo to point the compare link at

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
 
+      # cliff.toml's remote_url() macro reads {{ remote.github.owner }} / {{ remote.github.repo
+      # }}. Neither the action nor the git-cliff binary infers them from this checkout's origin
+      # by default in this environment — both v0.2.0 and v0.3.0 shipped with the "Full diff" link
+      # rendering as github.com///compare. github_token and GITHUB_REPO are what populate them.
       - uses: orhun/git-cliff-action@v4
         id: notes
         with:
           config: cliff.toml
           args: --latest --strip header
+          github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Publish GitHub Release
         run: |


### PR DESCRIPTION
Closes #50

## What changes

`.github/workflows/release.yml`: `orhun/git-cliff-action@v4` gains `github_token` and
`GITHUB_REPO`, which is what `cliff.toml`'s `remote_url()` macro needs to resolve
`{{ remote.github.owner }}` / `{{ remote.github.repo }}`.

## Why

Both published releases end with a broken link:

- v0.2.0: `**Full diff**: https://github.com///compare/v0.1.0...v0.2.0`
- v0.3.0: `**Full diff**: https://github.com///compare/v0.2.0...v0.3.0`

Reproduced, not guessed: in a disposable clone with `origin` pointed at a bogus URL —
approximating the action's checkout, which doesn't carry this repo's local-remote context —
`git-cliff` renders the broken link without `GITHUB_REPO` set, and the correct one with it set.
Confirmed the binary reads `GITHUB_REPO` directly (`git-cliff --help`), and that the plain
local binary run against this actual repo was never broken, which is why the bug shipped twice
without showing up in any local check.

## Reviewer notes

- One file, additive only — two new lines, both wiring existing secrets/context into an
  existing step. No behavior other than the compare link changes.
- Cannot be verified by `bash scripts/verify.sh` (it doesn't run the release workflow); verified
  by reproducing the exact failure and the fix locally, both quoted in the commit message.
- This is a patch fix, targeted at `v0.3.1` off `release/0.3.0` per `AGENTS.md`'s patch-release
  process — milestone set accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)