### PR TITLE
fix(contract): make the reach tables partition the selection axis (#64, #60, #56, #55)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -53,15 +53,23 @@ struck in constitution 2.0.0 for the reason above.
 ### selector
 
 Selects requests by attribute; a map where every entry must match. Written once per requirement.
-`{}` is every request, said explicitly. `"*"` means the attribute is present with any value — it
-is presence, not a glob.
+`{}` is every request, said explicitly, and reads as one statement about all of them together.
+`"*"` means the attribute is present with any value — it is presence, not a glob. On a
+**requirement's** selector it also quantifies: each distinct value is a statement of its own, so
+`{loadtest.request.name: "*"}` is one bar per named request where `{}` is one bar over all of them.
+Inside `bad` or `good` it does not quantify — those narrow a numerator, and a numerator is one
+number.
 
 A selector matches presence, never absence. That is why `bad` can be written and its mirror image
 cannot.
 
 *Rejected*: `filter` (Keptn) — too generic. `tags` — k6 terminology. `scope` — already means
 visibility. Holding the selection per criterion — reads fine for one criterion and duplicates for
-every requirement with more than one thing to say.
+every requirement with more than one thing to say. Reading `"*"` as presence alone, pooled the way
+`{}` is — what this entry said until #55 and #56: it settled that the attribute must be there and
+left the quantifier unstated, so the only honest reading of `{loadtest.request.name: "*"}` was one
+`{}` already had, and the value was a longer spelling of something else. "The average endpoint is
+fast" and "no endpoint is slow" are different requirements; the format now writes both.
 
 ### metric
 

--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ because the schema deliberately does not know that `http.client.request.duration
 
 Metric and attribute names are **borrowed from OpenTelemetry wherever an equivalent exists**, never
 invented. Names of our own are permitted only under `loadtest.*`, and only where semconv has none.
-Aliases and second spellings are forbidden. Derived quantities — throughput, error rate, apdex —
-must not become metrics; they are computed by aggregation from metrics that already exist.
+Aliases and second spellings are forbidden. Derived quantities — throughput and error rate — must
+not become metrics; they are computed by aggregation from metrics that already exist.
 
 The payoff is not tidiness: a report written in borrowed names correlates with the traces of the
 same run without glue, because both sides already agree on what an endpoint is called.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ selector: {loadtest.request.name: GET /}       # one request, by the name the to
 selector:                                      # one request inside a group
   loadtest.group.name: MyGroup
   loadtest.request.name: MyRequest
-selector: {error.type: "*"}                    # the attribute is present, any value
+selector: {error.type: "*"}                    # present with any value — and one bar per value
 selector: {http.route: /api/v1/checkout}       # one endpoint, by route
 ```
 
@@ -243,7 +243,7 @@ selector: {http.route: /api/v1/checkout}       # one endpoint, by route
 |---|---|
 | Keys | any string. Attribute names are **not enumerated by the schema** and never will be |
 | Values | string, number or boolean. `null` is rejected |
-| `"*"` | presence, not a glob. `{http.route: "/api/*"}` selects the literal string `/api/*` |
+| `"*"` | presence, not a glob. `{http.route: "/api/*"}` selects the literal string `/api/*`. On a requirement's `selector` it also quantifies: each distinct value is a statement of its own, so `{loadtest.request.name: "*"}` is one bar per named request where `{}` is one bar over all of them. Inside `bad` or `good` it does not quantify — those narrow a numerator, and a numerator is one number |
 
 A selector cannot say an attribute is **absent**. That is why `bad: {error.type: "*"}` works and the
 mirror-image `good` does not — write the failed fraction and compare with `lte`.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -72,6 +72,21 @@ that disagreement into a format whose only asset is that one document means one 
 
 *Would need*: the surveyed tools to agree on what an open or a closed model does under degradation. That is not something this format can bring about, which is why this is not a "yet".
 
+**apdex** — one number for how many users were served well: each request is classified against a
+threshold `T` as satisfied (`rt <= T`), tolerating (`T < rt <= 4T`) or frustrated, and the score is
+`(satisfied + tolerating / 2) / total`. It is the one figure in this area a stakeholder reads
+without training, and `APDEX` is a literal key in the NFR-YAML documents this format is meant to
+replace, so it gets asked for. Two constructs are missing and neither is small. A predicate carries
+one threshold, and a fraction — `bad` or `good` — splits a selection in two by attribute presence,
+so nothing here produces three bands or takes a second threshold. And no aggregation the format has
+— `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate` — takes a weighted sum of counts.
+
+This is why apdex sits here and not beside throughput and an error rate. Those two are **derived**:
+each reduces to one construct the format already has, `aggregation: rate` and a `bad` fraction.
+Apdex is **composite** and reduces to none.
+
+*Would need*: a banded classification carrying a second threshold, and an aggregation that weights the bands — each argued on its own merits rather than as a step toward apdex, because a scoring policy that arrives one field at a time is still a scoring policy inside a format whose argument is that it has none.
+
 ## A result document
 
 **A result document.** `Verdict` — the result of checking one predicate: `pass | warn | fail | noData | skipped`. `Outcome`

--- a/examples/every-request-is-fast.yaml
+++ b/examples/every-request-is-fast.yaml
@@ -1,0 +1,34 @@
+# "No endpoint may be slow."
+#
+# The blanket requirement, and the reason `"*"` quantifies. `{}` would pool every request into one
+# number, where one busy fast endpoint hides a quiet slow one and the verdict is green for the
+# wrong reason. `"*"` says the bar applies to each named request on its own, so any single endpoint
+# breaching it fails the run.
+#
+# One case that does not cover: a quantified selection expands to the requests actually observed,
+# so a run that recorded none has nothing to check and ends green. That is a fact about the target
+# rather than something this document can state — see the-run-held-up.yaml, where a guard is what
+# says the run happened at all.
+#
+# This is the only document here whose selection is quantified rather than pooled. Compare
+# the-run-held-up.yaml, which says `{}` and means the whole run as one.
+
+apiVersion: opennfr.io/v1
+kind: RequirementSet
+metadata:
+  name: every-request-perf
+  displayName: What every endpoint owes its callers
+
+spec:
+  requirements:
+    - name: every-named-request
+      displayName: No endpoint is slow
+      selector:
+        loadtest.request.name: "*"                 # each named request, separately — not pooled
+      criteria:
+        - displayName: 95th percentile
+          metric: http.client.request.duration
+          aggregation: p95
+          op: lte
+          threshold: 3
+          unit: s

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -320,7 +320,7 @@
         },
         "selector": {
           "$ref": "#/$defs/selector",
-          "description": "Which requests this requirement is about — written once, for every criterion and guard under it. `{}` is every request."
+          "description": "Which requests this requirement is about — written once, for every criterion and guard under it. `{}` is every request, pooled into one statement. A \"*\" value here also quantifies: each distinct value is a statement of its own. Inside `bad` or `good` it does not — those narrow a numerator, which is one number."
         }
       },
       "examples": [

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -580,6 +580,21 @@ TABLE = {
     },
 }
 
+# Written once so the rule and the probes below cannot drift into different words.
+NOT_A_PATH = "selector {} is not an assertion path"
+NOT_A_STRING = "an assertion path part must be a string"
+
+def selection_why(sel):
+    # Why this selector is not an assertion path, or [] if it is. A function rather than
+    # inline code so the probes below exercise the same rule the corpus is judged by;
+    # two copies would be free to disagree, which is the defect this section is fixing.
+    why = []
+    if set(sel) not in SELECTIONS:
+        why.append(NOT_A_PATH.format(sorted(sel)))
+    elif any(not isinstance(v, str) for v in sel.values()):
+        why.append(NOT_A_STRING)
+    return why
+
 def shape_of(p, why):
     if "good" in p:
         # successfulRequests exists, but a selector matches presence and never absence,
@@ -593,7 +608,27 @@ def shape_of(p, why):
         return "fraction"
     return "metric" if "metric" in p else "requests"
 
+# Rules that REJECT have nothing in examples/ to prove they fire: the corpus holds only
+# documents that validate and are assertable. Each probe is a selector this contract says
+# cannot be rendered, paired with the reason its row gives. A probe that stops being
+# rejected FAILs the section instead of passing quietly.
+SELECTION_PROBES = [
+    ({"loadtest.request.name": 200},  NOT_A_STRING),
+    ({"loadtest.request.name": True}, NOT_A_STRING),
+]
+
 rc, checked = 0, 0
+
+# An emptied probe table reports no failures and reads exactly like a sound one.
+if not SELECTION_PROBES:
+    print("  FAIL  no selection probe left — a rule nothing probes is a rule nothing checks")
+    sys.exit(1)
+for probe, expected in SELECTION_PROBES:
+    got = selection_why(probe)
+    if expected not in got:
+        print(f"  FAIL  probe {probe}: expected rejection {expected!r}, got {got or 'accepted'}")
+        rc = 1
+
 files = sorted(glob.glob("examples/*.yaml"))
 if not files:
     print("  FAIL  examples/ holds no document to check")
@@ -609,12 +644,7 @@ for f in files:
             for section in ("guards", "criteria"):
                 for p in r.get(section) or []:
                     checked += 1
-                    why = []
-
-                    if set(sel) not in SELECTIONS:
-                        why.append(f"selector {sorted(sel)} is not an assertion path")
-                    elif any(not isinstance(v, str) for v in sel.values()):
-                        why.append("an assertion path part must be a string")
+                    why = selection_why(sel)
 
                     if p.get("metric", METRIC) != METRIC:
                         why.append(f"metric {p['metric']} is not addressable")
@@ -651,7 +681,8 @@ if checked == 0:
     print("  FAIL  no predicate found to check — the scan is broken")
     sys.exit(1)
 if rc == 0:
-    print(f"  ok    {checked} predicates, all assertable by Gatling")
+    print(f"  ok    {checked} predicates assertable by Gatling, "
+          f"{len(SELECTION_PROBES)} selection probes still rejected")
 sys.exit(rc)
 GATLING
 fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -539,6 +539,11 @@ except ImportError as e:
 # request names. Not a route, not a method, not a status code. Path parts are strings.
 SELECTIONS = [set(), {"loadtest.request.name"}, {"loadtest.group.name", "loadtest.request.name"}]
 
+# Of those, the ones a quantifier has a scope for. `"*"` renders as forAll(), which takes no
+# path, so a quantified selection carrying one has no correspondence. Held beside SELECTIONS
+# so that adding a selection there forces a decision here instead of silently rejecting it.
+QUANTIFIABLE = [{"loadtest.request.name"}]
+
 # responseTime is the only addressable metric family.
 METRIC = "http.client.request.duration"
 
@@ -583,6 +588,7 @@ TABLE = {
 # Written once so the rule and the probes below cannot drift into different words.
 NOT_A_PATH = "selector {} is not an assertion path"
 NOT_A_STRING = "an assertion path part must be a string"
+QUANTIFIED = 'a quantified selection cannot carry a path: `"*"` reaches forAll(), which takes none'
 
 def selection_why(sel):
     # Why this selector is not an assertion path, or [] if it is. A function rather than
@@ -593,6 +599,11 @@ def selection_why(sel):
         why.append(NOT_A_PATH.format(sorted(sel)))
     elif any(not isinstance(v, str) for v in sel.values()):
         why.append(NOT_A_STRING)
+    elif any(v == "*" for v in sel.values()) and set(sel) not in QUANTIFIABLE:
+        # `"*"` quantifies: each distinct value is a statement of its own. Gatling spells
+        # that forAll(), which takes no path, so "every request inside one group" — and
+        # every other position `"*"` could occupy — has no correspondence.
+        why.append(QUANTIFIED)
     return why
 
 def shape_of(p, why):
@@ -615,6 +626,8 @@ def shape_of(p, why):
 SELECTION_PROBES = [
     ({"loadtest.request.name": 200},  NOT_A_STRING),
     ({"loadtest.request.name": True}, NOT_A_STRING),
+    ({"loadtest.group.name": "Checkout", "loadtest.request.name": "*"}, QUANTIFIED),
+    ({"loadtest.group.name": "*", "loadtest.request.name": "POST /checkout"}, QUANTIFIED),
 ]
 
 rc, checked = 0, 0

--- a/specs/004-strip-to-schema/contracts/gatling-reach.md
+++ b/specs/004-strip-to-schema/contracts/gatling-reach.md
@@ -38,11 +38,17 @@ Over a metric:
 
 | | Gatling | |
 |---|---|---|
-| `p50`…`p99.9` | `responseTime.percentile(n)` | **can** — target is `Int` milliseconds, so a fractional millisecond is not representable |
+| any percentile the schema admits — `^p\d{1,2}(\.\d+)?$` | `responseTime.percentile(n)` | **can** — target is `Int` milliseconds, so a fractional millisecond is not representable |
 | `max`, `min` | `responseTime.max` / `.min` | **can** |
 | `avg` | `responseTime.mean` | **can** |
 | `stddev` | `responseTime.stdDev` | **can** |
 | `sum` | — | **cannot** — `responseTime` offers no sum and no arithmetic that would produce one |
+
+The percentile row is the pattern and not a range, because a row is matched exactly and a range is
+not something a predicate matches. `p1`, `p10` and `p99.99` are all decidable from it, and all three
+are what the gate and `percentile(Double)` already accept. `p100` falls outside the pattern — the
+integer part is capped at two digits — and needs no row: the quantity it names, the slowest observed
+request, is `max`.
 
 Over the requests themselves, with no `metric` and no `bad`/`good`:
 
@@ -64,8 +70,10 @@ Over a fraction, with `bad` or `good`:
 
 **The numerator is part of the correspondence, not a detail of it.** An earlier draft of this
 contract listed the fraction shape without constraining `bad`, and the gate written from it
-accepted `bad: {}` and arbitrary status-code filters — both of which would have to be
-approximated at render time, which Principle III forbids.
+accepted `bad: {}` and arbitrary status-code filters. Neither has a `failedRequests` equivalent, so
+a renderer meeting one has to pick the nearest available number and has nowhere to say it picked
+one. The document asks for a share of a named failure and the run reports a share of something
+else.
 
 ## Operators
 
@@ -90,8 +98,8 @@ for another. A percentile in `%` is not a Gatling assertion.
 
 **Where the target is an `Int`, the threshold converted to the native unit must be a whole
 number.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
-fine. Rounding is not an option — it would move the bar silently, which is the approximation
-Principle III forbids.
+fine. Rounding is not an option: it moves the bar the author wrote, so the document states one
+limit and the run enforces another, and the report names neither.
 
 ## Two things Gatling cannot do at all
 

--- a/specs/004-strip-to-schema/contracts/gatling-reach.md
+++ b/specs/004-strip-to-schema/contracts/gatling-reach.md
@@ -2,7 +2,9 @@
 
 **Source**: `mappings/gatling.yaml` @ `cb7cb58`, itself sourced to the Gatling v3.15.1 source
 files `AssertionSupport.scala`, `AssertionBuilders.scala`, `AssertionPathParts.scala` and
-`AssertionModel.scala`. **Checked 2026-08-20.**
+`AssertionModel.scala`. **Checked 2026-08-20**, and re-checked 2026-08-24 for the scope rows:
+`AssertionSupport.scala` has three scopes and no more — `Global`, `ForAll`, `Details(parts)` — and
+only `Details` carries author strings, so `ForAll` takes no path.
 
 This is the bar FR-010, FR-011 and FR-012 test the corpus against. A predicate that is not in the
 **can** column below may not appear in a published example. It may still appear in a document
@@ -17,16 +19,31 @@ status code, not an error type.
 A selector matches a row on its keys **and** on its values. Partitioning this axis by key set alone
 leaves the value free, and the value is what a renderer emits.
 
+`"*"` says the attribute is present and that each distinct value is a statement of its own — a
+statement about the format, defined in `GLOSSARY.md` and restated in `README.md`. Here it is only
+mapped: the quantifier reaches `forAll()`, and `{}` stays the pooled reading. The two are different
+requirements — "the average endpoint is fast" against "no endpoint is slow" — and the table keeps
+them apart.
+
 | OpenNFR selector | Gatling | |
 |---|---|---|
 | `{}` | `global` | **can** |
-| `{loadtest.request.name: X}`, `X` a string | `details("X")` | **can** — `X` is a path part, never a pattern |
-| `{loadtest.group.name: G, loadtest.request.name: X}`, both strings | `details("G" / "X")` | **can** |
+| `{loadtest.request.name: X}`, `X` a string other than `"*"` | `details("X")` | **can** — `X` is a path part, never a pattern |
+| `{loadtest.group.name: G, loadtest.request.name: X}`, both strings other than `"*"` | `details("G" / "X")` | **can** |
+| `{loadtest.request.name: "*"}` | `forAll()` | **can** — the quantified reading: one assertion per observed request, not one number over all of them |
+| `{loadtest.group.name: G, loadtest.request.name: "*"}`, `G` other than `"*"` | — | **cannot** — no scope both quantifies and carries a path, so "every request inside one group" has no correspondence |
+| `{loadtest.group.name: "*", loadtest.request.name: X}` | — | **cannot** — the same, and a group is not addressable on its own |
 | any path value that is not a string | — | **cannot** — a path is `AssertionPathParts(parts: List[String])`. `{loadtest.request.name: 200}` and `{loadtest.request.name: "200"}` are different documents and only the second is renderable |
 | `{http.route: ...}` | — | **cannot** |
 | `{http.request.method: ...}` | — | **cannot** |
 | `{http.response.status_code: ...}` | — | **cannot** |
 | any other attribute | — | **cannot** |
+
+**The value is part of the correspondence, not a detail of it.** An earlier draft partitioned this
+axis by key set alone, and the gate written from it approved `{loadtest.request.name: "*"}` — which
+this table then rendered as a request literally named `*`, a path matching nothing, failing the run
+for a reason unrelated to what was asserted. The fraction axis learned the same lesson about `bad`,
+one table down.
 
 ## Metrics
 
@@ -108,11 +125,14 @@ limit and the run enforces another, and the report names neither.
 ## Two things Gatling cannot do at all
 
 - **Abort a run on a violated assertion.** Assertions are evaluated after the run.
-- **Fail on absent data in one case.** A `ForAll` assertion expands to the requests observed; if
-  none were observed it yields zero results and the run exits successfully — nothing failed
-  because nothing was checked. A `details(...)` path that matches nothing behaves the opposite
-  way and fails with a resolution error. Both are recorded because the difference reads as an
-  inconsistency otherwise.
+- **Fail on absent data in one case.** A `forAll()` assertion — the Selection row for
+  `{loadtest.request.name: "*"}` — expands to the requests observed; if none were observed it
+  yields zero results and the run exits successfully, because nothing failed and nothing was
+  checked. A `details(...)` path that matches nothing behaves the opposite way and fails with a
+  resolution error. Both are recorded because the difference reads as an inconsistency otherwise.
+  Neither is compensated for here: a document is not obliged to carry a guard and the gate does not
+  require one. This is a fact about the target, and recording one is not the same as legislating
+  around it.
 
 ## How this contract is applied
 

--- a/specs/004-strip-to-schema/contracts/gatling-reach.md
+++ b/specs/004-strip-to-schema/contracts/gatling-reach.md
@@ -14,11 +14,15 @@ Gatling's assertion scope is `Global`, `ForAll`, or `Details(parts)` where `part
 recorded group and request names. Nothing else is addressable — not a route, not a method, not a
 status code, not an error type.
 
+A selector matches a row on its keys **and** on its values. Partitioning this axis by key set alone
+leaves the value free, and the value is what a renderer emits.
+
 | OpenNFR selector | Gatling | |
 |---|---|---|
 | `{}` | `global` | **can** |
-| `{loadtest.request.name: X}` | `details("X")` | **can** |
-| `{loadtest.group.name: G, loadtest.request.name: X}` | `details("G" / "X")` | **can** |
+| `{loadtest.request.name: X}`, `X` a string | `details("X")` | **can** — `X` is a path part, never a pattern |
+| `{loadtest.group.name: G, loadtest.request.name: X}`, both strings | `details("G" / "X")` | **can** |
+| any path value that is not a string | — | **cannot** — a path is `AssertionPathParts(parts: List[String])`. `{loadtest.request.name: 200}` and `{loadtest.request.name: "200"}` are different documents and only the second is renderable |
 | `{http.route: ...}` | — | **cannot** |
 | `{http.request.method: ...}` | — | **cannot** |
 | `{http.response.status_code: ...}` | — | **cannot** |

--- a/specs/007-reach-table-rules/checklists/requirements.md
+++ b/specs/007-reach-table-rules/checklists/requirements.md
@@ -1,0 +1,51 @@
+# Specification Quality Checklist: The Rules By Which The Reach Tables Are Read
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **The one outstanding marker is resolved.** FR-013 asked whether the constitution's Principle II
+  should be corrected alongside `README.md:390-391`, both of which name apdex among quantities
+  computed by aggregation from metrics that already exist. Answered 2026-08-24: neither sentence
+  gains a corrected reason. Apdex leaves `README.md`'s list, which makes that sentence true of the
+  two quantities that remain, and becomes an entry in `docs/ideas.md` — a construct the format
+  does not have, carrying what would have to become true first. Principle II is knowingly left as
+  it stands and FR-015 records it, so it does not read as overlooked.
+
+- **On "no implementation details" and "technology-agnostic".** This repository's product *is*
+  its documents and the gate that checks them: `specs/004-strip-to-schema/contracts/gatling-reach.md`,
+  `README.md`, `scripts/verify.sh` and `examples/` are the deliverable, not the implementation of
+  one. Naming them is naming the subject matter. The criterion these items exist to protect —
+  that the spec does not choose a technology the feature has not committed to — holds: nothing
+  here names a language, a library, or a decoding strategy, and FR-017 forbids the one change
+  that would narrow the format to a tool. `specs/005-fix-milestone-bugs` was validated on the
+  same reading.
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/007-reach-table-rules/contracts/reach-selection.md
+++ b/specs/007-reach-table-rules/contracts/reach-selection.md
@@ -1,0 +1,85 @@
+# Contract: the delta to the Selection table
+
+**Feature**: `007-reach-table-rules`
+
+The Selection table lives in `specs/004-strip-to-schema/contracts/gatling-reach.md` and stays there.
+This file holds only what this feature **changes** about it — four rows added, two rows amended, one
+note moved — so a reviewer argues the delta instead of diffing two copies of the same table. Rows
+this feature does not touch (`{}` → `global`, and the four **cannot** rows for `http.*` and
+"any other attribute") are not restated here.
+
+## Rows added
+
+| OpenNFR selector | Gatling | |
+|---|---|---|
+| `{loadtest.request.name: "*"}` | `forAll()` | **can** — the quantified reading: one assertion per observed request, not one number over all of them |
+| `{loadtest.group.name: G, loadtest.request.name: "*"}` | — | **cannot** — no scope both quantifies and carries a path, so "every request inside one group" has no correspondence |
+| `{loadtest.group.name: "*", loadtest.request.name: X}` | — | **cannot** — the same, and a group is not addressable on its own |
+| any path value that is not a string | — | **cannot** — a path is `AssertionPathParts(parts: List[String])`. `{loadtest.request.name: 200}` and `{loadtest.request.name: "200"}` are different documents and only the second is renderable |
+
+The first three are commit 3 (#55, #56); the fourth is commit 2 (#60).
+
+## Rows amended
+
+The two existing `details(...)` rows gain a value constraint. Their Gatling column and verdict do
+not change.
+
+| Was | Becomes |
+|---|---|
+| `{loadtest.request.name: X}` | `{loadtest.request.name: X}`, **`X` a string other than `"*"`** |
+| `{loadtest.group.name: G, loadtest.request.name: X}` | `{loadtest.group.name: G, loadtest.request.name: X}`, **both strings other than `"*"`** |
+
+The literal reading becomes explicit on those rows rather than being the residue left over once the
+`"*"` rows are read — `X` is a path part, never a pattern.
+
+## The sentence the table gains
+
+**The value is part of the correspondence, not a detail of it.** An earlier draft of this contract
+partitioned this axis by key set alone, and the gate written from it approved
+`{loadtest.request.name: "*"}` — which the contract then rendered as a request literally named `*`,
+a path matching nothing, failing the run for a reason unrelated to what was asserted. The fraction
+axis learned the same lesson about `bad`, one table down.
+
+## The note that moves
+
+The absent-data paragraph in § *Two things Gatling cannot do at all* currently describes a scope no
+document can select, which is #56's complaint. It becomes a note on the `forAll()` row: the
+behaviour is unchanged, what changes is that a row now reaches it.
+
+Nothing in the format compensates for that behaviour. A document is not obliged to carry a guard and
+the gate does not require one — recording a fact about a target and legislating around it are
+different things, and only the first is this repository's business.
+
+## Where `"*"`'s meaning is written
+
+Not here. `"*"` says the attribute is present **and** that each distinct value is a statement of its
+own — a statement about the format, whose home is `GLOSSARY.md` § *selector*, restated for the field
+in `README.md` and for the schema's reader in `$defs/selector`'s description. This contract only
+maps it: the quantifier reaches `forAll()` here, and would reach whatever a second target calls the
+same idea.
+
+The two readings stay distinguishable, which is the point: `{}` is pooled, `{loadtest.request.name:
+"*"}` is quantified. "The average endpoint is fast" and "no endpoint is slow" are different
+requirements, and the format can now write both.
+
+## What the gate must do
+
+Not a copy of anything — `gatling-reach.md` states the rules and this is the behaviour they require
+of `scripts/verify.sh`.
+
+| Input | Verdict | Message names |
+|---|---|---|
+| key set not one of the three | reject | the selector, and that it is not an assertion path |
+| any path value not a string | reject | that an assertion path part is a string |
+| `"*"` on `loadtest.group.name` | reject | that a quantified selection cannot carry a path |
+| `"*"` on `loadtest.request.name`, with a group also present | reject | the same |
+| `"*"` on `loadtest.request.name` alone | accept | — |
+| all path values strings, none `"*"` | accept | — |
+
+Every rejection above has a probe (spec FR-008), and the probe table has a floor (FR-009). The
+section keeps reading `examples/` and never the schema.
+
+## Not touched
+
+The Metrics, Operators and Units tables. The Aggregations table changes in one row — the percentile
+row loses its ellipsis, research.md R3 — which is a different axis and a different commit.

--- a/specs/007-reach-table-rules/data-model.md
+++ b/specs/007-reach-table-rules/data-model.md
@@ -1,0 +1,68 @@
+# Phase 1: what a Selection row is, before and after
+
+**Feature**: `007-reach-table-rules` | **Date**: 2026-08-24
+
+No entity is added to the format. One entity in the *contract* gains a field, and that is the whole
+feature: a Selection row stops being keyed by a set of attribute names and starts being keyed by
+the pair (names, what their values may be).
+
+## The entity that changes
+
+**Selection row** — one line of the reach contract's Selection table. It is the unit an
+implementer matches a document against, and the unit the gate implements.
+
+| Field | Today | After |
+|---|---|---|
+| `keys` | the set of attribute names present | unchanged |
+| `values` | **absent** — the row says nothing | what each named attribute may carry: a string, and whether `"*"` is admitted in that position |
+| `gatling` | the scope and path emitted | unchanged in form; three rows are added and their scope is `forAll()` or none |
+| `verdict` | **can** / **cannot** | unchanged |
+| `reason` | present on **cannot** rows | unchanged; the three new **cannot** rows carry theirs |
+
+A row is matched **exactly**, on both fields. That is the invariant at `gatling-reach.md:111`, and
+adding `values` is what makes it true on this axis.
+
+## The term that changes
+
+**`"*"`** — defined in `GLOSSARY.md:56`, `README.md:246` and the schema's `$defs/selector`
+description as *the attribute is present with any value; presence, not a glob*.
+
+| | Today | After |
+|---|---|---|
+| Meaning | the attribute is present, with any value | the attribute is present, **and each distinct value is a statement of its own** |
+| Reading of `{loadtest.request.name: "*"}` | one number over all named requests — which is every request, so `global` | one statement per observed request |
+| Written in | `GLOSSARY.md`, `README.md`, schema `$defs/selector` description | the same three, changed together in one commit — research.md R8 |
+
+This is the Principle I obligation. It is a redefinition, not an addition: the old definition is
+not wrong, it is silent on the question that decides how a document renders. See research.md R1.
+
+## What each artifact carries afterwards
+
+| Artifact | Changes | What must not change |
+|---|---|---|
+| `specs/004-strip-to-schema/contracts/gatling-reach.md` | Selection table gains value constraints and three rows; percentile row loses its ellipsis; two Principle III citations become arguments; the absent-data note attaches to the `forAll()` row; **Checked** date moves to 2026-08-24 | Every existing **can** row keeps its verdict. The Metrics, Operators and Units tables are untouched |
+| `scripts/verify.sh` | § *Examples are assertable by Gatling* rejects on (key set, value); gains a probe table with a floor | It keeps reading `examples/` and never the schema. The `checked == 0` floor stays |
+| `GLOSSARY.md` | § *selector* states the quantifier; records the rejected alternative | The other twelve entries |
+| `README.md` | selector table states the quantifier; the Names section's derived-quantities sentence drops apdex | The exclusion itself: apdex still must not become a metric |
+| `docs/ideas.md` | gains an apdex entry with its `*Would need*` clause | The `loadtest.*` registry list keeps its `loadtest.apdex` (composite) mention — that is about a **name** not entering a namespace, not a construct not entering the format |
+| `examples/` | gains one document, three → four | The three existing documents keep validity and verdict |
+| `schema/.../requirementset.schema.json` | the `$defs/selector` **description**, so all three definitions of `"*"` say the same thing (research.md R8) | every constraint it makes today, byte for byte. The gate's embedded-example and closure-probe counts must come out unchanged |
+| `.specify/memory/constitution.md` | nothing | Principle II's apdex sentence and Principle III's cut clauses are knowingly left — spec FR-015 |
+
+## Validation rules, and where each lives
+
+| Rule | Source | Check |
+|---|---|---|
+| A path value is a string | contract, Selection table | gate, on the value; probe: a numeric path value |
+| `"*"` on `loadtest.request.name` alone quantifies | contract, Selection table | gate accepts; corpus document exercises it |
+| `"*"` elsewhere in a path has no correspondence | contract, two **cannot** rows | gate rejects; two probes |
+| A non-`"*"` path value is a literal path part | contract, Selection table | gate accepts; the three existing corpus documents exercise it |
+| Any percentile the schema's pattern admits | contract, Aggregations table | gate, unchanged behaviour; the row now states what the gate already does |
+
+Two things this table is making explicit, because both were the defect being fixed: every rule has
+exactly one source and one check, and no rule's only home is the gate.
+
+## State transitions
+
+None. Nothing in this feature has a lifecycle — a document is either assertable or it is not, and
+the verdict is a function of the document alone.

--- a/specs/007-reach-table-rules/plan.md
+++ b/specs/007-reach-table-rules/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: The Rules By Which The Reach Tables Are Read
+
+**Branch**: `007-reach-table-rules` | **Date**: 2026-08-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/007-reach-table-rules/spec.md`
+
+## Summary
+
+Milestone v0.4.0 — four issues found by the first OpenNFR renderer, all of them places where the
+published text does not decide something the gate already decides, or decides it wrongly. The
+contract claims its tables partition each axis; on the selection axis they partition by *key set*
+while what a renderer emits depends on the *value*. This feature makes the value part of the row
+(#60), gives the one value the format hands authors — `"*"` — the meaning authors reach for and a
+scope to render into (#55, #56), and repairs three sentences that are not true as written (#64).
+
+Phase 0 changed the shape of the work. Mapping `{loadtest.request.name: "*"}` to `forAll()` is not
+only a new row: under the term as defined today a selector picks one set and every predicate
+reduces it to one number, so `"*"` carries no quantifier and its pooled reading collapses to
+`global`. The per-request reading has to be **given** to `"*"` at the format level — which makes
+this a change to a defined term, engaging Principle I, and requires `GLOSSARY.md` and `README.md`
+to change alongside the contract. See research.md R1.
+
+## Technical Context
+
+**Language/Version**: None — this repository ships no code. One JSON Schema (draft 2020-12),
+markdown, and a POSIX shell gate that embeds Python 3 for the checks a shell cannot do.
+
+**Primary Dependencies**: `python3` with `pyyaml` and `jsonschema`, used by `scripts/verify.sh`
+only. No dependency is added by this feature.
+
+**Storage**: N/A
+
+**Testing**: `bash scripts/verify.sh` is the whole test model. This feature adds a probe table to
+its § *Examples are assertable by Gatling*, mirroring the one § *The schema holds up its own
+examples, and still rejects* already has.
+
+**Target Platform**: N/A — documents.
+
+**Project Type**: Format specification plus its validation gate.
+
+**Performance Goals**: N/A
+
+**Constraints**: what validates must not change (`schema/opennfr.io/v1/requirementset.schema.json`
+keeps every constraint it has, byte for byte; only its `$defs/selector` description moves);
+`.specify/memory/constitution.md` does not change; the reach gate keeps reading `examples/` and
+never the schema.
+
+**Scale/Scope**: one contract document, two sections of `README.md`, one `GLOSSARY.md` entry, one
+`docs/ideas.md` entry, one gate section, and the corpus from three documents to four. Three
+commits, three PRs.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] **I. Vocabulary Before Features** — **engaged, and this is the feature's main cost.** No term
+      is added, but one is redefined: `"*"` gains, on a selection attribute, the meaning *each
+      matching series separately* (research.md R1). `GLOSSARY.md` § *selector* is updated in the
+      same change, records the rejected alternative (mapping to `global`, which makes the value
+      redundant with `{}`) and what the old definition got wrong (it defined presence and left the
+      quantifier unstated, so the value's only honest reading was one already spoken for). The
+      argument predates the files: #55 and #56 both make it.
+- [x] **II. Borrow Names, Never Invent Them** — no metric or attribute name is added, renamed or
+      aliased. The feature *improves* compliance with this principle's last bullet: apdex stops
+      being listed among quantities computed by an aggregation that exists, because none does
+      (research.md R4). The identical sentence in this principle's own text is knowingly left —
+      spec FR-015.
+- [x] **III. No Silent Green** — every check added can fail. The probe table (FR-008) exists so
+      that each new **cannot** rule is demonstrated rather than trusted, and it carries a floor
+      (FR-009) so an emptied table fails the section instead of reporting success over nothing.
+      Nothing skips. The one place this principle could have been misapplied — obliging documents
+      to carry a guard because `forAll()` exits green on an empty run — was rejected on
+      2026-08-24: that is a fact about a target, and this repository records facts about targets
+      rather than legislating around them.
+- [x] **IV. Honest Status** — the claim the feature turns on, that `forAll` takes no path, is
+      sourced to `AssertionSupport.scala @ v3.15.1` and dated, with a second read on 2026-08-24
+      and its one inaccuracy recorded rather than smoothed over (research.md R2). The contract's
+      **Checked** header moves to the date of that read.
+- [x] **V. Structure Over Grammar** — no new field, no string DSL, no bespoke decoding. `"*"` is a
+      single sentinel value, not an open grammar: there is exactly one such value, it is compared
+      for equality, and nothing is parsed out of it.
+- [x] **VI. The Requirement Is Target-Blind** — the quantifier meaning is stated at the format
+      level, in the format's own words, without naming a target; the reach contract maps it onto
+      `forAll()` the way every other row maps a construct. No requirement document names a target.
+      Adding a second target would add a second description and change nothing here. What
+      validates does not change, so the format stays as wide as it is.
+- [ ] **VII** — *withdrawn in 3.0.0. No gate.*
+- [x] **VIII. Ideas Are Parked, Not Merged** — `docs/ideas.md` gains one entry (apdex) with its
+      `*Would need*` clause, keeping the gate's ideas-to-conditions count equal. Nothing outside
+      `docs/` links into it: `README.md` and the contract name `docs/ideas.md` in prose inside a
+      code span, never as link syntax. `git rm -r docs && bash scripts/verify.sh` still passes,
+      because nothing this feature adds outside `docs/` depends on anything inside it.
+- [x] **Compatibility** — no borrowed OTel name changes. Two field names in published examples
+      are touched in meaning, not spelling: `loadtest.group.name` and `loadtest.request.name` gain
+      a stated value constraint. Both changes are argued in issues (#60, #55, #56) and
+      `GLOSSARY.md` records what was rejected. Every construct kept has at least one surveyed
+      target that asserts it exactly — `forAll()` for the quantifier, `details(parts)` for the
+      literal path. The corpus narrows nowhere; the format does not narrow at all, and the rows
+      that say **cannot** say why.
+
+**Result**: pass, with Principle I engaged rather than clear. Nothing to justify in Complexity
+Tracking — the work Principle I requires is scoped into commit 3 (research.md R7) rather than
+waived.
+
+**Re-checked after Phase 1.** The design artifacts changed no answer above. They did make one
+answer's cost concrete: Principle I's obligation is three documents changing together —
+`GLOSSARY.md`, `README.md`, and the schema's `$defs/selector` description (research.md R8) — not
+one. Phase 1 added no construct, no field and no term beyond the redefinition already declared,
+and `contracts/reach-selection.md` is a design record rather than a second home for the rule.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-reach-table-rules/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — R1..R7 and one open question
+├── data-model.md        # Phase 1 output — what a Selection row is, before and after
+├── quickstart.md        # Phase 1 output — how each success criterion is checked
+├── contracts/
+│   └── reach-selection.md   # Phase 1 output — the rows to be written, verbatim
+├── checklists/
+│   └── requirements.md  # written by /speckit-specify, 16/16
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Repository (what this feature touches)
+
+```text
+specs/004-strip-to-schema/contracts/
+└── gatling-reach.md     # the source. Selection table, Aggregations percentile row,
+                         #  two Principle III citations, the closing absent-data note
+
+scripts/
+└── verify.sh            # the check. § "Examples are assertable by Gatling" gains value
+                         #  awareness and a probe table with a floor
+
+README.md                # the selector table (the quantifier meaning); the Names section
+                         #  (apdex leaves the derived-quantities sentence)
+GLOSSARY.md              # § selector — the redefinition Principle I requires
+docs/ideas.md            # apdex gains an entry with its condition
+
+examples/
+└── every-request-is-fast.yaml   # new: the blanket requirement, exercising forAll()
+
+schema/opennfr.io/v1/requirementset.schema.json
+                         # $defs/selector description only — research.md R8. Every
+                         #  constraint unchanged
+.specify/memory/constitution.md
+                         # not touched — spec FR-015
+```
+
+**Structure Decision**: no new directory and no new kind of artifact. The reach contract stays
+where it is, in `specs/004-strip-to-schema/contracts/`, because it is the published source and
+`scripts/verify.sh:516` points at it; this feature edits it in place rather than copying it
+forward. `specs/007-reach-table-rules/contracts/reach-selection.md` holds only the *delta* — the four rows
+added, the two amended, and the note that moves — so that reviewing it is arguing a change rather
+than diffing two copies of one table. It is not a second home for the rule.
+
+## Complexity Tracking
+
+> No Constitution Check gate failed. Nothing to justify.

--- a/specs/007-reach-table-rules/quickstart.md
+++ b/specs/007-reach-table-rules/quickstart.md
@@ -1,0 +1,172 @@
+# Quickstart: validating milestone v0.4.0
+
+**Feature**: `007-reach-table-rules` | **Date**: 2026-08-24
+
+Every success criterion in the specification is checkable by a command or by reading one table.
+This is how, in the order the commits land. Run from the repository root.
+
+## Prerequisites
+
+```bash
+python3 -m pip install --user --break-system-packages pyyaml jsonschema
+```
+
+(`--break-system-packages` is only needed on a Homebrew-managed `python3`. Nothing new is required
+beyond what `specs/004-strip-to-schema/quickstart.md` already asks for.)
+
+## 0. The baseline, before anything changes
+
+```bash
+bash scripts/verify.sh
+```
+
+Expected today: `PASS`, with `ok    9 predicates, all assertable by Gatling` and
+`ok    24 embedded examples valid, 54 closures still reject`. Every command below is a change to
+what those two lines cover, so record them first.
+
+The two link counts this section used to pin are deliberately not baselines: they rise with every
+markdown file added, including the files of this feature, so a moved count says nothing.
+
+## 1. Three sentences that are not true (#64, commit 1)
+
+**SC-005 — the percentile row is a row.** There is no command; the check is a reading. Take the
+three percentiles the schema admits and the published table does not name, and confirm each matches
+exactly one row:
+
+```bash
+python3 -c 'import re; p=re.compile(r"^p\d{1,2}(\.\d+)?$"); print([(a, bool(p.match(a))) for a in ["p1","p10","p99.99","p50","p100"]])'
+```
+
+Expected: every one but `p100` matches. After the fix, the contract's row admits exactly this set
+and says so by quoting the pattern; `p100` needs no row because its quantity is `max`.
+
+**SC-006 — no citation resolves to nothing.**
+
+```bash
+grep -n 'Principle III' specs/004-strip-to-schema/contracts/gatling-reach.md
+```
+
+Expected today: two hits, at lines 67-68 and 92-93. Expected after: zero. Then confirm both rules
+still give their reason:
+
+```bash
+sed -n '/numerator is part of the correspondence/,/^$/p;/Where the target is an .Int./,/^$/p' specs/004-strip-to-schema/contracts/gatling-reach.md
+```
+
+**SC-007 — apdex.**
+
+```bash
+grep -n -i 'apdex' README.md docs/ideas.md
+```
+
+Expected after: `README.md` no longer names apdex at all; `docs/ideas.md` names it in two places —
+the `loadtest.*` registry list, as before, and an entry of its own under *Fields argued for and left
+out*. Then confirm the ideas count still balances, which the gate does for you:
+
+```bash
+bash scripts/verify.sh 2>&1 | grep 'docs/ is'
+```
+
+Expected: `ok    docs/ is markdown-only, every idea states its condition, …`. A new entry without
+its `*Would need*` clause fails this line — that is Principle VIII's gate, not a convention.
+
+## 2. A selection row constrains its value (#60, commit 2)
+
+**SC-003 — the reason is in the contract, not only in the gate.** Write a document whose path value
+is not a string and hand it to the gate:
+
+```bash
+cat > /tmp/numeric-path.yaml <<'YAML'
+apiVersion: opennfr.io/v1
+kind: RequirementSet
+metadata: {name: numeric-path}
+spec:
+  requirements:
+    - name: two-hundred
+      selector: {loadtest.request.name: 200}
+      criteria:
+        - {metric: http.client.request.duration, aggregation: p95, op: lte, threshold: 500, unit: ms}
+YAML
+cp /tmp/numeric-path.yaml examples/ && bash scripts/verify.sh; rm examples/numeric-path.yaml
+```
+
+Expected: `FAIL`, naming the requirement and *an assertion path part must be a string*. This is the
+behaviour today as well — what changes is that the sentence is now findable in the contract:
+
+```bash
+grep -n 'is a string\|List\[String\]' specs/004-strip-to-schema/contracts/gatling-reach.md
+```
+
+Expected today: nothing. Expected after: the Selection table's value column.
+
+**SC-004 — the probes have a floor.** After commit 2 the reach section reports its probe count:
+
+```bash
+bash scripts/verify.sh 2>&1 | grep 'assertable by Gatling'
+```
+
+Expected after: a line naming both the predicates checked and the probes rejected. Delete the probe
+table and re-run — the section must FAIL, not report success over nothing. That is the same floor
+`specs/005-fix-milestone-bugs` put on the schema section.
+
+## 3. `"*"` selects every named request (#55, #56, commit 3)
+
+**SC-002 — the blanket requirement is writable and means what it says.** The new corpus document
+carries it; the gate accepts it:
+
+```bash
+bash scripts/verify.sh 2>&1 | grep 'assertable by Gatling'
+cat examples/every-request-is-fast.yaml
+```
+
+Expected: the predicate count rises from 9, and the document selects
+`{loadtest.request.name: "*"}`. Then confirm the contract names exactly one scope for it:
+
+```bash
+grep -n 'forAll' specs/004-strip-to-schema/contracts/gatling-reach.md
+```
+
+Expected: the **can** row, and the absent-data note attached to it. Nothing else.
+
+**The two neighbouring selections are rejected**, and the gate says so rather than this page
+saying it:
+
+```bash
+bash scripts/verify.sh 2>&1 | grep 'assertable by Gatling'
+```
+
+Expected after: `4 selection probes still rejected` — two for the string rule from § 2, two for
+`"*"` carrying a path. The probes are the assertion; if either stops being rejected the line turns
+into a FAIL naming the probe. `"*"` in **both** positions falls under the second of the two rows,
+whose `X` is unconstrained, so it is covered without a third row.
+
+Neither selection may be added to `examples/` — the corpus holds only documents that are
+assertable, which is why these live as probes.
+
+**SC-001 — the term changed in every place it is defined.**
+
+```bash
+grep -n -A 3 '^### selector' GLOSSARY.md
+grep -n '"\*"' README.md schema/opennfr.io/v1/requirementset.schema.json
+```
+
+Expected after: all three say the same thing about `"*"` — presence, **and** each distinct value a
+statement of its own — and `GLOSSARY.md` records the rejected alternative. Three documents
+disagreeing about one value is the defect this milestone exists to remove; leaving one of them
+behind would recreate it.
+
+## 4. Nothing else moved
+
+**SC-008.**
+
+```bash
+git diff main -- schema/ | grep '^[-+]' | grep -v '^[-+][-+]'
+git diff --stat main -- .specify/memory/constitution.md
+bash scripts/verify.sh 2>&1 | grep 'still rejects'
+```
+
+Expected: the first prints exactly one pair of lines, the `$defs/selector` description before and
+after (research.md R8) — any other line means a constraint moved. The second prints nothing: the
+constitution is untouched. The third prints `ok    24 embedded examples valid, 54 closures still
+reject`, the same counts as today, which is what proves the description change carried no
+constraint with it.

--- a/specs/007-reach-table-rules/research.md
+++ b/specs/007-reach-table-rules/research.md
@@ -1,0 +1,254 @@
+# Phase 0: research
+
+**Feature**: `007-reach-table-rules` | **Date**: 2026-08-24
+
+Seven questions the plan had to settle. R1 is the one that changed the shape of the work: the
+resolution chosen for #55 and #56 turns out to require a change to a defined term, which the
+specification did not carry.
+
+---
+
+## R1 — `"*"` on a path attribute carries a quantifier the selector does not have
+
+**Question**: the spec's User Story 1 maps `{loadtest.request.name: "*"}` to Gatling's `forAll()`.
+Does the format's own semantics support that reading?
+
+**Finding**: not as the term is defined today, and this is the crux of the feature.
+
+`GLOSSARY.md:55-57` defines the selector as "a map where every entry must match", `{}` as "every
+request, said explicitly", and `"*"` as "the attribute is present with any value — it is presence,
+not a glob". `README.md:246` and the schema's `$defs/selector` description agree. Under that
+definition every selector picks **one set**, and every predicate under it reduces that set to
+**one number** — the pooled reading. Nothing in a map of equalities carries a quantifier, which is
+precisely #56's diagnosis.
+
+So the pooled reading of `{loadtest.request.name: "*"}` is "all requests that have a recorded
+name". In Gatling every request it records has a name, so that set is every request, and the
+pooled reading is `global` — a longer spelling of `selector: {}`. The value would be redundant.
+
+The per-request reading — *each named request, separately* — is the one an author reaches for and
+the one #56 says cannot be written. Giving it to `"*"` is what makes the value carry its weight.
+But it is a change to what a document **means**, not only to what it renders to.
+
+**Decision**: define, at the format level, that `"*"` on a selection attribute quantifies over the
+matching series — one statement per distinct value — rather than pooling them. State it without
+naming a target; let the reach contract map it to `forAll()`.
+
+**Consequences the specification did not carry**:
+
+1. `GLOSSARY.md` § *selector* must gain the quantifier meaning in the same change. Principle I
+   requires it, requires a rejected alternative with its reason, and requires the argument to
+   live in an issue — which it does: #55 and #56 both argue it.
+2. `README.md`'s selector table must say the same thing in the same change, since it is the
+   document that describes every field.
+3. The schema's `$defs/selector` description currently defines `"*"` as presence alone. What the
+   schema *validates* does not change and must not (Principle VI; spec FR-017). Whether its
+   `description` gains the quantifier meaning is a live question — see "Open, carried to
+   `/speckit-tasks`" below.
+
+**Alternatives considered**:
+
+- *Map `{loadtest.request.name: "*"}` to `global`.* Faithful to the term as defined and needs no
+  glossary change. Rejected: it makes the value redundant with `{}` while still reading, to an
+  author, as the blanket requirement — the same trap #56 filed, moved one step along.
+- *Reject the document.* The option put to the author on 2026-08-24 and declined. It would leave
+  the blanket NFR — the commonest requirement there is — unwritable until v0.5.0 or later.
+- *Add a separate quantifier construct (`perAttribute`, a grouping key).* A new field, a schema
+  change, and a term with no precedent in the surveyed formats. Rejected as disproportionate to a
+  value the format already hands authors, and it would not stop `"*"` being reached for anyway.
+
+**Cost, recorded rather than hidden**: after this change there is no way to assert about a request
+literally named `*`. The value the format hands authors for "any value" cannot also be a literal.
+
+---
+
+## R2 — `forAll` takes no arguments
+
+**Question**: FR-016. Does Gatling's `ForAll` scope accept a path, and is the DSL spelling
+argument-free?
+
+**Finding**: no path, no arguments. Two independent sources agree.
+
+- **Primary, already in this repository.** `git show cb7cb58:mappings/gatling.yaml` is the target
+  description this contract was written from, deleted by `004-strip-to-schema` and still reachable
+  in history. Its `assertion-support` evidence, sourced to
+  `gatling-core/src/main/scala/io/gatling/core/assertion/AssertionSupport.scala @ v3.15.1` and
+  **checked 2026-08-20**, states: *"Three scopes exist and no more: AssertionPath.Global,
+  AssertionPath.ForAll, and AssertionPath.Details(parts). Only Details carries author strings."*
+  Its `assertion-model-3-9-5` evidence adds: *"No case carries author text except Details."*
+- **Corroborating, checked 2026-08-24.** Gatling's published assertion reference
+  (`https://docs.gatling.io/reference/script/core/assertions/`) lists `global` and `forAll` as
+  taking no arguments.
+
+**Decision**: the claim is carried by the primary evidence, which is dated and sourced to named
+files at a named version. The contract's **Checked** header is updated to 2026-08-24 for the
+corroborating read, and the new rows cite `AssertionSupport.scala`, which the header already names.
+
+**Recorded honestly**: the 2026-08-24 read of the documentation page also described `details` as
+argument-free, which is wrong — `AssertionPathParts(parts: List[String])` is the whole point of
+that scope. The page read is therefore used **only** for the `forAll`-takes-no-arguments point,
+where it agrees with the primary source; the primary source decides everywhere else.
+
+**Consequence**: `{loadtest.group.name: G, loadtest.request.name: "*"}` — "every request inside
+one group, each separately" — has no correspondence, because there is no scope that both
+quantifies and carries a path. It is a **cannot** row, and so is `"*"` in the group position.
+
+---
+
+## R3 — which percentiles the contract should name
+
+**Question**: FR-011. The Aggregations table writes `p50`…`p99.9`. What is the honest row?
+
+**Finding**: all three ends already admit more than the table names, and they agree with each
+other.
+
+| End | What it admits |
+|---|---|
+| Schema | `^p\d{1,2}(\.\d+)?$` — `p0` through `p99` with an optional fractional part |
+| Gate | `scripts/verify.sh:561` — `a.startswith("p") and a[1:].replace(".", "", 1).isdigit()` |
+| Gatling | `percentile(Double)` — arbitrary |
+
+**Decision**: the row names *any percentile the schema's pattern admits*, and quotes the pattern
+so a reader can decide `p1`, `p10` and `p99.99` without interpolating a range.
+
+**Not a gap**: `p100` falls outside the pattern — the integer part is capped at two digits — and
+needs no row. The quantity it names, the slowest observed request, is `max`, already a **can**.
+
+**Note for `/speckit-tasks`**: the gate's predicate is looser than the schema's pattern in one
+respect — it accepts a trailing dot (`"p50."`) that the pattern rejects. The schema runs first and
+rejects such a document, so no document reaches the gate in that state, and no behaviour changes.
+Recorded because the row will quote the pattern as the authority, and the gate should not be left
+disagreeing with the sentence it implements.
+
+---
+
+## R4 — what apdex needs that this format does not have
+
+**Question**: FR-012 and FR-013. What is the true reason apdex cannot be a metric here, and what
+would have to become true?
+
+**Finding**: apdex partitions each request against **two** thresholds — `rt ≤ T` satisfied,
+`T < rt ≤ 4T` tolerating, `rt > 4T` frustrated — and computes
+`(satisfied + tolerating / 2) / total`. Two constructs are missing:
+
+1. **A banded classification.** A predicate carries one `threshold`; a fraction (`bad`/`good`)
+   splits a selection in two by attribute presence. Neither produces three bands, and neither
+   takes a second threshold.
+2. **A weighted aggregation.** No member of `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate`
+   takes a weighted sum of counts.
+
+By contrast the other two quantities in the same sentence are one construct each: throughput is
+`aggregation: rate`; an error rate is `bad: {error.type: "*"}` with `aggregation: rate`.
+
+**Decision**: apdex leaves `README.md`'s derived-quantities sentence and becomes an entry in
+`docs/ideas.md` § *Fields argued for and left out*, whose `*Would need*` clause names both missing
+constructs. The repository already labels it **composite** rather than **derived** at
+`docs/ideas.md:152`, so this aligns two documents rather than introducing a distinction.
+
+**Alternative considered**: rewrite the reason in place, keeping apdex in the sentence. Rejected by
+the author on 2026-08-24 — a construct the format does not have belongs in the ideas area under
+Principle VIII, not in a sentence about quantities that *are* computable.
+
+**Left knowingly**: `.specify/memory/constitution.md`'s Principle II carries the same sentence,
+naming apdex. Out of scope (spec FR-015), recorded so it does not read as overlooked.
+
+---
+
+## R5 — what the two Principle III citations become
+
+**Question**: FR-014. Principle III is *No Silent Green*; its three surviving obligations are about
+reporting success on missing or unchecked data, and contain no clause about approximation. What do
+the two citations at `gatling-reach.md:67` and `:92` become?
+
+**Finding**: the constitution states plainly why the clause is absent — 3.0.0 cut the obligations
+governing *rendering a document into a target's assertions* because no artifact in this repository
+does that. That reasoning is recorded in the principle itself and still holds for the constitution.
+
+**Decision**: both rules are argued from what they cost rather than by citation.
+
+- *The fraction numerator*: a `bad` narrower than "an error happened" has no `failedRequests`
+  equivalent, so a renderer meeting one has to choose a nearest available number. The rule exists
+  to stop that choice being made silently — which is what the paragraph already says in its own
+  words, one sentence above the citation.
+- *The whole-number threshold*: rounding `0.5 ms` to `0` or `1` moves the bar the author wrote.
+  The document says one thing and the run checks another, and nothing in the report says so.
+
+Neither loses its reason; both stop borrowing authority they do not have.
+
+**Alternative considered**: restore the clause to Principle III, on the ground that the renderer
+whose absence justified the cut now exists at `galax-io/gatling-picatinny#236`. Rejected by the
+author on 2026-08-24 — it is still not in *this* repository, and an amendment is an "ask first"
+surface under `AGENTS.md`.
+
+---
+
+## R6 — how a **cannot** row is demonstrated
+
+**Question**: FR-008 and FR-009. `examples/` holds only documents that validate, so it cannot
+carry a counter-example. What proves that a rejection rule actually rejects?
+
+**Finding**: the pattern already exists in this repository, in a different section.
+`scripts/verify.sh:381-474` builds a `probes` dict for the schema section — a base document plus
+one mutation per constraint, each of which must be rejected. The reach section has no equivalent:
+it reads `examples/` and its only floor is `checked == 0`.
+
+**Decision**: the reach section gains the same shape — a probe table of documents that must be
+rejected, one per **cannot** rule this feature adds, with a floor that fails the section if the
+table is emptied. `specs/005-fix-milestone-bugs` FR-002a settled the principle: a section
+reporting success over zero probes reads exactly like a section that passed.
+
+**Boundary**: the probes are documents handed to the gate, not schema introspection. The reach
+section must keep reading `examples/` and never the schema — reading the schema would narrow the
+format to one tool (`scripts/verify.sh:524-526`).
+
+---
+
+## R7 — how the four issues decompose into commits
+
+**Question**: `AGENTS.md` maps one tracked issue to one semantic commit, each green on its own.
+Four issues, but #55 and #56 have one answer.
+
+**Decision**: three commits, in this order.
+
+| # | Commit | Closes | Green on its own because |
+|---|---|---|---|
+| 1 | `fix(contract): three sentences that are not true as written` | #64 | Documentation only; no gate behaviour changes |
+| 2 | `fix(contract): a selection row constrains its value` | #60 | Adds the string rule to contract and gate, with its probe; the corpus is unaffected |
+| 3 | `fix(contract): "*" selects every named request, and says so` | #55, #56 | Needs commit 2's value-aware gate; adds the quantifier meaning, the rows, the probes and one corpus document |
+
+Commit 3 names both issues. Splitting it would produce one commit that adds a row nothing reaches
+and another that reaches a row that does not exist; neither half is green alone, and the rule's
+purpose — every issue traceable to a green commit — is served by naming both on the one commit
+that answers them.
+
+**PR shape**: three PRs, stacked, each assigned to milestone v0.4.0 before merge, rebased not
+merged. Commit 3's PR carries the `GLOSSARY.md` and `README.md` changes R1 requires, because they
+are the same concern as the row.
+
+---
+
+## R8 — the schema's `$defs/selector` description gains the quantifier meaning
+
+**Question**: spec FR-017 says the schema must not change. `$defs/selector` is one of the three
+places `"*"` is defined. Does its `description` follow the redefinition, or stay as it is?
+
+**Finding**: what FR-017 protects is the set of documents that validate, and no option here touches
+it — a `description` is documentation, not a constraint. But since #31 landed, the schema documents
+every shape it defines, and this description is where `"*"` is defined for anyone reading the schema
+rather than the prose.
+
+**Decision** (author, 2026-08-24): amend the `description` string, in commit 3, alongside
+`GLOSSARY.md` and `README.md`. It is `$defs/requirement`'s `selector` description that carries the
+quantifier, not `$defs/selector` itself: `bad` and `good` `$ref` the latter, and a numerator is one
+number whatever `"*"` means for a requirement's selection. FR-017 is read as *nothing that changes which documents validate* —
+every constraint the schema makes is kept, byte for byte, and only the description moves.
+
+**Alternative considered**: leave it, so the schema stays untouched by the letter of FR-017.
+Rejected: the meaning would live in `GLOSSARY.md` and `README.md` while the schema stated a
+narrower one — three documents disagreeing about one value, which is the defect this whole
+milestone exists to remove.
+
+**Check**: the schema section of the gate validates every embedded example against the definition
+it illustrates (`005-fix-milestone-bugs` FR-013). A description change touches no example and no
+closure probe, so that section's counts — 24 embedded examples, 54 closures — must come out
+unchanged. If either moves, something other than the description moved with it.

--- a/specs/007-reach-table-rules/spec.md
+++ b/specs/007-reach-table-rules/spec.md
@@ -1,0 +1,184 @@
+# Feature Specification: The Rules By Which The Reach Tables Are Read
+
+**Feature Branch**: `007-reach-table-rules`
+
+**Created**: 2026-08-24
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/opennfr/milestone/6" — milestone **v0.4.0**, four issues: #64, #60, #56, #55.
+
+**Scope note**: Everything the first OpenNFR renderer found ([galax-io/gatling-picatinny#236](https://github.com/galax-io/gatling-picatinny/issues/236)) is split across milestones v0.4.0–v0.8.0 in the order the work has to happen. This is the first of them, and it comes first because the rest write rows into tables that do not yet hold their own invariant. The contract states that invariant at `specs/004-strip-to-schema/contracts/gatling-reach.md:111` — "The tables partition each axis. A predicate is assertable only if it matches a row **exactly**; anything unlisted is rejected" — and on the selection axis it is not true today: that axis is partitioned by *key set*, while what a renderer emits depends on the *value*. #56 was moved into this milestone from v0.5.0 on 2026-08-24; see Clarifications.
+
+## Clarifications
+
+### Session 2026-08-24
+
+- **Q**: `gatling-reach.md` twice justifies a rule by "the approximation Principle III forbids", and the constitution's Principle III (*No Silent Green*) contains no such clause — it was cut in 3.0.0. Restore the clause, or rewrite the argument? → **A**: Rewrite the argument in the contract. The constitution is not amended. It records why the clause was cut — the obligations governed rendering a document into a target's assertions, which no artifact in this repository does — and that reasoning still holds for the constitution even though a renderer now exists elsewhere.
+- **Q**: After the fix, what does `{loadtest.request.name: "*"}` correspond to — a rejection, or Gatling's `ForAll` scope? → **A**: `ForAll`. This is the requirement the value was reached for, and it merges #55 with #56, which asks why no selector reaches that scope. #56 was moved from milestone v0.5.0 to v0.4.0 on the same day, and both milestone descriptions were rewritten to match. Mapping the two onto each other does not wait on the path work in v0.5.0, because `forAll()` takes no path.
+- **Q**: `README.md:390-391` and the constitution's Principle II both exclude apdex among quantities "computed by aggregation from metrics that already exist", which is false of apdex — no aggregation this format has produces it. Correct the reason, in both documents or in one? → **A**: Neither. `README.md` stops naming apdex among derived quantities at all, which makes the sentence true as written of the two that remain, and apdex becomes an entry of its own in `docs/ideas.md` — where a construct the format does not have belongs under Principle VIII, carrying what would have to become true before it could enter. The constitution's copy is out of scope for this feature and left as it stands; it is recorded rather than dropped silently.
+- **Q**: `forAll()` on a run that observed no requests yields zero assertions and exits successfully. Should a requirement using that selection be obliged to carry a guard that fails on zero observed requests, enforced by the gate? → **A**: No. This repository ships a format and the table saying what converts; it does not ship enforcement. Obliging a document to carry an extra predicate to compensate for one target's behaviour narrows the format to that target, which Principle VI and FR-014 of `specs/004-strip-to-schema` both forbid. The absent-data behaviour is a fact about the target and is recorded as one.
+
+## User Scenarios & Testing *(mandatory)*
+
+The reader throughout is an implementer building a renderer from the published text — the role that found all four defects. What they need from each story is a rule they can follow without guessing, and a gate that agrees with the rule.
+
+### User Story 1 - "Every request" can be said, and means what it says (#55, #56, Priority: P1)
+
+An author writes the ordinary blanket requirement — *the 95th percentile of every business operation must be at most 3 s* — and reaches for the one construct the format hands them for "any value": `selector: {loadtest.request.name: "*"}`. Today that document passes the reach gate, because the gate partitions the selector axis by key set and never looks at the value, and then renders to `details("*")` — an assertion about a request literally named `*`, which matches nothing and fails the run with a resolution error unrelated to what was asserted. After this story, the same document corresponds to Gatling's `forAll()` scope, which expands to one assertion per observed request: what the author meant.
+
+**Why this priority**: the only `severity:critical` issue in the milestone, and the only defect here that silently produces a *wrong verdict* rather than an unanswerable question. It also closes the milestone's stated goal — after it, the selection axis is partitioned by the pair (key set, value) rather than by key set alone. It depends on User Story 2 having made the value part of the row at all.
+
+**Independent Test**: write a document selecting `{loadtest.request.name: "*"}`, confirm the gate accepts it, and confirm the contract names exactly one Gatling scope for it. Write the three neighbouring selections that carry `"*"` on a path attribute in any other position and confirm each is rejected with the reason the contract gives.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requirement whose selector is `{loadtest.request.name: "*"}`, **When** an implementer looks the selection up in the contract, **Then** exactly one row matches it and that row names `forAll()`.
+2. **Given** a requirement whose selector is `{loadtest.group.name: Checkout, loadtest.request.name: "*"}`, **When** the gate checks it, **Then** it is rejected, because `forAll()` accepts no path and so "every request inside one group" has no correspondence.
+3. **Given** a requirement whose selector is `{loadtest.group.name: "*", loadtest.request.name: POST /checkout}`, **When** the gate checks it, **Then** it is rejected for the same reason.
+4. **Given** the contract's closing note that a `ForAll` assertion over zero observed requests exits successfully, **When** an implementer reads it, **Then** it explains a row above it rather than describing a scope no document can select.
+5. **Given** a requirement whose selector is `{loadtest.request.name: "POST /checkout"}`, **When** the gate checks it, **Then** it is still accepted and still corresponds to `details("POST /checkout")` — a literal value keeps meaning a literal path part.
+
+---
+
+### User Story 2 - A selection row constrains its value, not only its key (#60, Priority: P2)
+
+`$defs/selector` admits `string`, `number` and `boolean` values, and is right to: an attribute value being a number is ordinary (`server.port: 8080`). A Gatling assertion path is a list of strings. The Selection table constrains only which keys are present and never states what the values may be, so an implementer meeting `loadtest.request.name: 200` — which is what YAML 1.1 makes of an unquoted request called `200`, alongside `1.10`, `on`, `off`, `yes` and `no` — either stringifies it (making `200` and `"200"`, two documents that differ, render identically) or rejects it with no authority in the contract to do so. The rule exists, but only in the gate.
+
+**Why this priority**: it is the general form of User Story 1's defect and the thing that makes that story's rows expressible — a row cannot say "`"*"` means `forAll()`" until rows are allowed to talk about values. It also settles, on the record, whether `200` and `"200"` are the same document.
+
+**Independent Test**: write a document whose path value is a number and one whose value is a boolean; confirm both are rejected and that the reason quoted by the gate is a sentence a reader can find in the contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** a requirement whose selector is `{loadtest.request.name: 200}`, **When** the gate checks it, **Then** it is rejected because an assertion path part is a string.
+2. **Given** the same rejection, **When** an implementer looks for its authority, **Then** the contract states it and the gate is the check, rather than the gate being the only place it is written down.
+3. **Given** a document with `{loadtest.request.name: "200"}`, **When** the gate checks it, **Then** it is accepted — the quoted form is a different document from the unquoted one, and only one of the two is renderable.
+
+---
+
+### User Story 3 - The percentile row is a row (#64 part 1, Priority: P3)
+
+The Aggregations table writes percentiles as `p50`…`p99.9`. A range written with an ellipsis is not something a predicate can match exactly, which is what the contract's own invariant demands. Both ends already agree on something wider: the gate accepts any percentile the schema's pattern admits, and Gatling takes an arbitrary `percentile(double)`. So `p10`, `p25` and `p1` are valid documents that an implementer reading the contract cannot decide.
+
+**Why this priority**: it is the invariant applied to the table that states it, and it is the smallest of the three sentences in #64. Nothing else in the milestone depends on it, but every later milestone writes rows into these tables and will copy whatever shape it finds.
+
+**Independent Test**: take three percentiles the schema admits and the published table does not name — `p1`, `p10`, `p99.99` — and confirm each matches exactly one row.
+
+**Acceptance Scenarios**:
+
+1. **Given** a predicate with `aggregation: p10`, **When** an implementer looks it up, **Then** exactly one row matches, and the row's wording does not require them to interpolate a range.
+2. **Given** the row as rewritten, **When** it is compared against the gate and against Gatling, **Then** all three admit the same set.
+
+---
+
+### User Story 4 - Apdex is an idea, not a derived quantity (#64 part 2, Priority: P4)
+
+`README.md` excludes throughput, error rate and apdex from becoming metrics, with one reason for all three: they are computed by aggregation from metrics that already exist. That is exactly right for the first two — throughput is `aggregation: rate`, an error rate is a `bad` fraction. It is false for apdex, which classifies each request into satisfied, tolerating and frustrated against two thresholds (T and 4T) and takes a half-weighted sum of the first two. That needs a banded classification and a weighted aggregation, and this format has neither: its predicate carries one threshold, and a fraction splits a selection in two by attribute presence. So apdex is not a derived quantity being kept out — it is a construct the format does not have, which is what `docs/` is for.
+
+**Why this priority**: the exclusion is not in dispute and no document changes verdict. What changes is that the sentence stops being citable later as evidence that apdex is reachable by aggregation — a question that gets asked, because `APDEX` is a literal key in the NFR-YAML documents this format is meant to replace — and that the answer moves to where a reader looking for an absent construct will find it, with the condition for its return attached.
+
+**Independent Test**: read the paragraph and ask, of each quantity it still names, whether the stated reason is true of it; all must answer yes. Then ask the ideas area whether the format can express apdex, and confirm it answers, with a condition.
+
+**Acceptance Scenarios**:
+
+1. **Given** the rewritten paragraph, **When** a reader asks which aggregation computes each quantity it names, **Then** each has one, and apdex is not among them.
+2. **Given** a reader asking whether apdex can be written today, **When** they look in the ideas area, **Then** it answers no and states what would have to become true first.
+3. **Given** the new entry, **When** the gate counts the ideas and the conditions in `docs/ideas.md`, **Then** the two counts are equal, as Principle VIII requires.
+4. **Given** the constitution, **When** this feature is complete, **Then** Principle II is unchanged — see FR-015.
+
+---
+
+### User Story 5 - The contract argues from text that exists (#64 part 3, Priority: P5)
+
+`gatling-reach.md` twice justifies a rule by "the approximation Principle III forbids" — for the fraction numerator, and for the whole-number threshold rule. Principle III is *No Silent Green*, and its three surviving obligations are about reporting success on missing or unchecked data; it contains no clause about rendering or approximation. Those clauses were cut in 3.0.0, deliberately and on the record. Both rules are right on their own merits; what is wrong is a NON-NEGOTIABLE principle cited twice, in the one document that is supposed to settle arguments, for a clause it does not contain.
+
+**Why this priority**: it changes no rule and no verdict, and it is the part of #64 that the later milestones lean on — v0.7.0's two issues both turn on how this contract argues a rendering rule.
+
+**Independent Test**: follow every constitution citation in the contract and confirm each resolves to text the constitution currently contains.
+
+**Acceptance Scenarios**:
+
+1. **Given** the rewritten contract, **When** a reader follows each of its citations of the constitution, **Then** each names a clause that is present in `.specify/memory/constitution.md`.
+2. **Given** the rewritten contract, **When** the two rules are read, **Then** each still states why it holds, and neither has been weakened to a bare assertion.
+3. **Given** the constitution, **When** this feature is complete, **Then** it is unchanged by User Story 5.
+
+### Edge Cases
+
+- **`"*"` on a non-path attribute.** `bad: {error.type: "*"}` is untouched: `error.type` is not an assertion path attribute, and the fraction rows already constrain that value exactly. Only `loadtest.group.name` and `loadtest.request.name` are read as path parts.
+- **A request genuinely named `*`.** After this change there is no way to assert about it. That is a loss, and it is the right trade: the value the format hands authors for "any value" cannot also be a literal, and a request named `*` is hypothetical while the blanket requirement is the commonest NFR there is. Recorded, not hidden.
+- **`{}` is not affected.** `selector: {}` remains `global` — the pooled reading, as the schema, `README.md` and the contract all already say. `forAll()` is reached only through `"*"`, so the two readings of "every request" stay distinguishable.
+- **An empty run.** A `forAll()` assertion over zero observed requests yields zero assertions and the run exits successfully. This is a fact about the target, recorded in the contract's closing section; it is not compensated for by any obligation on the document (see Clarifications).
+- **A percentile outside the schema's pattern.** `p100` does not match `^p\d{1,2}(\.\d+)?$` — the integer part is capped at two digits — and needs no row: the quantity it names, the slowest observed request, is `max`, already a **can** row.
+- **`loadtest.apdex` in the `loadtest.*` registry list.** That list names `loadtest.apdex` among names deliberately absent from the proposed registry, labelled *composite*. It is about a **name** not entering a namespace; FR-013's entry is about a **construct** not entering the format. Both stay, and the label keeps the word the repository already uses.
+- **A boolean path value.** `loadtest.request.name: on` parses as `true` under YAML 1.1 and is rejected on the same rule as a number; the reason must not name only numbers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**The selection axis**
+
+- **FR-001**: Every row of the reach contract's Selection table MUST state what values its attributes may carry, not only which keys are present. A row that constrains a key set while leaving the value free does not partition the axis, because what a renderer emits is decided by the value.
+- **FR-002**: The contract MUST state that a value carried by `loadtest.group.name` or `loadtest.request.name` and rendered as an assertion path part is a string. A document whose path value is a number or a boolean MUST be a **cannot**, with the reason stated in the contract rather than only in the gate.
+- **FR-003**: `{loadtest.request.name: "*"}` MUST be a **can** row corresponding to Gatling's `forAll()` scope.
+- **FR-004**: Every other selection carrying `"*"` on a path attribute MUST be a **cannot** row carrying its reason — specifically `{loadtest.group.name: G, loadtest.request.name: "*"}` and `{loadtest.group.name: "*", loadtest.request.name: X}`, both because `forAll()` accepts no path and a group-restricted "every request" therefore has no correspondence.
+- **FR-005**: A path value that is not `"*"` MUST continue to denote a literal path part, and the contract MUST make the literal reading explicit rather than leaving it as the residue of the `"*"` rows.
+- **FR-006**: The contract MUST NOT describe the behaviour of an assertion scope no document can select. The closing note on `ForAll` and absent data MUST be attached to the row that reaches it.
+- **FR-007**: `scripts/verify.sh` MUST implement FR-002, FR-003, FR-004 and FR-005 — rejecting on the pair (key set, value) rather than on the key set alone — and MUST remain the only implementation of these tables.
+
+**How the new rules are demonstrated**
+
+- **FR-008**: Every **cannot** rule added by FR-002 and FR-004 MUST have a probe document that the gate rejects, so that removing the rule fails the gate rather than passing it. The corpus cannot carry these cases: it holds only documents that validate.
+- **FR-009**: The probe set MUST have a floor. A probe section that ran zero probes MUST fail rather than report success, on the same ground as the existing `checked == 0` floor in the reach gate: a scan that checked nothing reads exactly like a scan that passed.
+- **FR-010**: `examples/` MUST gain one document exercising the `forAll()` selection, so that the new **can** row is exercised by the gate rather than asserted. It MUST state, as the corpus's other documents do, which human sentence it is the writing of.
+
+**The aggregation axis**
+
+- **FR-011**: The Aggregations table's percentile row MUST name exactly the set of aggregations the schema's pattern admits, without an ellipsis and without implying a restriction that neither the gate nor Gatling imposes.
+
+**Names**
+
+- **FR-012**: `README.md`'s exclusion of derived quantities MUST name only quantities of which the stated reason is true. Apdex MUST leave that sentence: it is not computed by an aggregation this format has. That apdex must not become a metric does not change — only where the format says so, and why.
+- **FR-013**: `docs/ideas.md` MUST gain an entry for apdex as a construct rather than as a name, stating what it would buy and what would have to become true before it could enter the format: a classification of each request into bands against two thresholds, and an aggregation that takes a weighted sum of those bands. The entry MUST carry its condition in the form Principle VIII's gate counts, so that ideas and conditions stay one to one.
+
+**Citations**
+
+- **FR-014**: The contract MUST NOT cite a clause of the constitution that the constitution does not contain. Both occurrences MUST be replaced by an argument from text that is actually present, or by the rule's own merits, with no loss of the reason each rule holds.
+- **FR-015**: `.specify/memory/constitution.md` MUST NOT change. Two of its clauses are in scope for correction and are knowingly left, so that neither reads as overlooked: Principle III's cut clauses, which FR-014 argues around rather than restores — the cut was deliberate and its reasoning is recorded in the principle itself — and Principle II's copy of the apdex sentence, which FR-012 corrects in `README.md` only.
+
+**Freshness and scope**
+
+- **FR-016**: Any claim this feature adds about Gatling — that `forAll()` takes no path, and that it is reached by no other construct — MUST be checked against the source files the contract already names, and the contract's **Checked** date MUST be updated to the date of that check.
+- **FR-017**: `schema/opennfr.io/v1/requirementset.schema.json` MUST NOT change what validates. Every constraint it makes today MUST survive unaltered: every defect here is a defect in what the published text says about the correspondence, not in what the format admits, and narrowing the schema to suit one target is forbidden by Principle VI. Its `$defs/selector` **description** MUST follow the redefinition of `\"*\"` in the same change as `GLOSSARY.md` and `README.md`, because it is one of the three places that value is defined and the schema documents every shape it defines. A description carries no constraint, so no document changes verdict.
+- **FR-018**: `bash scripts/verify.sh` MUST exit green, and every document already in `examples/` MUST keep both its validity and its verdict.
+
+### Key Entities
+
+- **The reach contract** (`specs/004-strip-to-schema/contracts/gatling-reach.md`): the source for what Gatling can assert. Tables of **can**/**cannot** rows over five axes, each row a correspondence between an OpenNFR construct and a Gatling one. Every defect in this feature is a row that does not decide, or a sentence that decides wrongly.
+- **A selection row**: one row of the Selection table. Today it is keyed by the set of attribute names present. After this feature it is keyed by that set *and* by what the values may be.
+- **The gate** (`scripts/verify.sh` § *Examples are assertable by Gatling*): the only implementation of the contract's tables. It reads `examples/` and never the schema.
+- **The corpus** (`examples/`): the published documents, and the only place documents are published. It holds documents that validate and are assertable; it cannot hold a counter-example, which is why FR-008 needs probes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every value-bearing row of the Selection table states what its values may be. Today: zero of three do.
+- **SC-002**: A document selecting `{loadtest.request.name: "*"}` corresponds to exactly one Gatling scope, and that scope is `forAll()`. Today it corresponds to a literal path part matching a request named `*`, so the run fails for a reason unrelated to the requirement.
+- **SC-003**: Every rejection the gate issues on the selection axis quotes a reason a reader can find in the contract. Today one such reason — that a path part is a string — exists only in the gate.
+- **SC-004**: Each **cannot** rule added by this feature is demonstrated by a probe that fails when the rule is removed, and the probe count has a floor above zero. Today the reach gate has no probes at all; its only floor is on predicates read from the corpus.
+- **SC-005**: Every row of every reach table can be matched by a predicate without interpolating a range. Today one row — percentiles — cannot.
+- **SC-006**: Zero citations of the constitution in the contract resolve to text the constitution does not contain. Today: two.
+- **SC-007**: Every quantity named in `README.md`'s exclusion of derived quantities is one the stated reason is true of — today two of three — and apdex is findable in the ideas area with a condition attached, where today it appears as a one-word parenthetical inside another entry's list.
+- **SC-008**: `bash scripts/verify.sh` is green; the corpus grows from three documents to four; zero existing documents change verdict; `schema/opennfr.io/v1/requirementset.schema.json` is byte-identical to its state at `2f4b15d`.
+
+## Assumptions
+
+- **The milestone's four issues map to three commits, not four.** `AGENTS.md` maps one tracked issue to one semantic commit, and that holds for #64 and #60. #55 and #56 are one change: adding the `forAll()` row is simultaneously what gives `ForAll` a denotation and what stops `"*"` rendering as a literal, and neither issue has a green commit that does not contain the other. One commit closes both, naming both.
+- **`forAll()` accepts no path.** Taken from the contract's own list of scopes — `Global`, `ForAll`, `Details(parts)`, where only the third carries parts — and from the form quoted in #56, `forAll().responseTime().percentile(95).lt(3000)`. FR-016 requires this to be re-checked against the named Gatling sources before the row lands rather than carried on this spec's word.
+- **The gate keeps reading `examples/` and never the schema.** The probes required by FR-008 are documents the gate is handed, not schema introspection. Extending the reach section to read the schema would narrow the format to one tool.
+- **`docs/ideas.md` is the existing authority for derived-versus-composite.** FR-012 aligns `README.md` with a distinction the repository has already drawn rather than introducing one, so Principle I's obligation to argue a new term in an issue first is not engaged.
+- **Ordering follows the milestone, not the priorities.** Priorities here rank value: User Story 1 is the `severity:critical` defect. The work order is #64, then #60, then #55 with #56, because each later change writes rows into a table the earlier one repaired.
+- **No issue is closed by this spec.** Under `AGENTS.md` an issue closes when the commit that fixes it lands on `main`: #64 with the one commit carrying all three of its parts, #60 with its own, #55 and #56 together with the single commit that answers both.
+- **No document currently in `examples/` uses `"*"` on a path attribute.** The three published documents select `{}`, one request name, and a group with a request name, all literal — so FR-003 and FR-004 change no existing verdict, and FR-018 is expected to hold without corpus edits.

--- a/specs/007-reach-table-rules/tasks.md
+++ b/specs/007-reach-table-rules/tasks.md
@@ -1,0 +1,165 @@
+---
+
+description: "Task list for 007-reach-table-rules (milestone v0.4.0)"
+---
+
+# Tasks: The Rules By Which The Reach Tables Are Read
+
+**Input**: Design documents from `/specs/007-reach-table-rules/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/reach-selection.md](./contracts/reach-selection.md), [quickstart.md](./quickstart.md)
+
+**Tests**: this repository's test model is `bash scripts/verify.sh` and nothing else. Tasks that add
+a probe are not "test tasks" in the template's sense — a probe is how a **cannot** rule is
+demonstrated at all, required by spec FR-008, not an optional extra.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different files, no dependency on an incomplete task
+- **[Story]**: which user story the task serves (US1…US5 from [spec.md](./spec.md))
+- Every task names the file it changes
+
+## Phases are ordered by commit, not by priority
+
+Priorities in [spec.md](./spec.md) rank **value**: US1 is the `severity:critical` defect. The order
+below is what can actually be built, from [research.md](./research.md) R7 — each later commit writes
+rows into a table the earlier one repaired.
+
+| Phase | Commit | Closes | Stories | Priority |
+|---|---|---|---|---|
+| 2 | `fix(contract): three sentences that are not true as written` | #64 | US3, US4, US5 | P3, P4, P5 |
+| 3 | `fix(contract): a selection row constrains its value` | #60 | US2 | P2 |
+| 4 | `fix(contract): "*" selects every named request, and says so` | #55, #56 | US1 | P1 |
+
+**Foundational phase**: the template's Phase 2 is empty here. Nothing blocks every story — US3, US4
+and US5 are documentation edits with no shared prerequisite. The one piece of shared machinery, the
+probe harness in the reach gate, is introduced by the first commit that needs it (T009, Phase 3) and
+reused by Phase 4. It is called out there rather than hoisted, so that every commit stays green on
+its own, which `AGENTS.md` requires.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: know what the numbers are before anything moves, so a change that shifts one is visible.
+
+- [X] T001 Run `bash scripts/verify.sh` and confirm the counts recorded in `specs/007-reach-table-rules/quickstart.md` § 0 still hold (9 predicates; 24 embedded examples and 54 closures; 25 links out of `docs/`; 150 internal links). Correct that section if any has moved since 2026-08-24.
+
+**Checkpoint**: baseline recorded. Phases 2 and 3–4 are independent of each other from here and may be worked in parallel by two people; they touch the same file in different sections, so stack the PRs and rebase rather than merge.
+
+---
+
+## Phase 2: Three sentences that are not true (US3, US4, US5) — commit 1, closes #64
+
+**Goal**: every sentence in the published text is true as written, and every citation resolves.
+
+**Independent test**: follow each constitution citation in the contract and confirm it names a clause the constitution contains; look up `p1`, `p10` and `p99.99` and confirm each matches exactly one row; ask of each quantity in `README.md`'s exclusion whether the stated reason is true of it.
+
+- [X] T002 [P] [US3] Rewrite the percentile row at `specs/004-strip-to-schema/contracts/gatling-reach.md:41` to name any percentile the schema's pattern admits, quoting `^p\d{1,2}(\.\d+)?$` as the authority, and drop the `p50`…`p99.9` ellipsis. Add the one-line note that `p100` falls outside the pattern and needs no row, its quantity being `max` — research.md R3.
+- [X] T003 [P] [US5] Replace the Principle III citation at `specs/004-strip-to-schema/contracts/gatling-reach.md:67-68` with the argument from what the rule costs: a `bad` narrower than "an error happened" has no `failedRequests` equivalent, so a renderer meeting one must pick a nearest available number, and the rule exists to stop that being done silently — research.md R5.
+- [X] T004 [P] [US5] Replace the Principle III citation at `specs/004-strip-to-schema/contracts/gatling-reach.md:92-93` with the argument that rounding moves the bar the author wrote, so the document says one thing and the run checks another — research.md R5.
+> **A defect this feature left alone, fixed elsewhere.** `specs/004-strip-to-schema/contracts/gatling-reach.md`
+> held a row of the Units table orphaned below the paragraph T004 edits, with three cells where that
+> table has four columns. It was out of scope here — `AGENTS.md` forbids opportunistic changes outside
+> the issue, and it belonged to no milestone-v0.4.0 issue — and it landed on `main` on its own as
+> `dd7a5ef`, *put the unreachable-units row back in the Units table*. This branch rebased onto it; the
+> conflict is in the paragraph T004 rewrites, and resolving it means taking the Units table from `main`
+> and the paragraph from T004. T004 still does not touch that row.
+
+- [X] T005 [P] [US4] Remove apdex from the derived-quantities sentence at `README.md:390-391`, leaving throughput and error rate, of which the stated reason is true. Do not weaken the exclusion itself.
+- [X] T006 [US4] Add an apdex entry to `docs/ideas.md` § *Fields argued for and left out*, opening with `**apdex**` at line start so the gate counts it, naming the two missing constructs — a banded classification against two thresholds (T, 4T) and a weighted aggregation over those bands — and closing with a `*Would need*` clause. Keep the existing `loadtest.apdex` (composite) mention in the `loadtest.*` registry list: that is about a name not entering a namespace — research.md R4.
+- [X] T007 [US4] Run `bash scripts/verify.sh` and confirm § *docs/ is isolated* still reports every idea stating its condition; a new entry without its `*Would need*` clause fails that line, which is Principle VIII's gate rather than a convention. Fix `docs/ideas.md` if it does not balance.
+- [X] T008 [US3] Confirm `specs/004-strip-to-schema/contracts/gatling-reach.md` contains zero occurrences of `Principle III` and that both rules edited by T003 and T004 still state why they hold.
+
+**Checkpoint**: commit 1 is green and shippable on its own. No gate behaviour changed; the corpus is untouched.
+
+---
+
+## Phase 3: A selection row constrains its value (US2) — commit 2, closes #60
+
+**Goal**: the rule that an assertion path part is a string lives in the contract, with the gate as its check — the reverse of how it stands today.
+
+**Independent test**: hand the gate a document whose path value is a number and one whose value is a boolean; both are rejected, and the reason each names is a sentence findable in the contract.
+
+- [X] T009 [US2] Add a probe harness to `scripts/verify.sh` § *Examples are assertable by Gatling*: a base document known to be assertable, a table of mutations each of which must be rejected, and a floor that FAILs the section if the table is empty. Mirror the shape already at `scripts/verify.sh:381-474` in the schema section. The section must keep reading `examples/` and never the schema — research.md R6.
+- [X] T010 [US2] Add the value constraint to the Selection table in `specs/004-strip-to-schema/contracts/gatling-reach.md`: a value carried by `loadtest.group.name` or `loadtest.request.name` and rendered as a path part is a string, sourced to `AssertionPathParts(parts: List[String])`, with a **cannot** row for any path value that is not a string. State that `{loadtest.request.name: 200}` and `{loadtest.request.name: "200"}` are different documents and only the second is renderable — contracts/reach-selection.md.
+- [X] T011 [US2] Keep the existing value check in `scripts/verify.sh` (`an assertion path part must be a string`) and move its authority: the message stays, and the contract is now where the rule is written. Confirm the rejection path still fires for a numeric and a boolean value.
+- [X] T012 [P] [US2] Add a probe to `scripts/verify.sh` for a numeric path value (`{loadtest.request.name: 200}`), asserting it is rejected naming the string rule.
+- [X] T013 [P] [US2] Add a probe to `scripts/verify.sh` for a boolean path value (`{loadtest.request.name: on}`, which YAML 1.1 reads as `true`), asserting the message does not name only numbers.
+- [X] T014 [US2] Delete the string rule from `scripts/verify.sh` temporarily and confirm the section FAILs, then restore it. A probe that cannot fail is the defect `specs/005-fix-milestone-bugs` FR-002 exists to prevent.
+
+**Checkpoint**: commit 2 is green and shippable. The corpus is unchanged — its three documents all carry literal string paths.
+
+---
+
+## Phase 4: `"*"` selects every named request (US1) — commit 3, closes #55 and #56
+
+**Goal**: the blanket requirement is writable, and it means one statement per observed request rather than one number over all of them.
+
+**Independent test**: a document selecting `{loadtest.request.name: "*"}` is accepted and the contract names exactly one scope for it; the two selections that carry `"*"` alongside a path are rejected; a literal path value still renders as a literal path part.
+
+**Depends on**: Phase 3 — the gate must be value-aware before a value can be given a meaning, and T009's harness carries this phase's probes.
+
+- [X] T015 [US1] Redefine `"*"` in `GLOSSARY.md` § *selector* (line 56): the attribute is present **and** each distinct value is a statement of its own. Record the rejected alternative — mapping it to `global`, which makes the value redundant with `{}` — and what the old definition got wrong: it settled presence and left the quantifier unstated, so the value's only honest reading was one already spoken for. Principle I requires all of this in the same change; the argument lives in #55 and #56 — research.md R1.
+- [X] T016 [P] [US1] Restate the same meaning in `README.md`'s selector table (line 246), where `"*"` currently reads "presence, not a glob". Keep "not a glob" — it is still true and still load-bearing.
+- [X] T017 [P] [US1] Amend the `description` of `$defs/selector` in `schema/opennfr.io/v1/requirementset.schema.json` so all three definitions of `"*"` agree. Change the description string only — every constraint the schema makes stays byte for byte, and no document changes verdict — research.md R8.
+- [X] T018 [US1] Apply the delta in `specs/007-reach-table-rules/contracts/reach-selection.md` to the Selection table in `specs/004-strip-to-schema/contracts/gatling-reach.md`: add the `forAll()` **can** row and the two `"*"`-with-a-path **cannot** rows, amend the two existing `details(...)` rows to require a string other than `"*"`, and add the sentence that the value is part of the correspondence. Rows that file does not list are left exactly as they are.
+- [X] T019 [US1] Reattach the absent-data note in `specs/004-strip-to-schema/contracts/gatling-reach.md` § *Two things Gatling cannot do at all* to the `forAll()` row it now explains, so the contract stops documenting the behaviour of a scope no document can select — #56's second half.
+- [X] T020 [US1] Update the **Checked** header of `specs/004-strip-to-schema/contracts/gatling-reach.md` to 2026-08-24 and cite `AssertionSupport.scala` for the claim that `ForAll` carries no author strings — spec FR-016, research.md R2.
+- [X] T021 [US1] Teach `scripts/verify.sh` § *Examples are assertable by Gatling* the value rules: accept `"*"` when the key set is exactly `{loadtest.request.name}`; reject it in the group position and reject it on the request name when a group is also present, naming that a quantified selection cannot carry a path.
+- [X] T022 [P] [US1] Add a probe to `scripts/verify.sh` for `{loadtest.group.name: Checkout, loadtest.request.name: "*"}`, asserting rejection.
+- [X] T023 [P] [US1] Add a probe to `scripts/verify.sh` for `{loadtest.group.name: "*", loadtest.request.name: POST /checkout}`, asserting rejection.
+- [X] T024 [US1] Add `examples/every-request-is-fast.yaml` — the blanket requirement, selecting `{loadtest.request.name: "*"}`, opening with the human sentence it is the writing of, as the other three corpus documents do. This is the only document exercising the new **can** row, so without it the accept path is asserted rather than checked — spec FR-010.
+- [X] T025 [US1] Confirm `git diff main -- schema/` shows exactly one changed pair of lines, the `$defs/selector` description, and that `bash scripts/verify.sh` still reports `24 embedded examples valid, 54 closures still reject`. Either count moving means a constraint moved with the description.
+
+**Checkpoint**: commit 3 is green. The milestone's stated goal holds — the Selection table partitions on (key set, value), and `"the tables partition each axis"` is true on the selection axis.
+
+---
+
+## Phase 5: Polish and release bookkeeping
+
+- [X] T026 Walk `specs/007-reach-table-rules/quickstart.md` end to end and confirm every expected output matches, correcting the quickstart where reality differs rather than the other way round.
+- [X] T027 Confirm `docs/` is still droppable in one operation, which Principle VIII requires and T006 added an entry to: copy `docs/` aside, `rm -rf docs`, run `bash scripts/verify.sh` (must stay green), then restore from the copy. Do **not** reach for `git stash`/`git checkout -- docs` while T006's entry is uncommitted — restoring from the index discards it, which is exactly what happened on the first attempt here.
+- [ ] T028 Open three stacked PRs, one per commit, each with a conventional title, each assigned to milestone v0.4.0 before merge, rebased onto `main` rather than merged — `AGENTS.md`.
+- [ ] T029 Close #64, #60, #55 and #56 as their commits land on `main`. Commit 3 names both #55 and #56; neither has a green commit that does not contain the other — research.md R7.
+
+---
+
+## Dependencies
+
+```text
+T001  setup
+  ├── Phase 2 (commit 1, #64)   T002…T008   — independent of Phases 3 and 4
+  └── Phase 3 (commit 2, #60)   T009…T014
+        └── Phase 4 (commit 3, #55 #56)  T015…T025
+              └── Phase 5  T026…T029
+```
+
+- T009 (probe harness) blocks T012, T013, T022, T023.
+- T010 blocks T011: the contract states the rule before the gate is described as its check.
+- T015 blocks T018: the term is redefined before a row maps it, which is Principle I's ordering — a term appears in the glossary before it appears anywhere else.
+- T021 blocks T024: the corpus document must be accepted by a gate that knows the rule, not by one that has not learned it yet.
+
+## Parallel opportunities
+
+- **Across phases**: Phase 2 shares no line with Phases 3–4. Two people can work them at once; both touch `specs/004-strip-to-schema/contracts/gatling-reach.md`, so stack the PRs and rebase.
+- **Within Phase 2**: T002, T003, T004, T005 are four separate edits in two files — all `[P]`. T006 follows T005 only by topic, not by dependency.
+- **Within Phase 3**: T012 and T013 are two probes, independent once T009 exists.
+- **Within Phase 4**: T016 and T017 restate T015's decision in two other files and can go in parallel with each other. T022 and T023 are independent probes.
+- **Outside this feature**: none. The orphaned Units row was to have been fixed concurrently; that session was deleted without landing anything, and the row is left as found — see the note in Phase 2.
+
+## Implementation strategy
+
+**MVP**: Phases 3 and 4 together — commits 2 and 3. That is the smallest slice delivering the
+milestone's stated goal, because it is US1 (the `severity:critical` defect) plus the value-awareness
+US1 stands on. Phase 2 is fully independent and ships whenever; the milestone puts it first because
+v0.7.0's two issues lean on the Principle III rewrite, not because anything here waits on it.
+
+**Increment order**: commit 1 changes no behaviour and can land immediately. Commit 2 adds a rule the
+gate already enforces, so it changes no verdict either — it moves where the rule is written and adds
+the machinery to prove it. Only commit 3 changes what a document means, and it is the one that needs
+`GLOSSARY.md`, `README.md` and the schema description to move together.
+
+**What must stay true throughout**: `bash scripts/verify.sh` green after every commit; every
+constraint in the schema unaltered; `.specify/memory/constitution.md` untouched; the reach gate
+reading `examples/` and never the schema.


### PR DESCRIPTION
Milestone **v0.4.0** — all four issues, found by the first OpenNFR renderer ([galax-io/gatling-picatinny#236](https://github.com/galax-io/gatling-picatinny/issues/236)).

The reach contract states an invariant: *the tables partition each axis; a predicate is assertable only if it matches a row exactly*. On the selection axis that was not true — the axis was partitioned by **key set**, while what a renderer emits depends on the **value**. After this, it is true.

Closes #64
Closes #60
Closes #56
Closes #55

## Commits

Four, in dependency order. Each is green on `bash scripts/verify.sh` on its own; verified per commit.

| Commit | Closes |
|---|---|
| `docs(speckit): add 007-reach-table-rules spec/plan/tasks` | — |
| `fix(contract): three sentences that are not true as written` | #64 |
| `fix(contract): a selection row constrains its value` | #60 |
| `fix(contract): "*" selects every named request, and says so` | #55, #56 |

## What a reviewer should know

**#56 was moved into this milestone from v0.5.0.** It asks why no selector reaches Gatling's `ForAll` scope; #55 reports that `{loadtest.request.name: "*"}` is approved by the gate and rendered as a request literally named `*`. They are one answer, and neither has a green commit that does not contain the other — hence one commit naming both. Both milestone descriptions were rewritten to match.

**The `"*"` fix is a change to a defined term, not just a new row.** Under the term as defined, a selector picks one set and every predicate reduces it to one number. `"*"` carried no quantifier, so the pooled reading of `{loadtest.request.name: "*"}` was "all requests that have a name" — which in Gatling is every request, i.e. `global`, making the value a longer spelling of `{}`. The per-request reading has to be *given* to `"*"` at the format level. That engages **Principle I**: `GLOSSARY.md`, `README.md` and the schema's `$defs/selector` description change together, and the glossary records the rejected alternative and what the old definition left unstated. The argument predates the files — #55 and #56 both make it.

**The schema's constraints do not move.** `git diff main -- schema/` is exactly one changed pair of lines, the `$defs/selector` description. The gate's `24 embedded examples valid, 54 closures still reject` is unchanged, which is what proves no constraint travelled with the description.

**The constitution is untouched, in two places on purpose.** Principle III's cut clauses are argued around rather than restored — the cut was deliberate and its reasoning is recorded in the principle. Principle II's copy of the apdex sentence is left; `README.md` is corrected and apdex moves to the ideas area. Both are recorded in the spec (FR-015) so neither reads as overlooked.

**A rejection rule now has to prove it fires.** `examples/` holds only documents that validate, so a **cannot** row has nothing there to demonstrate it. The reach section gains a probe table with a floor, mirroring the schema section. Both halves were verified by breaking them: removing the string rule fails the probes, emptying the table fails the floor.

**One thing lost, recorded rather than hidden**: there is no longer a way to assert about a request literally named `*`. The value the format hands authors for "any value" cannot also be a literal.

## Numbers

| | before | after |
|---|---|---|
| Predicates in the corpus | 9 | 10 |
| Selection probes | 0 | 4 |
| Documents in `examples/` | 3 | 4 |
| Citations resolving to nothing | 2 | 0 |
| Embedded examples / closures | 24 / 54 | 24 / 54 |

## Note on PR granularity

`AGENTS.md` asks for one concern per PR, which would make this three stacked PRs plus the spec. It is one PR at the requester's instruction; the commits are split so a reviewer can read them separately, and a rebase merge preserves that. Say the word and I will split it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
