### PR TITLE
docs(speckit): put the unreachable-units row back in the Units table

### DIFF
--- a/specs/004-strip-to-schema/contracts/gatling-reach.md
+++ b/specs/004-strip-to-schema/contracts/gatling-reach.md
@@ -86,12 +86,12 @@ for another. A percentile in `%` is not a Gatling assertion.
 | `failedRequests.percent` | `%`, `1` | percent, 0..100 | `Double` |
 | `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Int`** |
 | `requestsPerSec` | `{request}/s` | per second | `Double` |
+| — | `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
 
 **Where the target is an `Int`, the threshold converted to the native unit must be a whole
 number.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
 fine. Rounding is not an option — it would move the bar silently, which is the approximation
 Principle III forbids.
-| `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
 
 ## Two things Gatling cannot do at all
 


### PR DESCRIPTION
## The defect

In `specs/004-strip-to-schema/contracts/gatling-reach.md`, the row naming the units no assertable statistic reaches was separated from the Units table by the whole-number-threshold paragraph — and glued directly to the end of it with no blank line, so markdown read it as a lazy continuation and rendered it as literal pipe-delimited text inside the prose. It has never displayed as a table row. It also carried three cells against a four-column header.

## The fix

Move it into the table body after `requestsPerSec`, and add the missing leading cell.

The three cells that were there line up as **Accepts | Native | Target** — a list of units, no native unit, and a verdict where the other rows name a target type. What is missing is **Statistic**, and that absence is the row's content: no statistic accepts these units. `—` states it, and is the mark the Selection, Metrics, Aggregations and Operators tables in this same file already use for "no Gatling equivalent".

```
| — | `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
```

## Why a row and not prose

The alternative was to write it as a sentence under the paragraph. A row, because the table is a **partition**, and a partition only reads as one when both halves sit in the same column:

- the four reachable rows admit `ms`, `s`, `%`, `1`, `{request}`, `{request}/s` — six units;
- this row names the other eleven;
- together they are `$defs/unit`'s seventeen-value enum exactly — disjoint, complete, nothing twice (verified against the schema, not counted by eye).

`scripts/verify.sh` enumerates precisely those six in `TIME`, `SHARE`, `COUNT` and `PERSEC`, so this row is the gate's complement written down. Demoted to prose, the completeness stops being something a reader checks by going down a column, and the next unit added to the enum can go missing from both halves with nothing looking wrong. Prose would also mean rewriting the cells into a sentence — content change, where this PR is meant to have none.

## Scope

Documentation only. No cell content changes: the three existing cells are byte-identical and in the same order; only the leading cell and the line's position are new. Every table in the file now has rows matching its header — checked, 7 tables, 0 mismatches, 0 orphan rows.

`bash scripts/verify.sh` → **PASS**.

Found while planning v0.4.0 (`specs/007-reach-table-rules`) and deliberately left out of that work as out of scope, so it is here on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #66
