### PR TITLE
fix(governance): the constitution catches up with the documents that follow it

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -3,9 +3,15 @@ SYNC IMPACT REPORT
 ==================
 Version change: 3.0.0 -> 4.0.0
 
-Bump rationale: MAJOR. Principle VI's second bullet is "redefined in a way that permits what it
-previously forbade" — adding a target may now change one existing document, the one holding the
-target descriptions, where the previous wording forbade changing any.
+Bump rationale: MAJOR, at two limbs, and the highest governs.
+
+  1. Principle VI's second bullet is "redefined in a way that permits what it previously forbade" —
+     adding a target may now change one existing document, the one holding the target descriptions,
+     where the previous wording forbade changing any. MAJOR.
+  2. Principle II gains a clause: composite quantities do not become metrics either, for a reason
+     that is not the derived one. That is "existing guidance is materially expanded". MINOR.
+
+Both ride one amendment, so the document takes one version number, as the versioning policy says.
 
 Travelling with other work: no. This amendment IS the work. Milestone v0.7.0 exists to make this
 file stop contradicting the documents that follow it, and the pull request carrying it says so in
@@ -20,7 +26,22 @@ ships two normative documents that contradict each other, with the reconciliatio
 feature plan under a directory AGENTS.md itself reads as history (#83). Every milestone after this
 one writes another target fact into the document Principle VI forbids changing.
 
+The second half is smaller and the same shape. #64 removed apdex from README.md's derived-quantities
+sentence because the stated reason — computed by aggregation from metrics that already exist — is
+false of it: apdex needs a banded classification carrying a second threshold and an aggregation
+weighting the bands, and the format has neither. Principle II kept all three names under that reason,
+so the repository shipped two normative statements about the same three names that disagreed, with
+the false one in the higher-authority document (#75). The deferral that recorded this closed with its
+milestone and has had no open home since.
+
 Sections materially changed:
+  - Principle II — the derived-quantities clause becomes two. apdex leaves the derived list, where
+    the stated reason is false of it, and is named in a new clause for COMPOSITE quantities, which
+    reduce to no construct the format has. The clause states the rule; the argument for why apdex
+    reduces to nothing stays in docs/ideas.md, where this repository argues about constructs it does
+    not have. Mirroring README.md's deletion without replacement was the alternative, and was
+    rejected: it makes the two documents agree by making this one silent, and this principle is the
+    only place the constitution says what may not become a metric name.
   - Principle VI — the second bullet becomes two. A target's DESCRIPTION is defined as what a
     renderer reads to turn a requirement document into that target's assertions; exactly one is
     required per target; a description MAY be a section of an existing document; and a gate
@@ -76,8 +97,11 @@ unusable across tools because their words meant different things in different pl
   semconv has no equivalent.
 - Aliases and second spellings for the same concept are FORBIDDEN, including
   human-friendly shorthands.
-- Derived quantities (throughput, error rate, apdex) MUST NOT become metrics. They are
-  computed by aggregation from metrics that already exist.
+- Derived quantities (throughput, error rate) MUST NOT become metrics. They are computed by
+  aggregation from metrics that already exist.
+- Composite quantities MUST NOT become metrics either, for the opposite reason: they reduce to
+  no construct the format has. apdex is the case on the record, and `docs/ideas.md` carries what
+  would have to become true before it could enter.
 
 **Rationale**: a second vocabulary is a second source of truth, and the two diverge as
 soon as either changes. Borrowing is also what makes a result report correlate with the

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,54 +1,50 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: 2.1.0 → 3.0.0
+Version change: 3.0.0 -> 4.0.0
 
-Bump rationale: MAJOR on two counts, each independently sufficient under this document's own
-policy — "a principle or a binding constraint is removed, or redefined in a way that permits
-what it previously forbade".
+Bump rationale: MAJOR. Principle VI's second bullet is "redefined in a way that permits what it
+previously forbade" — adding a target may now change one existing document, the one holding the
+target descriptions, where the previous wording forbade changing any.
 
-  1. Principle VII is REMOVED. It bound every change to name an architectural role and to amend
-     ARCHITECTURE.md first; that document is deleted by the work this amendment travels with.
-     Number VII stays withdrawn and is not reused.
-  2. "MUST NOT change without an ADR" is redefined. The decision records are deleted with
-     reference/, so the requirement becomes an argued issue plus a glossary entry recording what
-     was rejected. Both instruments already existed under Principle I; nothing new is introduced.
+Travelling with other work: no. This amendment IS the work. Milestone v0.7.0 exists to make this
+file stop contradicting the documents that follow it, and the pull request carrying it says so in
+its first paragraph, as the amendment procedure requires.
 
-     Four further clauses made an ADR mandatory and are redirected in the same amendment, because
-     leaving any of them would be the defect this amendment exists to remove, one file over:
-     Principle I's rename rule, Principle IV's ADR-status rule, Principle V's custom-decoding
-     justification, and the Development Workflow's contradict-an-ADR rule. A rule that cannot be
-     obeyed is not a rule.
-
-Travelling with other work, disclosed as the amendment procedure requires: this ships in the
-pull request that reduces the repository to a schema, examples and one field description. What
-breaks without it is not hypothetical — Principle VII would bind against a file that no longer
-exists, and the compatibility clause would require a record in a directory that no longer exists.
-That is the third time in three changes a rule has been left pointing at something deleted, which
-is the pattern this amendment stops rather than repeats.
+What breaks without it: v0.5.0 consolidated the Gatling correspondence into README.md on the
+argument of #68 — the tables existed twice and had drifted, with four issues closed a release
+earlier live again in the copy on the page most readers meet. AGENTS.md states that consolidation
+as settled architecture. Principle VI forbade it in terms, and Governance says that where the two
+disagree this document wins and the other is wrong and MUST be fixed. Left alone, the repository
+ships two normative documents that contradict each other, with the reconciliation filed in a
+feature plan under a directory AGENTS.md itself reads as history (#83). Every milestone after this
+one writes another target fact into the document Principle VI forbids changing.
 
 Sections materially changed:
-  - Principle III — trimmed to what exists. Its clauses on rendering, on target descriptions and
-    on declaring where a target passes on absent data described machinery no artifact in this
-    repository contains. The guarantee is unchanged; three obligations survive, and they are the
-    three anything here can actually break.
-  - Principle VII — removed.
-  - Principle VIII — reduced to `docs/`. The experimental area and its two grandfathered
-    artifacts are deleted by the same work, so the clause naming them goes with them.
-  - Compatibility Constraints — the target-description surface is removed, because nothing in
-    the repository describes a target. Two surfaces remain, and they change on an argued issue.
-  - Every path follows the move: the glossary is GLOSSARY.md at the repository root, and the
-    reference/ directory ceases to exist.
+  - Principle VI — the second bullet becomes two. A target's DESCRIPTION is defined as what a
+    renderer reads to turn a requirement document into that target's assertions; exactly one is
+    required per target; a description MAY be a section of an existing document; and a gate
+    implementing one is not a second one. Adding a target still may not change the format, the
+    schema or the published corpus. The amendment record is appended to the principle, and it
+    states that nothing checks the rule, because nothing does.
+  - Compatibility Constraints — "nothing in this repository describes a target" was made false by
+    v0.5.0 and is corrected. The list of compatibility-sensitive surfaces is unchanged at two
+    items; restoring the third, what a target's description may declare, is recorded there as the
+    rejected alternative rather than left undiscussed.
 
-Owed by 2.0.0 and now settled by deletion rather than by argument: ARCHITECTURE.md (issue #35)
-and the conformance ladder (issue #36). Both documents are gone; both issues are closed with a
-reason rather than left pointing at nothing.
+Owed and not settled here: nothing validates this file. Principle III's third clause — any artifact
+nothing validates MUST say so in its own text — is unmet by this document, and that is why the
+contradiction above stood through two releases. It is not one of milestone v0.7.0's issues and gets
+its own, because the honest fix is an argument about what such a check could decide, not a sentence.
+
+Numbers: no principle is removed. VII remains the only withdrawn number.
 
 Templates and docs reviewed:
-  ✅ .specify/templates/plan-template.md   — the VII gate deleted, III and Compatibility rewritten
+  ✅ .specify/templates/plan-template.md   — the VI gate and the version pointer follow
   ✅ .specify/templates/spec-template.md   — no change needed
   ✅ .specify/templates/tasks-template.md  — no change needed
   ✅ .specify/templates/checklist-template.md — no change needed
+  ✅ AGENTS.md § Architecture — the departure parenthetical is removed; its rule stands unchanged
 -->
 
 # OpenNFR Constitution
@@ -141,9 +137,14 @@ that stays free of targets.
 
 - A requirement document MUST NOT name a target: not in a field, a value, a metric name, or an
   example. It carries no per-target section, override or conditional.
-- The correspondence between the document's vocabulary and a target's own MUST live in that
-  target's description. Adding a target MUST NOT change the format, the schema, or any
-  existing document.
+- A target's **description** is what a renderer reads to turn a requirement document into that
+  target's assertions. The correspondence between the document's vocabulary and a target's own
+  MUST live there, and there MUST be exactly **one** description per target: a second copy is
+  what drift is made of. A description MAY be a section of an existing document. A gate that
+  implements a description is not a second description — it MAY name the reason a row gives,
+  and MUST NOT carry a second copy of the rows.
+- Adding a target MUST NOT change the format, the schema, or the published corpus, and MUST NOT
+  change any existing document other than the one holding the target descriptions.
 - A target's own statistic MAY decide the run. That is what an assertion-first format is: the
   target computes its percentile, asserts against it, and reports. This project does not
   recompute it. What the format MUST NOT do is imply that two targets asserting the same
@@ -173,6 +174,31 @@ cost of the change is stated rather than hidden: two targets asserting one crite
 necessarily produce the same number, and no rule here can make them. The most the format can
 honestly promise is that the *statement* is one statement, and that every place the targets
 disagree is written down where a reader will find it.
+
+4.0.0 split the second bullet in two and rewrote what it forbids. It read "Adding a target MUST NOT
+change the format, the schema, or any existing document", and by v0.5.0 the repository was doing the
+opposite on purpose: #68 found the Gatling correspondence stated in two places and drifted, with four
+issues closed a release earlier live again in the copy on the page most readers meet. One home was
+the fix, and `README.md` was chosen as that home — which made adding a second target a change to an
+existing document, which this bullet forbade in terms. The departure was declared in a feature plan,
+under a directory `AGENTS.md` reads as history and nowhere a contributor looks for rules, so the
+repository shipped two contradicting normative documents for two releases (#83).
+
+What was wrong was the unit, not the rule. The property a separate file bought was not separateness;
+it was that there is one place to look, and the drift #68 fixed was two copies disagreeing. The
+bullet now requires that property directly, and defines what has to be singular before requiring it.
+The definition earns its keep rather than decorating the rule: without it the clause would forbid
+every statement about a target outside a description, and this repository would violate it in four
+places, two of them deliberately — a sentence naming what three load generators each call a request,
+which is the argument for the field existing at all, and a gate comment giving the reason one of its
+own rows gives, which v0.6.0 required. A renderer reads neither, so neither is a description, and the
+rule reaches what it was written for. Nor does `specs/` count: it is read as history, not as
+documentation, and Principle VIII says so where that reading is enforced.
+
+Nothing checks any of this. `scripts/verify.sh` does not read this file, which is why the
+contradiction stood through two releases, and "is this sentence a target description" is not a
+question a script decides. The bullet is enforced in review or not at all, and says so here rather
+than reading as though a gate were watching — which is Principle IV pointed at this principle.
 
 ### VII. *(withdrawn in 3.0.0)*
 
@@ -222,8 +248,13 @@ and a `GLOSSARY.md` entry recording the alternative that was rejected:
 deleted with `reference/`, and a requirement to record a decision in a directory that does not
 exist is not a requirement. Both instruments that replace it already existed under Principle I:
 a naming disagreement is argued in an issue before files change, and every glossary entry carries
-a rejected alternative. The third surface, what a target's description may declare, is removed —
-nothing in this repository describes a target.
+a rejected alternative. The third surface, what a target's description may declare, was removed in
+3.0.0, when nothing in this repository described a target. One does now: `README.md` § *What any tool
+can actually run*, added in v0.5.0. The surface is **not** restored, and that is a decision rather
+than an oversight — restoring it would put an argued issue and a `GLOSSARY.md` entry recording a
+rejected alternative behind every edit to a reach row, and `GLOSSARY.md` is the vocabulary document,
+where a rejected table row does not belong. Reach rows change through the ordinary issue and
+milestone rules, as four of them did in v0.6.0.
 
 Binding constraints:
 
@@ -301,4 +332,4 @@ justified in writing in the plan's Complexity Tracking section.
 **Runtime guidance**: `AGENTS.md` for process, `GLOSSARY.md` for vocabulary, `README.md` for
 the format itself.
 
-**Version**: 3.0.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-23
+**Version**: 4.0.0 | **Ratified**: 2026-08-10 | **Last Amended**: 2026-08-30

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -41,7 +41,7 @@
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 Answer each gate explicitly. A "no" is either fixed or justified in Complexity Tracking
-below — never left blank. See `.specify/memory/constitution.md` (v3.0.0).
+below — never left blank. See `.specify/memory/constitution.md` (v4.0.0).
 
 - [ ] **I. Vocabulary Before Features** — does this feature introduce or rename a term? If so, is
       `GLOSSARY.md` updated in the same change, with a rejected alternative and its reason? Was
@@ -60,7 +60,9 @@ below — never left blank. See `.specify/memory/constitution.md` (v3.0.0).
       parser? Are value sets closed?
 - [ ] **VI. The Requirement Is Target-Blind** — does any requirement document name a target, in a
       field, a value, a metric name or an example? Does adding a target change the format, the
-      schema, or an existing document?
+      schema, the published corpus, or any existing document other than the one holding the target
+      descriptions? Is there still exactly one description per target, and does any gate carry a
+      second copy of its rows?
 - [ ] **VII** — *withdrawn in 3.0.0. No gate.*
 - [ ] **VIII. Ideas Are Parked, Not Merged** — does anything outside `docs/` link into it? Does
       every idea state what would have to become true before it could enter the format? Does

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -49,7 +49,7 @@ below — never left blank. See `.specify/memory/constitution.md` (v4.0.0).
 - [ ] **II. Borrow Names, Never Invent Them** — is every metric and attribute name taken from
       OpenTelemetry semconv where an equivalent exists? Is anything new confined to `loadtest.*`,
       and does the field description say so where the corpus depends on it? Are there aliases, or
-      derived quantities masquerading as metrics?
+      derived or composite quantities masquerading as metrics?
 - [ ] **III. No Silent Green** — does any check this adds skip rather than fail when it cannot
       run? Does any check report success having scanned nothing? Does any artifact this adds
       claim a validation that does not happen? If a check's input is being deleted, is the check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ No code. One JSON Schema (`schema/opennfr.io/v1/requirementset.schema.json`), do
 
 ## Architecture
 
-The schema decides; `README.md` explains it, and is the only document that describes a field or states what a target can assert — a second target is a second section there, not a second file (argued in `specs/008-path-denotation/plan.md` § Complexity Tracking, against constitution Principle VI). `GLOSSARY.md` defines the terms the schema carries. Compatibility-sensitive: any OpenTelemetry semantic convention name borrowed by the format, and any field name that appears in a published example.
+The schema decides; `README.md` explains it, and is the only document that describes a field or states what a target can assert — a second target is a second section there, not a second file. `GLOSSARY.md` defines the terms the schema carries. Compatibility-sensitive: any OpenTelemetry semantic convention name borrowed by the format, and any field name that appears in a published example.
 
 ## Test Model
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -79,7 +79,9 @@ without training, and `APDEX` is a literal key in the NFR-YAML documents this fo
 replace, so it gets asked for. Two constructs are missing and neither is small. A predicate carries
 one threshold, and a fraction — `bad` or `good` — splits a selection in two by attribute presence,
 so nothing here produces three bands or takes a second threshold. And no aggregation the format has
-— `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate` — takes a weighted sum of counts.
+— `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate`, `sum` — takes a weighted sum of counts. `sum`
+is the one that looks like it might: it adds up the values a metric carries, and nothing here sorts
+requests into bands or gives a band a weight, so there are no weighted counts for it to add.
 
 This is why apdex sits here and not beside throughput and an error rate. Those two are **derived**:
 each reduces to one construct the format already has, `aggregation: rate` and a `bad` fraction.

--- a/specs/010-constitution-catches-up/checklists/requirements.md
+++ b/specs/010-constitution-catches-up/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: The Constitution Catches Up
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Iteration 1** raised two `[NEEDS CLARIFICATION]` markers, at FR-009 and FR-018. Both were decisions the user owns, and both were answered on 2026-08-30:
+  - **FR-009** — correct the false Compatibility Constraints sentence, and do **not** restore "what a target's description may declare" as a compatibility-sensitive surface. The rejected alternative is recorded in FR-010.
+  - **FR-018** — Principle II deletes `apdex` from the derived clause **and** gains a composite clause naming it, with a reason true of it. Mirroring `README.md`'s deletion alone was the rejected alternative.
+- **Iteration 2** re-ran the checklist with both resolved. All items pass.
+- "Non-technical stakeholders" reads as *a contributor who is not the author* here. The subject of this feature is the repository's own governing documents; there is no end user below that, and every requirement names a document and a sentence rather than a mechanism.
+- Every success criterion is decidable by reading the shipped files. None names a tool, a language or a data structure; `bash scripts/verify.sh` appears in SC-007 as the repository's existing gate, which the milestone does not change.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`. None are.

--- a/specs/010-constitution-catches-up/contracts/principle-ii.md
+++ b/specs/010-constitution-catches-up/contracts/principle-ii.md
@@ -1,0 +1,100 @@
+# Contract: the delta to Principle II, and to the argument it left behind
+
+**Feature**: `010-constitution-catches-up` | **Issue**: [#75](https://github.com/galax-io/opennfr/issues/75)
+
+Two edits, in two files, on one subject. `README.md` **does not change** — its sentence is the
+correct one and is what Principle II's first clause is being brought to. The schema, the corpus, the
+gate and `GLOSSARY.md` do not change.
+
+## What does not change, and why that is the decision
+
+**`README.md:424`.** After #64 it reads *"Derived quantities — throughput and error rate — must not
+become metrics; they are computed by aggregation from metrics that already exist."* That is the
+target of the correction, not a subject of it. It gains no counterpart to the composite clause:
+§ *Names* tells an author what they may write, and a class of quantity the format cannot express is
+not something an author can write. It is refused by the reach tables' `any other` Metrics row and
+parked under `docs/`, which § *What is not in the format yet* already points at (FR-021).
+
+**`GLOSSARY.md`.** No term is added, renamed or redefined. The word *composite* classifies a quantity
+the format does not carry — it is not a field, a value, or a name a document may hold — and Principle I
+requires a term to reach `GLOSSARY.md` before it reaches an example, a schema or an implementation.
+The constitution is none of the three, and `docs/ideas.md:86` already uses the word of apdex in the
+sentence being corrected (FR-026).
+
+**The mint bar.** v0.6.0 put *"a name is minted only where something outside this repository already
+records the quantity under one"* in `GLOSSARY.md` § *metric*, and the Development Workflow's *"A PR
+that contradicts a decision recorded in `GLOSSARY.md` MUST amend that entry instead"* is what makes it
+binding. It stays there. The new clause says which quantities are not metrics; it does not restate the
+bar for minting the ones that are (FR-020).
+
+## Delta 1 — Principle II, one bullet becomes two
+
+`.specify/memory/constitution.md:83-84`. **Before:**
+
+```text
+- Derived quantities (throughput, error rate, apdex) MUST NOT become metrics. They are
+  computed by aggregation from metrics that already exist.
+```
+
+**After:**
+
+```text
+- Derived quantities (throughput, error rate) MUST NOT become metrics. They are computed by
+  aggregation from metrics that already exist.
+- Composite quantities MUST NOT become metrics either, for the opposite reason: they reduce to
+  no construct the format has. apdex is the case on the record, and `docs/ideas.md` carries what
+  would have to become true before it could enter.
+```
+
+**Why the reason has to change with the name.** The clause is read by someone deciding whether apdex
+is reachable — `APDEX` is a literal key in the NFR-YAML documents this format replaces, so the
+question gets asked. The old clause told them an aggregation the format has computes it. It does not:
+apdex needs a banded classification carrying a second threshold, and an aggregation weighting the
+bands, and the format has neither. Throughput and an error rate each reduce to one construct that
+exists — `aggregation: rate`, and a `bad` fraction. That is the difference the two bullets carry.
+
+**Mirroring `README.md`'s deletion alone was the alternative and was rejected**: it makes the two
+documents agree by making the higher-authority one silent, and Principle II is the only place the
+constitution says what may not become a metric name.
+
+**The clause states the rule, not the argument** (FR-019). Why apdex reduces to nothing stays in
+`docs/ideas.md`. Copying an argument into the constitution is the mechanism both issues in this
+milestone are made of.
+
+**`docs/ideas.md` is named in a code span, never as a markdown link.** Principle VIII permits the
+first and the isolation gate fails on the second.
+
+## Delta 2 — the parked argument passes its own check
+
+`docs/ideas.md:81`, inside the existing `**apdex**` entry. **Before:**
+
+> And no aggregation the format has — `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate` — takes a
+> weighted sum of counts.
+
+**After** it must list the seventh name and stay true with it there (FR-022, FR-023): `sum` joins the
+enumeration, and the sentence says why `sum` is not the aggregation apdex needs — it adds up the
+values a metric carries, and nothing in the format classifies a request into a band or gives a band a
+weight, so there is no weighted sum of counts for it to take.
+
+**The set is checked, not remembered.** `$defs/aggregation` is a string with an `anyOf` of two
+branches: an enum of seven names — `avg`, `min`, `max`, `count`, `rate`, `sum`, `stddev` — and the
+pattern `^p\d{1,2}(\.\d+)?$`. `sum` was the single omission. It is not a name the repository has
+forgotten: `README.md:150` and `:309` both list it and `README.md:647` carries a `cannot` row for it.
+
+## The one gate this delta can break
+
+`scripts/verify.sh` § *docs/ is isolated* counts ideas with `^\*\*(.+?)\*\*` and conditions with
+`text.count("*Would need*")`, and fails when the two differ. The apdex entry opens at `docs/ideas.md:75`
+and carries its `*Would need*` at `:88`.
+
+**The edit must add no line-initial bold and no second `*Would need*`** (FR-024). Both counts stay at
+**16** — the `26` the gate prints on that line is the number of links it scanned, not the number of
+ideas it found. `bash scripts/verify.sh` and `git rm -r docs && bash scripts/verify.sh` both stay green.
+
+## What a reviewer checks
+
+1. Every quantity the derived clause names has one aggregation, and a reader can say which.
+2. apdex is named, in the composite clause, under a reason that is true of it.
+3. Principle II and `README.md` § *Names* say the same thing about every name they both mention.
+4. The enumeration in `docs/ideas.md` equals the schema's aggregation enum.
+5. `docs/ideas.md` has the same number of entries and conditions as before, and the gate is green.

--- a/specs/010-constitution-catches-up/contracts/principle-vi.md
+++ b/specs/010-constitution-catches-up/contracts/principle-vi.md
@@ -1,0 +1,141 @@
+# Contract: the delta to Principle VI, and to the three files that follow it
+
+**Feature**: `010-constitution-catches-up` | **Issue**: [#83](https://github.com/galax-io/opennfr/issues/83)
+
+The reach tables live in `README.md` § *What any tool can actually run* and **do not change**. The
+schema, the corpus and the gate do not change. This file holds only the delta: one bullet in the
+constitution becomes three, one rationale paragraph is added, one sentence in *Compatibility
+Constraints* stops being false, one parenthetical leaves `AGENTS.md`, and one gate question plus one
+version pointer in the plan template follow.
+
+## What does not change, and why that is the decision
+
+**The one-home decision.** #68 argued it, v0.5.0 shipped it, and #83 says outright it is not
+reopening it. `AGENTS.md`'s rule — *a second target is a second section there, not a second file* —
+survives this milestone word for word. What ends is its status as a declared departure.
+
+**The reach tables.** Not a row, not a reason, not a date. This milestone changes the rule that says
+the tables may live where they live.
+
+**`scripts/verify.sh`.** Its one citation of Principle VI (`:540`) claims that extending the reach
+gate to read the schema would be the format narrowing to one tool. The amended bullet keeps *"MUST
+NOT change the format, the schema"* verbatim, so the citation stays true and the file stays shut.
+
+**`specs/`.** `specs/008-path-denotation/plan.md` keeps its unchecked Principle VI box and its
+Complexity Tracking row. That row is the evidence the departure was disclosed; rewriting it to match
+the new rule would erase the only record that the old one was ever departed from.
+
+## Delta 1 — Principle VI, bullet 2 becomes three bullets
+
+`.specify/memory/constitution.md:143-146`. **Before:**
+
+```text
+- A requirement document MUST NOT name a target: not in a field, a value, a metric name, or an
+  example. It carries no per-target section, override or conditional.
+- The correspondence between the document's vocabulary and a target's own MUST live in that
+  target's description. Adding a target MUST NOT change the format, the schema, or any
+  existing document.
+```
+
+**After:**
+
+```text
+- A requirement document MUST NOT name a target: not in a field, a value, a metric name, or an
+  example. It carries no per-target section, override or conditional.
+- A target's DESCRIPTION is what a renderer reads to turn a requirement document into that
+  target's assertions. The correspondence between the document's vocabulary and a target's own
+  MUST live there, and there MUST be exactly one description per target: a second copy is what
+  drift is made of. A description MAY be a section of an existing document. A gate implementing
+  a description is not a second description — it MAY name the reason a row gives, and MUST NOT
+  carry a second copy of the rows.
+- Adding a target MUST NOT change the format, the schema, or the published corpus, and MUST NOT
+  change any existing document other than the one holding the target descriptions.
+```
+
+**What each clause is for**
+
+| Clause | Satisfies | Why it is in the text |
+|---|---|---|
+| the definition of a description | FR-005 | the rule has to say what it constrains, or it reads as a prohibition on naming a target anywhere — false at four sites ([research.md](../research.md) R1) |
+| *exactly one description per target* | FR-003 | this is the property #68 bought. Separateness was the mechanism; singularity was the point |
+| *MAY be a section of an existing document* | FR-001 | the sentence that stops forbidding what the repository does |
+| the gate carve-out | FR-005 | v0.6.0's FR-023 required `scripts/verify.sh` to keep the sentence giving a row's reason. A rule that forbade it would contradict a decision nine days old |
+| *the published corpus* | FR-002 | replaces *any existing document* with the prohibition still true. `examples/` is named as a thing adding a target may not touch, which the old sentence covered only by accident |
+| *other than the one holding the target descriptions* | FR-001, FR-004 | one exception, named by role and not by path, so a later move to `targets/` needs no second amendment |
+
+**No path is named.** `README.md` does not appear in the amended bullet. `specs/008-path-denotation/plan.md`
+§ *Complexity Tracking* records that `targets/gatling.md` is where descriptions go if a second target
+arrives, and a rule naming today's filename would need amending on a move it does not govern.
+
+## Delta 2 — Principle VI gains its record
+
+Appended to Principle VI after the existing rationale, in the manner Principle III's 3.0.0 paragraph
+already uses (FR-007, FR-008). It MUST state, in the principle itself:
+
+1. **What the old bullet said and why it failed** — v0.5.0 put the Gatling correspondence in
+   `README.md` because #68 found it in two places, drifted, with four issues closed a release earlier
+   live again in the copy on the page most readers meet. One home was the fix. That made adding a
+   second target a change to an existing document, which the bullet forbade in terms.
+2. **That the departure was declared where contributors do not read rules** — inside a feature plan,
+   under a directory `AGENTS.md` reads as history — so the repository shipped two contradicting
+   normative documents for two releases (#83).
+3. **What was actually wrong: the unit.** The separate file bought singularity, not separateness.
+   The bullet now requires the property directly and defines what has to be singular first.
+4. **That nothing checks it.** `scripts/verify.sh` does not read this file, which is why the
+   contradiction stood through two releases, and *"does this sentence state a correspondence"* is not
+   a question a script decides. The bullet is enforced in review or not at all, and the text says so
+   rather than reading as though a gate were watching.
+
+Point 4 is Principle IV applied to this principle: a rule that reads as gated when it is not is a
+document reading as more settled than it is.
+
+## Delta 3 — the Compatibility Constraints sentence stops being false
+
+`.specify/memory/constitution.md:225`, last sentence of the 3.0.0 rationale paragraph. **Before:**
+
+> The third surface, what a target's description may declare, is removed — nothing in this repository
+> describes a target.
+
+**After** it must carry three facts and no fourth: the surface was removed in 3.0.0 **when** nothing
+described a target; one exists now, `README.md` § *What any tool can actually run*, added in v0.5.0;
+and the surface is **not** restored, because a reach row would then need an argued issue and a
+`GLOSSARY.md` entry recording a rejected alternative — and `GLOSSARY.md` is the vocabulary document,
+where a rejected table row does not belong. Four reach rows changed in v0.6.0 through the ordinary
+issue and milestone rules, and nothing about that went wrong (FR-009, FR-010).
+
+**The list of compatibility-sensitive surfaces does not change.** Two items in, two items out. Under
+the document's versioning policy, restoring the third would be a separate limb; it is recorded here
+as the rejected alternative so a later reversal is a decision and not a rediscovery.
+
+## Delta 4 — `AGENTS.md` loses the parenthetical
+
+`AGENTS.md:35`. The sentence keeps its rule and loses its footing (FR-012).
+
+**Before:** `… a second target is a second section there, not a second file (argued in
+`specs/008-path-denotation/plan.md` § Complexity Tracking, against constitution Principle VI).`
+
+**After:** `… a second target is a second section there, not a second file.`
+
+Nothing replaces it. A citation of the constitution would be the third copy of a rule that already
+has a home, and the `specs/` pointer is what `AGENTS.md` itself reads as history.
+
+## Delta 5 — the plan template follows
+
+`.specify/templates/plan-template.md` (FR-013). Two edits, one of them easy to miss:
+
+| Line | Before | After |
+|---|---|---|
+| `:44` | ``See `.specify/memory/constitution.md` (v3.0.0).`` | ``… (v4.0.0).`` |
+| `:61-63` | *"Does adding a target change the format, the schema, or an existing document?"* | asks about the format, the schema, the published corpus, and any existing document **other than the one holding the target descriptions**, and adds: is there still exactly one description per target? |
+
+The version pointer is in scope because a gate that cites a superseded version is the same defect
+this milestone is fixing, one file over.
+
+## What a reviewer checks
+
+1. Principle VI names no file path.
+2. The amended bullet is true of the repository as it stands — `README.md:478` and
+   `scripts/verify.sh:566` are permitted by it, and a second reach table anywhere is not.
+3. `AGENTS.md` § *Architecture* and Principle VI can be read back to back with no third file.
+4. The template's Principle VI question and the principle agree on what adding a target may change.
+5. The compatibility list still has two items.

--- a/specs/010-constitution-catches-up/data-model.md
+++ b/specs/010-constitution-catches-up/data-model.md
@@ -1,0 +1,69 @@
+# Data Model — The Constitution Catches Up
+
+**Feature**: `010-constitution-catches-up` | **Date**: 2026-08-30
+
+There is no data. This feature adds no field, no value and no term, and changes nothing a renderer
+reads. What it has instead is a set of **normative statements**, each with one home and a status, and
+the milestone is a change to four of them and to the two files that quote them. This document is the
+inventory: where each statement lives, what it says now, and what it says after.
+
+## The statements this milestone touches
+
+| # | Statement | Home | Now | After |
+|---|---|---|---|---|
+| S1 | what adding a target may change | `.specify/memory/constitution.md:144-146` | *"…or any existing document"* — false of the repository since v0.5.0 | the format, the schema and the corpus stay out of reach; **one** existing document is reachable, named by role |
+| S2 | what a target's description *is* | nowhere | undefined, though three clauses already constrain one | defined in Principle VI: what a renderer reads to turn a document into that target's assertions |
+| S3 | whether this repository describes a target | `.specify/memory/constitution.md:225` | *"nothing in this repository describes a target"* — false since v0.5.0 | one exists, `README.md` § *What any tool can actually run*; the surface stays off the compatibility list, and why is recorded |
+| S4 | which quantities may not become metrics | `.specify/memory/constitution.md:83-84` | three names under one reason, false of the third | two names under the reason true of them; a second clause for composite quantities, naming apdex |
+| S5 | where a second target goes | `AGENTS.md:35` | the rule, plus a parenthetical declaring it a departure | the rule alone |
+| S6 | the Principle VI gate a plan answers | `.specify/templates/plan-template.md:61-63` | quotes S1's withdrawn wording | quotes S1 as amended, and asks after S2's singularity |
+| S7 | which aggregations the format has | `docs/ideas.md:81` | six names and the percentile pattern | seven names and the pattern, with the seventh's disposition stated |
+
+S1–S4 are the constitution. S5–S7 are what follows it. Nothing else in the repository changes.
+
+## Where each statement is allowed to be repeated
+
+The amendment turns a *structural* containment into a *counted* one, so the count is the model.
+
+| Statement | Copies permitted | Copies today | Enforced by |
+|---|---|---|---|
+| a target's description | exactly one per target | one — `README.md` § *What any tool can actually run*; `specs/004-strip-to-schema/contracts/gatling-reach.md` is a redirect that says it carries no rule | review. No script reads for this |
+| the reason a description's row gives | the description, plus the gate implementing it | two, by v0.6.0's FR-023, which required it | review |
+| a survey fact naming a tool | unbounded — not a description | `README.md:49`, `:56`, `:478`, `:759`, `docs/ideas.md:130` | nothing; the rule does not reach them |
+| the rule about what may not become a metric | the constitution states it; `README.md` § *Names* restates the author-facing half | two, agreeing | review, and #75 is what happens when they stop agreeing |
+| the argument for why apdex is not a metric | `docs/ideas.md`, once | one | Principle VIII's entry/condition count |
+
+The middle row is the one Phase 0 changed. A rule forbidding every second statement of a target fact
+would have made the gate's comments, and the survey sentence at `README.md:478`, violations of a MUST
+in the constitution ([research.md](./research.md) R1).
+
+## Two classes of quantity, and the aggregation set they are decided against
+
+S4 splits one class into two. The split is not new vocabulary — `docs/ideas.md:84-86` already draws it
+— it is the constitution catching up to a distinction the repository was already making.
+
+| Class | Reduces to | Example | Why it is not a metric |
+|---|---|---|---|
+| **derived** | one construct the format has | throughput → `aggregation: rate`; error rate → a `bad` fraction | an aggregation already computes it, so a metric would be a second spelling |
+| **composite** | nothing the format has | apdex | it needs a banded classification carrying a second threshold and an aggregation weighting the bands, and there are neither |
+
+The set it is decided against, from `$defs/aggregation` — an `anyOf` of an enum and a pattern:
+
+```text
+avg  min  max  count  rate  sum  stddev        ^p\d{1,2}(\.\d+)?$
+```
+
+Seven names. `docs/ideas.md:81` lists six of them, which is S7's defect. `sum` adds up the values a
+metric carries; nothing in the format classifies a request into a band or gives a band a weight, so
+no weighted sum of counts is available to any of the seven.
+
+## The invariant
+
+**Every normative statement has one home, and the home is where a reader looking for the rule goes
+first.** Both issues in this milestone are that invariant broken the same way: a statement was
+corrected where readers meet it and left standing where authority sits. The amendment does not add
+machinery for it — nothing here reads `.specify/memory/constitution.md`, and that is stated in the
+principle rather than implied away.
+
+What the milestone leaves behind is one countable property a reviewer can check without judgment:
+**one description per target**, and a gate that points at it rather than restating it.

--- a/specs/010-constitution-catches-up/plan.md
+++ b/specs/010-constitution-catches-up/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: The Constitution Catches Up
+
+**Branch**: `010-constitution-catches-up` | **Date**: 2026-08-30 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/010-constitution-catches-up/spec.md`
+
+**This plan is for an amendment PR.** Under the constitution's own governance it must say so where a
+reviewer meets it, and must show what breaks without it. Nothing breaks in the running sense —
+nothing here runs. What breaks is that the repository keeps shipping two normative documents that
+contradict each other, and keeps a MUST in the governing file whose stated reason is false.
+
+## Summary
+
+Milestone **v0.7.0**, two issues, one sentence under both: *a correction reached the document readers
+meet and not the document that wins.*
+
+- **#83**: v0.5.0 made `README.md` the sole home of the Gatling correspondence and wrote that rule
+  into `AGENTS.md`. Principle VI says adding a target must not change any existing document. The
+  reconciliation is in `specs/008-path-denotation/plan.md`, under a directory `AGENTS.md` reads as
+  history. Two normative documents, contradicting, for two releases.
+- **#75**: #64 removed apdex from `README.md`'s derived-quantities sentence because the stated reason
+  is false of apdex. Principle II still carries all three names under that reason, and the deferral
+  that recorded this — `specs/007-reach-table-rules` FR-015 — closed with its milestone.
+
+**The work is four files.** `.specify/memory/constitution.md` (one bullet becomes three, one becomes
+two, one rationale paragraph, one false sentence, one version), `AGENTS.md` (a parenthetical leaves),
+`.specify/templates/plan-template.md` (two gate questions and a version pointer), `docs/ideas.md`
+(one word joins an enumeration, and a clause makes the sentence survive it).
+
+**Nothing the format owns moves.** The schema, `examples/`, `scripts/`, `GLOSSARY.md` and `README.md`
+are untouched, and so is every file under `specs/` except this feature's own.
+
+The plan's two load-bearing decisions:
+
+- **The amendment replaces a structural containment with a counted one, and defines what is counted.**
+  A target's description is what a renderer reads; there is exactly one per target; a gate
+  implementing one is not a second one. This is narrower than the spec's first draft, which Phase 0
+  found false of the repository at four sites.
+- **Principle II moves apdex rather than dropping it.** A composite clause with a reason true of the
+  class, and the argument stays in `docs/ideas.md` where the repository keeps arguments.
+
+## Technical Context
+
+**Language/Version**: none. This feature touches no schema, no code and no gate. Four markdown files
+and one template.
+
+**Primary Dependencies**: none added. `bash scripts/verify.sh` still needs `python3` with `pyyaml` and
+`jsonschema`, unchanged.
+
+**Storage**: N/A — files in a git repository.
+
+**Testing**: `bash scripts/verify.sh` proves only that nothing broke; no section of it reads any file
+this milestone edits except `docs/ideas.md`, and there only for the entry/condition count and the
+isolation scan. The real validation is reading, and [quickstart.md](quickstart.md) is the procedure
+for it — eight checks, each repeatable by a second person who does not know what the author intended.
+
+**Target Platform**: N/A.
+
+**Project Type**: a format specification. This particular feature is governance: the documents that
+say what may be done to the format.
+
+**Performance Goals**: N/A.
+
+**Constraints**: the amendment must be **true of the repository as it stands**. A MUST that the
+repository already violates is #83 recreated by the commit that fixes #83, and Phase 0 caught exactly
+that in the spec's first FR-005 ([research.md](research.md) R1). Every clause the amendment adds was
+checked against every site that could violate it before it was written.
+
+**Scale/Scope**: 4 files changed outside `specs/`, 0 added, 0 examples edited, 0 schema rules touched,
+0 terms added. Two issues, one pull request, three commits — the spec, then #83, then #75.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against **v3.0.0**, the version in force. This feature is the amendment that produces
+v4.0.0; it is checked against the rules it is changing, which is the only order that can catch an
+amendment doing more than it says.
+
+- [x] **I. Vocabulary Before Features** — no term is added or renamed, so `GLOSSARY.md` does not
+      change. The one word that looks like a candidate is *composite*: it classifies a quantity the
+      format does not carry — not a field, a value, or a name a document may hold — and Principle I's
+      trigger is a term reaching an example, a schema or an implementation, none of which the
+      constitution is. `docs/ideas.md:86` already uses it of apdex, in the sentence this milestone
+      corrects. Recorded as FR-026 rather than left for a reviewer to wonder about. Both changes were
+      argued in issues before files moved: #83 and #75.
+- [x] **II. Borrow Names, Never Invent Them** — **engaged: this feature amends it.** No metric or
+      attribute name is added, renamed or aliased, and no name becomes permissible that was not.
+      apdex moves between two clauses of the same principle; what changes is the reason given, from
+      one that is false of it to one that is true. The bar for minting a name stays in `GLOSSARY.md`
+      § *metric* where v0.6.0 put it, and FR-020 forbids the new clause being written as though it
+      had replaced it.
+- [x] **III. No Silent Green** — this feature adds no check, deletes no check, and deletes no check's
+      input. It adds a **rule** that no gate enforces, which is the risk this principle governs from
+      the other side: FR-005 requires the amended bullet to say so in its own text, so the principle
+      cannot read as though something were watching. *Recorded, not fixed*: the constitution is itself
+      an artifact nothing validates and does not say so, which is this principle's third clause
+      unmet — by the repository, before this milestone and after it. It is why both defects survived
+      two releases. It is not one of this milestone's two issues, so it is owed an issue rather than
+      folded in; see *Out of Scope* in the spec and the row below.
+- [x] **IV. Honest Status** — **opened as failing, closed by Phase 0.** The spec's first FR-005 stated
+      a MUST that four sites in this repository violate, two of them deliberately, including one
+      v0.6.0 explicitly required. [research.md](research.md) R1 enumerated every target mention
+      outside the reach section and the requirement was rewritten. R1 also found that `README.md:478`
+      violates the **unamended** Principle VI, and says so rather than quietly relying on the new
+      definition to absorb it. No claim about an external tool is added anywhere in this milestone, so
+      nothing here needs a source date beyond the commit everything was read at, `1e394f1`.
+- [x] **V. Structure Over Grammar** — no field, no value set, no schema change, no string parsed.
+- [x] **VI. The Requirement Is Target-Blind** — **satisfied, and this is the point.** No requirement
+      document names a target; `examples/` is untouched. No target is added, so the clause being
+      amended is not engaged by the change itself. This is the gate `specs/008-path-denotation/plan.md`
+      could not tick — it left VI as its only unchecked box and declared a departure — and this
+      feature can tick it because it takes the route the constitution offers instead of the one 008
+      had to improvise. The departure ends here rather than being renewed.
+- [x] **VII** — *withdrawn in 3.0.0. No gate.*
+- [x] **VIII. Ideas Are Parked, Not Merged** — `docs/ideas.md` is edited, and the isolation gate is
+      checked rather than assumed. The edit is inside the existing `**apdex**` entry at `:75`, adds
+      no line-initial bold and no second `*Would need*`, so the entry and condition counts stay equal
+      at 16 (FR-024). Nothing outside `docs/` gains a link into it: the constitution names the path in
+      a code span, which Principle VIII permits in terms, and `specs/` is the gate's only exemption
+      anyway. `git rm -r docs && bash scripts/verify.sh` stays green.
+- [x] **Compatibility** — no borrowed OpenTelemetry name is touched, and no field name appearing in a
+      published example. No construct is added, so the surveyed-target floor is not engaged. The list
+      of compatibility-sensitive surfaces is unchanged at two items (FR-010); restoring the third,
+      *what a target's description may declare*, was considered and is recorded as the rejected
+      alternative rather than left undiscussed.
+
+**Post-Phase-1 re-check**: unchanged. Phase 1 produced two contracts, a data model and a quickstart,
+and added no obligation the gates above did not already cover. The one gate that moved during the
+feature is IV, and it moved from failing to passing in Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-constitution-catches-up/
+├── spec.md               # what and why, with the two answered decisions
+├── plan.md               # this file
+├── research.md           # Phase 0 — seven questions; R1 rewrote a requirement
+├── data-model.md         # Phase 1 — the seven statements, their homes and their copy counts
+├── quickstart.md         # Phase 1 — eight checks, all of them reading
+├── contracts/
+│   ├── principle-vi.md   # the delta for #83: five edits across three files
+│   └── principle-ii.md   # the delta for #75: two edits across two files
+├── checklists/
+│   └── requirements.md   # spec quality, 16/16
+└── tasks.md              # Phase 2 — /speckit-tasks, not created here
+```
+
+### Repository (what this feature edits)
+
+```text
+.specify/memory/constitution.md      # Principle II :83, Principle VI :143, Compatibility :225, version
+.specify/templates/plan-template.md  # :44 version pointer, :49 II gate, :61 VI gate
+AGENTS.md                            # :35 — the parenthetical leaves
+docs/ideas.md                        # :81 — sum joins the enumeration
+
+# untouched, and checked to be untouched (quickstart step 1)
+schema/  examples/  scripts/  GLOSSARY.md  README.md  specs/008-path-denotation/
+```
+
+**Structure Decision**: none to make. There is no source tree; the artifacts this feature changes are
+the four files above, and the contracts name every line.
+
+## Complexity Tracking
+
+> No Constitution Check gate fails. The rows below are the two costs this amendment takes on
+> knowingly, recorded here because the alternative to recording them is #83 again.
+
+| Trade | Why accepted | Alternative rejected because |
+|---|---|---|
+| **Structural containment becomes counted containment, and nothing enforces the count.** Before v0.5.0 a target description could not leak into the format's description, because it was a different file. After the amendment the guarantee is "exactly one description per target", checked by a reviewer | The separateness was the mechanism; **singularity** was the property, and it is the one #68's drift actually broke — two copies of the tables disagreeing, with four issues live again in one of them. The amendment requires the property directly instead of the mechanism that used to imply it | Restoring a separate `targets/gatling.md` would honour the old wording and reverse a decision argued in #68 and shipped in v0.5.0, which #83 says outright it is not asking for. Writing a gate for it would need a script that decides *"is this sentence a target description"*, which nothing can; a gate that cannot decide its question is the silent green Principle III forbids. So the rule says it is unenforced, which is Principle IV rather than a workaround |
+| **This milestone edits an artifact nothing validates, and does not fix that.** Principle III's third clause — *any artifact nothing validates MUST say so in its own text* — is unmet by `.specify/memory/constitution.md` itself, and that is why both defects here survived two releases | It is not one of the milestone's two issues, and `AGENTS.md` is explicit that work outside them does not ride along. It also needs its own argument: what a check on this file could decide is a real question, and answering it inside an amendment PR would be the smuggling the governance clause exists to stop | Adding one sentence now would be cheap and would close the clause, and was rejected because the honest version of the fix is not a sentence — it is deciding whether a gate is possible. FR-005 does the narrow version where it belongs: the one rule this milestone adds says in its own text that nothing checks it |

--- a/specs/010-constitution-catches-up/quickstart.md
+++ b/specs/010-constitution-catches-up/quickstart.md
@@ -1,0 +1,203 @@
+# Quickstart — validating The Constitution Catches Up
+
+**Feature**: `010-constitution-catches-up` | **Date**: 2026-08-30
+
+This milestone changes no behaviour, so `bash scripts/verify.sh` proves only that nothing broke. The
+work is validated by **reading**, and every check below is a comparison a second person can repeat
+without knowing what the author intended. Where a step's expected output is a judgment, the step says
+what would fail it.
+
+## Prerequisites
+
+```bash
+bash scripts/verify.sh
+```
+
+Green before you start. If it is not, the failure predates this milestone.
+
+---
+
+## 1. Nothing the format owns moved
+
+The strongest claim this milestone makes is a negative one.
+
+```bash
+git diff --stat main...HEAD -- schema/ examples/ scripts/ GLOSSARY.md README.md specs/008-path-denotation/
+```
+
+**Expect**: empty. Six paths, no output. A single line here means a requirement was violated — the
+schema and corpus by FR-027, `GLOSSARY.md` by FR-025, `README.md` by FR-021, `specs/` by FR-016.
+
+```bash
+git diff --stat main...HEAD
+```
+
+**Expect**: exactly four files outside `specs/010-constitution-catches-up/` —
+`.specify/memory/constitution.md`, `.specify/templates/plan-template.md`, `AGENTS.md`,
+`docs/ideas.md`. That is SC-008.
+
+---
+
+## 2. The two documents stop contradicting each other (#83, SC-001)
+
+Read these two, in this order, and nothing else:
+
+```bash
+sed -n '/^## Architecture/,/^## Test Model/p' AGENTS.md
+sed -n '/^### VI\./,/^### VII/p' .specify/memory/constitution.md
+```
+
+**Expect**: `AGENTS.md` states that a second target is a second section in `README.md`, with **no
+parenthetical**. Principle VI permits exactly that.
+
+**What fails it**: a reader having to open a third file to reconcile them; `AGENTS.md` still citing
+`specs/008-path-denotation/plan.md`; the principle naming `README.md`.
+
+Then the negative check — the rule must still bite:
+
+```bash
+grep -n "targets/gatling.md\|README.md" .specify/memory/constitution.md | sed -n '/VI/p'
+```
+
+**Expect**: no path inside Principle VI (FR-004). The exception is named by role.
+
+---
+
+## 3. The amended rule is true of the repository as it stands (SC-002)
+
+This is the check Phase 0 added, and the one most likely to be skipped. The rule must permit what the
+repository already does and refuse what it should.
+
+**Permitted, and must stay permitted:**
+
+```bash
+sed -n '477,479p' README.md      # k6's name tag, Gatling's request name, JMeter's sampler label
+sed -n '564,567p' scripts/verify.sh   # "no Gatling scope denotes the requests a path encloses"
+```
+
+Neither is a description a renderer reads. If the amended bullet forbids either, it ships a violated
+MUST and must be rewritten — this is [research.md](./research.md) R1 and FR-005.
+
+**Refused, and must stay refused:** a second table of what Gatling can assert, anywhere. Confirm
+there is still exactly one:
+
+```bash
+grep -rln "Gatling" --include=*.md . | grep -v '^./specs/' | grep -v '^./.claude/'
+head -4 specs/004-strip-to-schema/contracts/gatling-reach.md
+```
+
+**Expect**: `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/ideas.md` — of which only `README.md`
+carries rows; and the `gatling-reach.md` redirect still saying in its own text that it carries no rule.
+
+---
+
+## 4. Principle II names two classes, and each reason is true of its class (#75, SC-003)
+
+```bash
+sed -n '/^### II\./,/^### III/p' .specify/memory/constitution.md
+sed -n '423,426p' README.md
+```
+
+**Expect**: the derived clause names throughput and error rate. For each, name the aggregation:
+`rate` and a `bad` fraction. apdex appears in the composite clause, under *reduces to no construct
+the format has*.
+
+**What fails it**: apdex still in the derived list; a composite clause that restates why apdex needs
+two constructs (that argument belongs to `docs/ideas.md` — FR-019); a clause written as though it
+were the only thing refusing `loadtest.apdex` (FR-020).
+
+Cross-check the two documents agree on every name they both mention:
+
+```bash
+grep -o "throughput\|error rate\|apdex" README.md | sort | uniq -c
+grep -n "throughput\|error rate\|apdex" .specify/memory/constitution.md
+```
+
+**Expect**: no name asserted in one and denied in the other.
+
+---
+
+## 5. The parked argument passes its own check (SC-004)
+
+```bash
+python3 -c "import json; d=json.load(open('schema/opennfr.io/v1/requirementset.schema.json')); print(d['\$defs']['aggregation']['anyOf'])"
+sed -n '80,83p' docs/ideas.md
+```
+
+**Expect**: the enum's seven names all present in the prose, plus `p*` for the pattern, and a clause
+saying why `sum` is not the aggregation apdex needs.
+
+The gate check that this edit could break:
+
+```bash
+bash scripts/verify.sh 2>&1 | grep "docs/ is isolated" -A1
+git rm -r --cached -q docs && bash scripts/verify.sh >/dev/null 2>&1; echo "exit=$?"; git reset -q
+```
+
+**Expect**: `ok  docs/ is markdown-only, every idea states its condition…`, and the ideas/conditions
+counts unchanged at **16 and 16** — the `26` in the gate's own line is how many links it scanned, not
+how many ideas it found. If the edit added a line-initial `**bold**`, the counts diverge and the
+section fails (FR-024).
+
+```bash
+python3 -c "import re,io; t=io.open('docs/ideas.md',encoding='utf-8').read(); print(len(re.findall(r'^\*\*(.+?)\*\*',t,re.M)), t.count('*Would need*'))"
+```
+
+---
+
+## 6. The gate a plan is held to matches the rule it cites (SC-005)
+
+```bash
+sed -n '41,45p'  .specify/templates/plan-template.md
+sed -n '/VI. The Requirement Is Target-Blind/,+4p' .specify/templates/plan-template.md
+```
+
+**Expect**: the version pointer names v4.0.0 (FR-014), and the Principle VI question asks about the
+format, the schema, the corpus, and any existing document *other than the one holding the target
+descriptions* — plus whether there is still exactly one per target. Read it against Principle VI and
+the two must agree without a third file.
+
+Also check the Principle II gate names both classes (FR-015):
+
+```bash
+sed -n '/II. Borrow Names/,+4p' .specify/templates/plan-template.md
+```
+
+---
+
+## 7. The version and its record (SC-006)
+
+```bash
+tail -3 .specify/memory/constitution.md
+sed -n '1,40p' .specify/memory/constitution.md
+```
+
+**Expect**: `**Version**: 4.0.0`, **Last Amended** on the landing date, and a Sync Impact Report that
+names Principle VI (MAJOR — *redefined in a way that permits what it previously forbade*), Principle II
+(MINOR — *materially expanded*), states why each previous wording failed, and lists the templates
+reviewed. VII is still the only withdrawn number.
+
+---
+
+## 8. The milestone's own linkage (SC-009)
+
+```bash
+bash scripts/verify.sh
+bash scripts/check-linkage.sh 2>/dev/null || echo "(run in CI)"
+gh pr view --json milestone,body --jq '{milestone: .milestone.title, first_para: (.body | split("\n\n")[0])}'
+```
+
+**Expect**: green; milestone **v0.7.0**; `Closes #83` and `Closes #75` both present; and a first
+paragraph that says the PR amends the constitution and what breaks without it (FR-030). Three commits,
+#83's before #75's, each green on its own:
+
+```bash
+git log --oneline main..HEAD
+```
+
+To check each commit is green on its own, check it out in a scratch worktree rather than moving this
+one — `AGENTS.md` forbids the shared stash stack for exactly this:
+
+```bash
+git worktree add /tmp/onfr-green <sha> && (cd /tmp/onfr-green && bash scripts/verify.sh)
+```

--- a/specs/010-constitution-catches-up/research.md
+++ b/specs/010-constitution-catches-up/research.md
@@ -1,0 +1,186 @@
+# Phase 0 — Research: The Constitution Catches Up
+
+**Feature**: `010-constitution-catches-up` | **Date**: 2026-08-30 | **Spec**: [spec.md](spec.md)
+
+Seven questions. One of them changed a functional requirement: the containment rule the spec wrote
+into Principle VI is **false of this repository today**, and shipping it would have put a violated
+MUST into the document whose entire claim is that it wins — which is #83, recreated by the commit
+that fixes #83. R1 is that finding and its resolution. The rest are verification: exact text, exact
+line, exact count, so the plan edits a sentence it has read rather than one it remembers.
+
+Everything below was read at `1e394f1` on 2026-08-30. Nothing here is a claim about an external
+tool, so nothing here needs a source date beyond that one.
+
+---
+
+## R1 — Is "a fact about a target MUST NOT be stated outside a target's description" true today?
+
+**Question**: spec FR-005 replaces Principle VI's structural containment — a separate file cannot
+leak, because it is a separate file — with a rule about where target facts may appear. Before the
+amendment carries that rule, is the repository already obeying it?
+
+**Answer**: **No.** Under the rule as the spec first worded it, four sites violate it, and at least
+two of them are load-bearing and were kept deliberately.
+
+Every mention of the target outside `README.md` § *What any tool can actually run*, excluding
+`specs/` (history) and `.claude/`:
+
+| Site | What it says | Under the rule as first worded |
+|---|---|---|
+| `README.md:49`, `:56` | gatling-picatinny's `assertionFromYaml` is tool-internal; Gatling Enterprise has a results transport | violation — facts about the target |
+| `README.md:478` | *"`loadtest.request.name` — k6's `name` tag, Gatling's request name, JMeter's sampler label — is the honest fallback"* | violation, and under the **unamended** principle too: it is literally a correspondence between the format's vocabulary and three targets' own |
+| `README.md:759`, `docs/ideas.md:130` | k6 signals a failed request with a metric, JMeter with a boolean column, Gatling with KO | violation — facts about the target |
+| `scripts/verify.sh:566`, `:655` | *"no Gatling scope denotes the requests a path encloses"*; *"Gatling spells that forAll(), which takes no path"* | violation — and v0.6.0's FR-023 **required** the first of these to stay |
+| `CONTRIBUTING.md:48`, `AGENTS.md:31`/`:39` | the target is Gatling; the gate checks the tables | not a capability claim; survives any wording |
+
+The two that matter are `README.md:478` and the gate's comments. The first is the argument for the
+field existing at all — every load generator records a request name, and three are named as evidence.
+Striking the names would remove the evidence for a debt `README.md` deliberately records. The second
+is the executable form of the tables; v0.6.0 settled it in terms — *"MUST lose its `(#52)` pointer
+and keep the sentence that gives the reason. It MUST NOT gain a copy of the row"* — so a rule that
+forbids the gate from naming a reason contradicts a decision this repository took nine days ago.
+
+**Resolution**: the rule is not about *facts*, it is about **descriptions**, and the amendment has to
+say what one is. A target's description is what a renderer reads to turn a document into that
+target's assertions. With that definition the clause is true today and stays checkable:
+
+- `README.md` § *What any tool can actually run* is a description — a renderer reads the rows. There
+  is exactly one, and `specs/004-strip-to-schema/contracts/gatling-reach.md` is a redirect that says
+  in its own text that it carries no rule. The one-home property holds.
+- `README.md:478` is not a description. A renderer reads nothing from it; it is why the field exists.
+- `scripts/verify.sh` is not a description either — it is the one implementation of one, and
+  `README.md:559` already says so: *"implements these tables and is the only implementation, and
+  nothing else restates them."*
+- `README.md:759` and `docs/ideas.md:130` are arguments about constructs the format does not have.
+
+**What changed in the spec**: FR-005 was rewritten. It now requires the amended principle to define
+a target description before it constrains one, to require exactly one per target, and to say that a
+gate implementing a description is not a second description — it may name the reason a row gives and
+may not carry a second copy of the rows. That last clause is v0.6.0's FR-023 promoted from a
+one-release decision to the rule it was already following.
+
+**Alternatives considered**: (a) keep the broad wording and clean up the four sites — rejected,
+because it deletes the evidence at `README.md:478` and reverses v0.6.0's FR-023, neither of which is
+in this milestone and both of which would need their own argument. (b) drop the containment rule
+entirely and let Principle VI keep only the one-home clause — rejected, because the structural
+guarantee the amendment removes is the whole reason #68's drift was possible, and replacing it with
+nothing is what the amendment is being watched for.
+
+---
+
+## R2 — How many statements of the Gatling correspondence exist, and is "exactly one" true?
+
+**Question**: FR-003 requires the amended principle to demand exactly one description per target.
+Is that satisfied at `1e394f1`, or does the amendment ship a rule the repository already breaks?
+
+**Answer**: **Satisfied.** One description: `README.md` § *What any tool can actually run* § *Gatling*
+(`README.md:551` onwards). `README.md:559` states the singularity itself. The former second copy,
+`specs/004-strip-to-schema/contracts/gatling-reach.md`, was reduced to a redirect on 2026-08-25 and
+says so in its first line: *"This file is a redirect and carries no rule."* `AGENTS.md:31` records
+that this one file under `specs/` is not history for that reason.
+
+The gate is the one implementation and is carved out by R1's definition rather than by exception.
+
+---
+
+## R3 — Which documents still in force cite the wording being amended?
+
+**Question**: an amendment that leaves a citation pointing at deleted text is the defect this
+milestone exists to remove, one file over. The constitution's own 3.0.0 report says that had already
+happened three times.
+
+**Answer**: **two in force, two history.**
+
+| Site | Cites | Disposition |
+|---|---|---|
+| `.specify/templates/plan-template.md:62` | *"Does adding a target change the format, the schema, or an existing document?"* | **in force** — follows the amendment (FR-013) |
+| `AGENTS.md:35` | the departure, *"against constitution Principle VI"* | **in force** — loses the parenthetical (FR-012) |
+| `specs/008-path-denotation/plan.md:233` and its Constitution Check | the unchecked VI box and the Complexity Tracking row | **history** — untouched (FR-014) |
+| `specs/003-assertion-first-format/spec.md:117`, `:271` | the old wording, twice | **history** — untouched (FR-014) |
+
+Nothing under `.github/` cites a principle. `scripts/verify.sh:540` cites Principle VI for a claim
+the amendment preserves — that narrowing the format to one tool is forbidden — and needs no edit,
+because the amended bullet keeps *"MUST NOT change the format, the schema"* verbatim.
+
+---
+
+## R4 — Which version limb, and what number?
+
+**Question**: the document's own policy decides this, and getting it wrong is the kind of error that
+is invisible until someone cites a version.
+
+**Answer**: **4.0.0**, MAJOR, and the Sync Impact Report names two limbs.
+
+- Principle VI is *"redefined in a way that permits what it previously forbade"* — MAJOR by name.
+- Principle II's composite clause is *"existing guidance is materially expanded"* — MINOR.
+- *"Where one amendment carries material at more than one limb, the highest limb governs and the
+  document takes one version number."*
+
+No principle is removed, so no number is withdrawn and VII stays the only withdrawn number.
+`3.0.0 → 4.0.0`, and **Last Amended** takes the landing date.
+
+---
+
+## R5 — Can the `docs/ideas.md` edit break the isolation gate?
+
+**Question**: Principle VIII's gate counts ideas against conditions, and an edit that changes either
+count fails the section.
+
+**Answer**: **No, provided no line-initial bold is added.** `scripts/verify.sh` counts entries with
+`re.findall(r"^\*\*(.+?)\*\*", text, re.M)` and conditions with `text.count("*Would need*")`, then
+fails when the two differ. The apdex entry begins `**apdex**` at `docs/ideas.md:75` and carries its
+`*Would need*` at `:88`. FR-021's edit is inside the sentence at `:81`, adds no line-initial bold and
+no second `*Would need*`, so both counts are unchanged at 16 and 16 (counted at `1e394f1`; the
+`26` the gate prints on that line is its link count, not its entry count).
+
+`specs/` is exempt from the isolation scan and is *"the ONLY exemption"* per the gate's own comment,
+so this feature's own artifacts may name `docs/ideas.md`. They name it in code spans anyway, matching
+the habit of every prior spec here.
+
+---
+
+## R6 — What exactly does the format's aggregation set contain?
+
+**Question**: FR-020 requires the enumeration in the apdex entry to match the schema. A fix that
+guesses the set repeats the defect it is fixing.
+
+**Answer**: `$defs/aggregation` is a string constrained by `anyOf` of two branches — an enum of
+**seven** names, `avg`, `min`, `max`, `count`, `rate`, `sum`, `stddev`, and the percentile pattern
+`^p\d{1,2}(\.\d+)?$`.
+
+`docs/ideas.md:81` lists `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate` — the pattern and six
+of the seven. `sum` is the single omission. `README.md:150` and `:309` both list it, and
+`README.md:647` carries a `cannot` row for it, so it is not a name the repository has forgotten.
+
+The conclusion the enumeration supports survives `sum`: it sums the values a metric carries, and the
+format has no construct that classifies requests into bands and none that gives a band a weight, so
+there is nothing for a weighted sum of counts to be taken over.
+
+---
+
+## R7 — Is `AGENTS.md` § *Architecture* the only copy of that sentence?
+
+**Question**: #83 is a duplicated-and-drifted sentence. Before editing one copy, count them.
+
+**Answer**: **No — there is a fourth copy, two revisions stale, and it is out of scope.**
+`.copier-answers.yml:6` carries an `architecture:` answer reading *"The schema decides; `README.md`
+explains it and is the only document that describes a field."* That is the **pre-v0.5.0** wording: it
+never gained *"or states what a target can assert"* and never gained the second-target sentence, so it
+never carried the departure #83 is about and does not become false by amending it. Its `structure:`
+answer is stale in a second way — it predates the `gatling-reach.md` redirect sentence in
+`AGENTS.md:31`.
+
+It is a generator answer file, not a document a reader follows, and correcting it is not one of this
+milestone's two issues. Under `AGENTS.md` — *"Work that is not one of the milestone's issues does not
+ride along: it gets its own issue"* — it is recorded in the plan's *Out of Scope* and owed an issue.
+
+---
+
+## What Phase 0 changed
+
+| Finding | Verified how | Where it landed |
+|---|---|---|
+| FR-005's containment rule is false of the repository at four sites, two of them deliberate | enumerated every target mention outside the reach section; read v0.6.0's FR-023 and `README.md:478` in full | **FR-005 rewritten**: the rule is about descriptions, the amendment must define one, and the gate is carved out by the definition rather than by exception |
+| `README.md:478` violates the **unamended** Principle VI as well — it is a vocabulary correspondence outside a target's description | read the principle's second bullet against the line | recorded here; not fixed, because the definition R1 adopts resolves it and the alternative deletes a recorded debt's evidence |
+| A fourth copy of the architecture sentence exists in `.copier-answers.yml`, two revisions behind | read the file | *Out of Scope*, owed its own issue |
+| Two in-force citations of the amended wording, not one | swept every file outside `.git` for the sentence and for principle citations | FR-012 and FR-013 confirmed as the complete set |

--- a/specs/010-constitution-catches-up/spec.md
+++ b/specs/010-constitution-catches-up/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: The Constitution Catches Up
+
+**Feature Branch**: `010-constitution-catches-up`
+
+**Created**: 2026-08-30
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/opennfr/milestone/9" — milestone **v0.7.0**, two open issues: #83 and #75. A third, #84, is closed as *not planned* and is not in scope.
+
+**Scope note**: This milestone touches no format. Nothing in `schema/`, `examples/` or `scripts/` changes, no term is added or renamed, and `GLOSSARY.md` does not move. What changes is `.specify/memory/constitution.md`, and the three files that quote it or that it contradicts: `AGENTS.md`, `.specify/templates/plan-template.md` and `docs/ideas.md`.
+
+Both issues are the same failure seen twice. A correction was argued, agreed and shipped into the documents a reader meets — `README.md` for #75, `AGENTS.md` for #83 — and did not reach the one document that says it wins wherever the two disagree. The repository therefore ships two normative statements about the same thing, with the false one in the higher-authority file, twice. It comes first in the release order because every milestone after it writes another target fact into the document Principle VI forbids changing.
+
+## Decisions
+
+### Session 2026-08-30
+
+- **Q**: The constitution's governance clause offers two routes when another document conflicts with it — fix the other document, or amend the principle. #83 is the conflict. Which route? → **A**: **Amend Principle VI.** #83 says outright that it is not an argument that the one-home decision was wrong: #68 was argued, `README.md` has carried the Gatling section since `6d3a882`, and consolidating the tables is what the repository chose and shipped. Fixing `AGENTS.md` back to a separate target file would undo a decision on the strength of a rule the decision showed to be wrong. The other route is the one the amendment procedure exists for.
+- **Q**: What does the amended clause say instead of *"Adding a target MUST NOT change the format, the schema, or any existing document"*? → **A**: It keeps every prohibition still true — not the format, not the schema, not the published corpus — and permits exactly one exception: the document that holds the target descriptions. **One**, not one-or-more. The property #68 bought was not "target facts live in a separate file"; it was "target facts live in exactly one place", and the drift it fixed was two copies of the tables disagreeing. Written that way the rule keeps its bite and stops forbidding what the repository does.
+- **Q**: Does the amended clause name `README.md`? → **A**: **No.** #83's own Complexity Tracking row records that if a second target ever arrives, `targets/gatling.md` is where both go. A rule that hardcodes today's filename has to be amended again on a move that changes nothing it governs; a rule that says *the one document that holds the target descriptions* survives it. The constitution names files elsewhere, so this is a departure from its own habit and is made deliberately, for that reason.
+- **Q**: The old sentence was a structural containment — a separate file cannot leak into the format's description because it is a different file. One home inside `README.md` loses that. What replaces it? → **A**: **A definition, and a singularity on top of it.** A target's description is *what a renderer reads to turn a document into that target's assertions*; there is exactly one per target, and a gate implementing a description is not a second one. The first draft of this decision was broader — *no fact about a target is stated outside a target's description* — and Phase 0 found it false of the repository at four sites, two of them kept on purpose: `README.md:478` names three tools' request-name spellings as the argument for why `loadtest.request.name` exists at all, and v0.6.0's FR-023 **required** `scripts/verify.sh` to keep the sentence giving a row's reason. See [research.md](./research.md) R1. The narrowed rule is what v0.6.0 was already enforcing: its FR-013 stripped *"no scope carries a wildcard path part"* out of the `loadtest.group.name` field description — a reach claim in a field description — while leaving the survey sentences alone.
+- **Q**: Principle II lists apdex among derived quantities *"computed by aggregation from metrics that already exist"*. #64 removed it from `README.md` because that reason is false of apdex. Does the constitution mirror the deletion, or delete and replace with a true reason? → **A**: **Delete and replace.** apdex leaves the derived list, and the clause gains a second limb for the class it actually belongs to: a **composite** quantity reduces to no construct the format has, and does not become a metric either. Mirroring the deletion alone was the alternative and was rejected: it makes the two documents agree by making the higher-authority one silent, and Principle II is the only place the constitution says what may not become a metric name.
+- **Q**: Does the new limb restate the apdex argument? → **A**: **No.** It states the rule and the reason true of the class, and names apdex as the case on the record. Why apdex specifically reduces to nothing — that it needs a banded classification carrying a second threshold and an aggregation weighting the bands, and the format has neither — stays in `docs/ideas.md`, which is where this repository argues about constructs it does not have. A rule has one home and its argument has another; copying the argument into the constitution is the mechanism that produced both issues in this milestone.
+- **Q**: What was already stopping `loadtest.apdex` before this limb existed? → **A**: `GLOSSARY.md` § *metric* carries the bar v0.6.0 set — *"a name is minted only where something outside this repository already records the quantity under one"* — made binding by the Development Workflow's *"A PR that contradicts a decision recorded in `GLOSSARY.md` MUST amend that entry instead"*; the reach tables' Metrics axis refuses `any other` name; `docs/ideas.md` parks apdex with the two constructs it would need. The new limb is therefore not the only thing holding the line, which is why it can be one sentence rather than a policy.
+- **Q**: `docs/ideas.md` argues the apdex case from a closed enumeration — *"no aggregation the format has — `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate` — takes a weighted sum of counts"* — and the schema's enum carries `sum`. Fix which way? → **A**: **Add `sum` and make the sentence survive it.** The conclusion holds: `sum` sums the values a metric carries, and nothing in the format classifies requests into bands or gives a band a weight, so there is no weighted sum of counts for it to take. The defect is that the argument was checkable and failed its check, in the one document the repository keeps for arguing about constructs the format does not have.
+- **Q**: The Compatibility Constraints paragraph says *"The third surface, what a target's description may declare, is removed — nothing in this repository describes a target."* `README.md` § *What any tool can actually run* describes one. Is that in scope? → **A**: **Yes** — it is the same statement made false by the same change, in the file being amended, and leaving it means knowingly shipping a false sentence in the document whose whole claim is that it wins. **Correct the sentence, and do not restore the surface.** Bringing back *"what a target's description may declare"* as compatibility-sensitive would make every edit to a reach row require an argued issue and a *Rejected* entry in `GLOSSARY.md` — and `GLOSSARY.md` is the vocabulary document, where a rejected table row does not belong. v0.6.0 changed four reach rows through ordinary issues, and nothing about that went wrong. The rejected alternative is recorded so a later reversal is a decision rather than a rediscovery.
+
+### What the amendment says
+
+> A target's description is what a renderer reads to turn a document into that target's assertions. It is permitted to exist, and permitted to be a section of an existing document, provided there is exactly one per target — and a gate implementing one is not a second one.
+
+Everything else Principle VI says is unchanged: a requirement document still names no target, adding a target still changes neither the format nor the schema nor the corpus, and the vantage-point and derivation clauses stand as written.
+
+Principle II's correction is one clause and reads alongside it:
+
+> A **derived** quantity is not a metric: an aggregation over metrics that already exist computes it. A **composite** quantity is not a metric either, for the opposite reason: it reduces to no construct the format has.
+
+apdex moves from the first sentence, where the reason is false of it, to the second, where it is true.
+
+### What Phase 0 changed
+
+One requirement. FR-005 first read *a fact about a target MUST NOT be stated outside a target's description*, and [research.md](./research.md) R1 enumerated every target mention in the repository and found the rule false at four sites — two of which are load-bearing and one of which v0.6.0 explicitly required. Shipping it would have put a violated MUST into the document whose whole claim is that it wins, which is #83 recreated by the commit that fixes #83.
+
+The rule is now about **descriptions** rather than facts, and the amendment has to define one before it constrains one. R1 also found that `README.md:478` violates the **unamended** Principle VI — it states a correspondence between the format's vocabulary and three targets' own, outside any target description. The definition resolves it; the alternative was to delete the sentence, which removes the evidence for a debt `README.md` records on purpose.
+
+## User Scenarios & Testing *(mandatory)*
+
+The reader throughout is a contributor deciding what they are allowed to do, and — for the last story — the reviewer holding them to it. Both currently get contradictory answers depending on which file they open.
+
+### User Story 1 - Two normative documents stop contradicting each other (#83, Priority: P1)
+
+A contributor wants to add a second target. `AGENTS.md` § *Architecture* tells them a second target is a second section in `README.md`. `.specify/memory/constitution.md` Principle VI tells them adding a target must not change any existing document — and, in Governance, that where the two disagree the constitution wins and `AGENTS.md` is wrong and must be fixed. The reconciliation exists, in `specs/008-path-denotation/plan.md` § *Complexity Tracking*, under a directory `AGENTS.md` itself says is read as history.
+
+There is no reading of the shipped documents under which the contributor is right.
+
+After this story Principle VI permits what the repository does and forbids what it should: adding a target may change the one document that holds target descriptions, and nothing else. `AGENTS.md` states the rule without declaring a departure, and stops citing a plan for authority it no longer needs.
+
+**Why this priority**: it is the conflict the milestone exists for, and the one every later milestone widens — each release that writes a reach row into `README.md` is another act the unamended principle forbids.
+
+**Independent Test**: read `AGENTS.md` § *Architecture* and Principle VI back to back. Neither states something the other prohibits, and neither needs a third file to be reconciled.
+
+**Acceptance Scenarios**:
+
+1. **Given** the amended Principle VI, **When** a contributor asks whether adding a second target may change an existing document, **Then** the answer is yes for exactly one document and no for every other, and the answer is in the principle rather than in a plan.
+2. **Given** `AGENTS.md` § *Architecture*, **When** a reader looks for what makes its rule legitimate, **Then** it is legitimate under the constitution as shipped, and the sentence carries no parenthetical pointing into `specs/`.
+3. **Given** the amended principle, **When** a reader asks where a target's reach tables may live, **Then** the text names no path, and a later move to `targets/gatling.md` would satisfy it without another amendment.
+4. **Given** a contributor writing a second table of what Gatling can assert into `README.md` § *Every field*, **When** they check Principle VI, **Then** it refuses — there is one description per target — while the survey sentence at `README.md:478` and the gate's own comments stay permitted, because neither is a description a renderer reads.
+
+---
+
+### User Story 2 - Principle II stops giving a false reason (#75, Priority: P2)
+
+Someone with an NFR-YAML document in hand — where `APDEX` is a literal key — reads Principle II to find out whether apdex is reachable. It tells them apdex is a derived quantity *"computed by aggregation from metrics that already exist"*. It is not: apdex needs a banded classification carrying a second threshold and an aggregation that weights the bands, and the format has neither. `README.md` was corrected by #64 a release ago; the constitution was not, and it is the document that wins.
+
+After this story every quantity the derived clause names has an aggregation a reader can point to, and apdex is named one clause down, under the reason that is true of it.
+
+**Why this priority**: second because it misleads rather than blocks — no contributor is currently unable to act on it, they are only told something false on the way. It rides the same amendment and the same version bump, so it costs nothing extra to fix here and would need its own amendment later.
+
+**Independent Test**: name the aggregation that computes each quantity the clause lists. Every one has one, and apdex is not among them.
+
+**Acceptance Scenarios**:
+
+1. **Given** the amended Principle II, **When** a reader asks which aggregation computes each derived quantity it names, **Then** each has exactly one — `rate` for throughput, a `bad` fraction for error rate — and apdex is not among them.
+2. **Given** the amended Principle II, **When** a reader asks why apdex is not a metric, **Then** the answer is in the principle, is true of apdex, and is a different reason from the one given for throughput.
+3. **Given** the amended Principle II and `README.md` § *Names*, **When** the two are read side by side, **Then** they say the same thing about every name they both mention, and neither asserts what the other denies.
+4. **Given** a contributor proposing `loadtest.apdex` as a metric name, **When** they look for what refuses it, **Then** Principle II does, and so do `GLOSSARY.md` § *metric* and the reach tables' Metrics axis, which refused it before this clause existed.
+
+---
+
+### User Story 3 - The parked argument passes its own check (#75 part 2, Priority: P3)
+
+`docs/ideas.md` argues that apdex cannot be written today from a closed enumeration of what the format has: `p*`, `max`, `min`, `avg`, `stddev`, `count`, `rate`. The schema's aggregation enum carries `sum`, `README.md`'s predicate table lists it, and a reach row refuses it by name — so `sum` is not a name the repository has forgotten, it is a name this one sentence omits.
+
+The conclusion is right and the argument is checkable and fails. In the one document the repository keeps for arguing about constructs it does not have, that is the wrong thing to be wrong about.
+
+**Why this priority**: third because nothing downstream depends on it — it is an argument, not a rule. It is fixed here because it is the second half of #75 and because an enumeration that a reader can check against the schema in ten seconds should survive being checked.
+
+**Independent Test**: compare the enumeration against the schema's `$defs/aggregation` enum. The two agree, and the sentence they support is still true.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected entry, **When** a reader lists the aggregations the format has against the schema, **Then** the enumeration is complete.
+2. **Given** `sum` in the list, **When** a reader asks why it does not take a weighted sum of counts, **Then** the entry answers: it sums the values a metric carries, and nothing in the format classifies requests into bands or weights one.
+3. **Given** the edited file, **When** the isolation gate counts ideas against `*Would need*` lines, **Then** the counts are equal, because no entry was added.
+
+---
+
+### User Story 4 - The gate a plan is held to matches the rule it cites (#83, Priority: P4)
+
+`.specify/templates/plan-template.md` asks, at the Principle VI gate: *"Does adding a target change the format, the schema, or an existing document?"* That is the sentence being amended. Left as it is, the next plan is gated on wording that no longer exists in the file the template points at, and a plan that satisfies the constitution fails the template — or, worse, passes it by answering a question nobody can locate.
+
+**Why this priority**: last because it follows mechanically from Story 1 and has no argument of its own. It is in scope because the constitution's own amendment convention reviews the templates, and because a stale gate is how a repaired rule gets re-broken by the next feature that runs the check.
+
+**Independent Test**: read the template's Principle VI question against the amended principle. The two agree on what adding a target may change.
+
+**Acceptance Scenarios**:
+
+1. **Given** the amended constitution, **When** the template's Principle VI gate is read, **Then** its question quotes the current wording and not the withdrawn one.
+2. **Given** a plan answering that gate, **When** a reviewer checks the answer against the constitution, **Then** no third document is needed to decide whether it passes.
+
+---
+
+### Edge Cases
+
+- **A reach row is edited.** Does the amended clause make every change to a target description a governed event? It must not: the rule governs *adding a target*, and editing a published row is ordinary work under the existing issue and milestone rules.
+- **A format-level statement sits near a target one.** `README.md` § *Names* records a gap the format has — a duration for a span an author bracketed — beside metric names a target can and cannot assert. The rule must not push format-level claims into a target's section. v0.6.0 drew this line deliberately (its FR-015 and FR-016 against FR-017), and the amendment must not blur it.
+- **A survey sentence names a tool.** `README.md:478` says `loadtest.request.name` is what k6, Gatling and JMeter each call a request, which is the argument for the field existing. It is not a description — a renderer reads nothing from it — and the rule must leave it standing, or the amendment deletes the evidence for a debt `README.md` deliberately records.
+- **The gate restates a reason.** `scripts/verify.sh:566` gives the reason a `cannot` row gives. v0.6.0's FR-023 required exactly that. The rule must permit it and must still forbid a second copy of the rows.
+- **The one document becomes two.** If `targets/gatling.md` is ever created while `README.md` keeps a Gatling section, the rule is violated by the state of the repository rather than by a change to it. The text must make that a violation and not a gap.
+- **A rule nothing checks.** No script reads `.specify/memory/constitution.md`; this defect stood through two releases for exactly that reason. The amendment adds no gate — the milestone touches no script — so the containment rule ships unenforced, and must not read as though something enforced it.
+- **A withdrawn number.** Neither principle is removed, so no number is withdrawn and none is reused.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**#83 — the constitution permits the one home it already has**
+
+- **FR-001**: Principle VI's second bullet MUST stop forbidding what the repository does. The sentence *"Adding a target MUST NOT change the format, the schema, or any existing document"* MUST be replaced by wording under which adding a target may change exactly one existing document — the one that holds the target descriptions — and no other.
+- **FR-002**: The replacement MUST keep every prohibition still true of the repository: adding a target MUST NOT change the format, MUST NOT change the schema, and MUST NOT change the published corpus in `examples/`.
+- **FR-003**: The replacement MUST require that there be exactly **one** such document. That singularity is the property #68 bought — two copies of the tables drifted, and four issues closed a release earlier were live again in one of them — and it is the whole of what the departure traded for.
+- **FR-004**: The replacement MUST NOT name a file path. `targets/gatling.md` is where the descriptions go if a second target arrives, recorded in `specs/008-path-denotation/plan.md` § *Complexity Tracking*, and a rule naming today's filename would need amending again on a move it does not govern.
+- **FR-005**: Principle VI MUST carry the containment rule that replaces the structural one it loses, and MUST define its subject before constraining it. A target's **description** is what a renderer reads to turn a document into that target's assertions; there MUST be exactly one per target; and a gate implementing a description is **not** a second description — it may name the reason a row gives and MUST NOT carry a second copy of the rows. The rule MUST NOT be written as a prohibition on stating any fact about a target, which is false of this repository at four sites ([research.md](./research.md) R1), and the text MUST make clear that no gate checks it.
+- **FR-006**: Principle VI's first bullet MUST stand unchanged, and the amended second bullet MUST NOT be readable as licensing a per-target section in a *requirement* document. A reader MUST be able to tell the two kinds of document apart from the principle's own text.
+- **FR-007**: Principle VI MUST record what changed and why the previous wording failed, in the principle itself, in the manner Principle III's 3.0.0 paragraph and Principle VI's own rationale already use. A reader MUST NOT have to open `specs/` to learn that the rule moved.
+- **FR-008**: The Sync Impact Report at the head of `.specify/memory/constitution.md` MUST be rewritten for this amendment: which principles are altered, why each current wording fails, the version limb each hits, and the templates reviewed.
+- **FR-009**: The Compatibility Constraints rationale sentence *"nothing in this repository describes a target"* MUST stop being false. It MUST record that the third surface was removed when nothing described a target, and that a description now exists.
+- **FR-010**: The list of compatibility-sensitive surfaces MUST NOT change. Restoring *"what a target's description may declare"* is the rejected alternative and MUST be recorded as one: it would put an argued issue and a `GLOSSARY.md` *Rejected* entry behind every edit to a reach row, and `GLOSSARY.md` is the vocabulary document — a rejected table row does not belong in it. v0.6.0 edited four reach rows through ordinary issues without incident.
+- **FR-011**: The document's version MUST become **4.0.0** and **Last Amended** MUST become the date the amendment lands. Principle VI hits the MAJOR limb — *"redefined in a way that permits what it previously forbade"* — and Principle II's new clause hits MINOR — *"existing guidance is materially expanded"*. The policy's *"the highest limb governs"* settles it at MAJOR, and the Sync Impact Report MUST name both limbs rather than only the one that wins.
+- **FR-012**: `AGENTS.md` § *Architecture* MUST lose the parenthetical *"(argued in `specs/008-path-denotation/plan.md` § Complexity Tracking, against constitution Principle VI)"*. The rule the sentence states is unchanged; what ends is its status as a declared departure and its citation of a plan the same file reads as history.
+- **FR-013**: `.specify/templates/plan-template.md`'s Principle VI gate MUST ask a question the amended principle answers. Its current second clause — *"Does adding a target change the format, the schema, or an existing document?"* — MUST follow the wording it quotes, and MUST also ask whether there is still exactly one description per target.
+- **FR-014**: The same file's version pointer — *"See `.specify/memory/constitution.md` (v3.0.0)"* at `:44` — MUST name the version this milestone ships. A gate citing a superseded version is the defect this milestone is fixing, one file over.
+- **FR-015**: The same file's Principle II gate asks whether there are *"derived quantities masquerading as metrics"*. It MUST cover composite ones too, so the gate and the amended principle name the same two classes.
+- **FR-016**: No file under `specs/` may change. `specs/008-path-denotation/plan.md` keeps its unchecked Principle VI box and its Complexity Tracking row: that is the record of what was true when it was written, and rewriting it would erase the evidence that the departure was disclosed.
+
+**#75 — Principle II stops carrying the false reason**
+
+- **FR-017**: Principle II's derived-quantities clause MUST name only quantities the stated reason is true of. `apdex` leaves the parenthetical, and that sentence becomes what `README.md` has carried since #64.
+- **FR-018**: Principle II MUST gain a second clause for **composite** quantities, with a reason that is true of them: they reduce to no construct the format has, and they do not become metrics either. apdex MUST be named there, so the correction moves it rather than dropping it.
+- **FR-019**: The new clause MUST state the rule and not restate the argument. Why apdex reduces to nothing — the banded classification carrying a second threshold, and the aggregation weighting the bands — stays in `docs/ideas.md`. A rule and its argument have different homes, and copying one into the other is the mechanism both issues in this milestone are made of.
+- **FR-020**: The clause MUST NOT be written as the only thing refusing `loadtest.apdex`. `GLOSSARY.md` § *metric*, the reach tables' `any other` Metrics row and the parking in `docs/ideas.md` already do, and the text MUST NOT imply that they stopped mattering.
+- **FR-021**: `README.md` MUST NOT change. Its sentence is the correct one and is what Principle II's first clause is being brought to. It gains no counterpart to the composite clause: `README.md` § *Names* tells an author what they may write, and a class of quantity the format cannot express is not something an author can write — it is refused by the reach tables and parked under `docs/`, which § *What is not in the format yet* already points at. The two documents agree on every name they both mention, which is what #75 asks for.
+- **FR-022**: `docs/ideas.md`'s apdex entry MUST enumerate the aggregations the format has. `sum` MUST join `p*`, `max`, `min`, `avg`, `stddev`, `count` and `rate`, matching the schema's `$defs/aggregation` enum exactly.
+- **FR-023**: The sentence MUST stay true with `sum` present: it MUST state why `sum` does not take a weighted sum of counts — it sums the values a metric carries, and no construct in the format classifies requests into bands or gives a band a weight.
+- **FR-024**: No entry may be added to `docs/ideas.md`. The isolation gate counts line-initial bold entries against `*Would need*` lines and fails when they differ, and this fix edits prose inside an entry that already has both.
+
+**Across the milestone**
+
+- **FR-025**: No term is added, renamed or redefined, so `GLOSSARY.md` MUST NOT change. `.specify/memory/constitution.md` is not a compatibility-sensitive surface, and none is touched.
+- **FR-026**: The word *composite* in FR-018 owes no glossary entry. Principle I requires a term to reach `GLOSSARY.md` before it reaches an example, a schema or an implementation; the constitution is none of the three, and `docs/ideas.md` already uses the word of apdex in the sentence this milestone corrects. It classifies a quantity the format does not carry — it is not a field, a value or a name a document may contain.
+- **FR-027**: Nothing in `schema/`, `examples/` or `scripts/` may change. `scripts/verify.sh`'s one citation of Principle VI — that extending the reach gate to read the schema would be the format narrowing to one tool — stays true, because the amended bullet keeps *"MUST NOT change the format, the schema"*.
+- **FR-028**: `bash scripts/verify.sh` MUST exit green at every commit, and every document in `examples/` MUST keep both its validity and its verdict.
+- **FR-029**: The milestone lands as one pull request carrying milestone **v0.7.0**: the spec commit first, then one commit per issue, with `Closes #83` and `Closes #75`. #83 comes first, as the milestone's own description orders it.
+- **FR-030**: The pull request's first paragraph MUST state that it amends the constitution and MUST show what breaks without the amendment. The governance disclosure rule bites on amendments travelling with other work; this one travels with none, and the disclosure is made anyway because an amendment a reviewer finds by reading a diff is smuggled however small the diff is.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader who opens `AGENTS.md` § *Architecture* and Principle VI finds no statement in either that the other forbids, and needs no third file to reconcile them.
+- **SC-002**: No document still in force declares a departure from a principle still in force. The one that did is under `specs/`, is unchanged, and is read as history.
+- **SC-003**: Every quantity Principle II's derived clause names has exactly one aggregation that computes it, and a reader can name which. apdex is not among them; it is named in the composite clause, under a reason that is true of it. Principle II and `README.md` § *Names* say the same thing about every name they both mention.
+- **SC-004**: The aggregation enumeration in `docs/ideas.md`'s apdex entry equals the schema's `$defs/aggregation` enum — seven names — plus the percentile pattern, and the conclusion it supports holds with the seventh name present.
+- **SC-005**: The Principle VI gate in `.specify/templates/plan-template.md` and the principle it gates agree, word for word, on what adding a target may change.
+- **SC-006**: The constitution's version is **4.0.0**, and its Sync Impact Report names both altered principles, why each previous wording failed, and the limb each hits — MAJOR for VI, MINOR for II — with the highest governing.
+- **SC-007**: `bash scripts/verify.sh` exits green at every commit of the pull request, and the milestone's diff over `schema/`, `examples/`, `scripts/`, `GLOSSARY.md`, `README.md` and `specs/008-path-denotation/` is empty.
+- **SC-008**: Four files change and no others: `.specify/memory/constitution.md`, `AGENTS.md`, `.specify/templates/plan-template.md` and `docs/ideas.md` — plus this feature's own directory under `specs/`.
+- **SC-009**: Both issues are closed by the commits that land their fixes, and the pull request carries milestone **v0.7.0** before it merges.
+
+## Assumptions
+
+- **The one-home decision stands.** #68 was argued and shipped; #83 states it is not reopening it. The amendment is written to legitimise that decision, not to re-litigate it.
+- **`AGENTS.md`'s rule is right and only its footing is wrong.** The sentence *"a second target is a second section there, not a second file"* survives the milestone. What is removed is its parenthetical, because after the amendment the rule needs no plan to stand on.
+- **`specs/` is history.** `AGENTS.md` says so and the isolation gate exempts it. No spec artifact is corrected to match the new rule, including the one that declared the departure.
+- **No gate is added.** The milestone description says nothing here touches the schema, the gate or the corpus. The containment rule in FR-005 therefore ships as text a reviewer applies, and says so — writing a check for "does this sentence state a fact about a target" is not something a script decides.
+- **`GLOSSARY.md` § *metric* is binding.** The mint bar set in v0.6.0 lives there, and the Development Workflow's *"a PR that contradicts a decision recorded in `GLOSSARY.md` MUST amend that entry instead"* is what makes a glossary decision a rule rather than a note. FR-020 rests on this.
+- **The constitution may say more than `README.md` without drifting from it.** After this milestone Principle II carries a composite clause `README.md` has no counterpart to. That is not the #75 defect repeated: #75 was a false sentence in the higher-authority document, not an absent one in the lower. The constitution states the naming rules; `README.md` § *Names* tells an author what they may write. FR-021 records the reasoning so the next audit finds a decision rather than a gap.
+- **The version limb is MAJOR.** Principle VI is redefined to permit what it forbade; Principle II's new clause is a MINOR expansion. *"The highest limb governs"* settles it, and both are disclosed.
+- **Two commits, one per issue**, as `AGENTS.md` requires — the spec commit precedes both and is not folded into either.
+
+## Out of Scope
+
+- **A check on the constitution.** Nothing in `scripts/verify.sh` reads `.specify/memory/constitution.md`, which is why both defects survived two releases. Principle III says an artifact nothing validates must say so in its own text, and the constitution does not. That is a third defect of the same family, it needs its own issue and its own argument about what such a check could decide, and it does not ride here: the milestone touches no script.
+- **#84.** Closed as *not planned*. Its subject — success criteria of `v0.5.0` that contradict a functional requirement in the same file — is a spec artifact under `specs/`, which this milestone does not touch by FR-016.
+- **The mint bar's home.** Whether v0.6.0's *"a name is minted only where something outside this repository already records the quantity under one"* ought to be a constitutional clause rather than a `GLOSSARY.md` line is a real question and is not this milestone's. The composite clause added by FR-018 states which quantities may not become metrics; it does not restate the bar for minting the ones that may. Those are different rules with different homes, and moving the second is its own argument.
+- **A composite clause in `README.md`.** Not added, for the reason FR-021 records. If a later audit finds an author who needed it there, that is an issue about `README.md` § *Names* and not an amendment.
+- **Restating the Gatling correspondence anywhere.** The reach tables stay where they are, unedited. This milestone changes the rule that says they may be there; it does not touch a row.

--- a/specs/010-constitution-catches-up/tasks.md
+++ b/specs/010-constitution-catches-up/tasks.md
@@ -1,0 +1,220 @@
+---
+
+description: "Tasks for 010-constitution-catches-up"
+---
+
+# Tasks: The Constitution Catches Up
+
+**Input**: Design documents from `specs/010-constitution-catches-up/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: none. This milestone adds no check and changes no behaviour; nothing here is testable by a
+script, and pretending otherwise would be the silent green Principle III forbids. Validation is the
+eight reading checks in [quickstart.md](quickstart.md), and every checkpoint below names the ones it
+satisfies.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different file, no dependency on an unfinished task
+- **[Story]**: which user story the task serves (US1–US4)
+- Every task names the file it touches, and most name the line
+
+## Path Conventions
+
+No source tree. Four files outside `specs/`:
+
+```text
+.specify/memory/constitution.md      # Principle II :83, Principle VI :143, Compatibility :225, version footer
+.specify/templates/plan-template.md  # :44 version pointer, :49 II gate, :61 VI gate
+AGENTS.md                            # :35
+docs/ideas.md                        # :81
+```
+
+---
+
+## Phases are commits, and two of them carry two stories each
+
+Three repository rules shape this list:
+
+- **1 issue = 1 commit**, each green on `bash scripts/verify.sh` on its own. There are two issues, so
+  there are two issue commits, and a phase is a commit. US1 and US4 are both #83; US2 and US3 are
+  both #75.
+- **#83 first**, as the milestone's own description orders it — *"It comes first because every
+  milestone after it writes another target fact into the document Principle VI forbids."*
+- **Spec-first**: `specs/010-constitution-catches-up/` lands in its own `docs(speckit)` commit before
+  either fix.
+
+### Where the version bump and the Sync Impact Report go
+
+Both issues edit `.specify/memory/constitution.md`, and the version and its report describe the
+amendment as a whole. Split as follows, so the document is **internally coherent at every commit**:
+
+| Commit | Version | Sync Impact Report |
+|---|---|---|
+| #83 | `3.0.0 → 4.0.0` | written, covering the Principle VI limb (MAJOR) |
+| #75 | stays `4.0.0` | **extended** with the Principle II limb (MINOR) |
+
+This is the versioning policy read literally: *"Where one amendment carries material at more than one
+limb, the highest limb governs and the document takes one version number."* One amendment, one
+number, landing in two commits. The alternative — holding the bump until #75 — leaves the #83 commit
+with an amended Principle VI under a version footer saying 3.0.0, which is a document reading as
+other than it is.
+
+---
+
+## Phase 1: Setup (baselines)
+
+**Purpose**: write down the before-state. Three of the quickstart's checks are comparisons, and a
+comparison without a "before" cannot fail.
+
+- [X] T001 [P] Record the branch-point gate output as the baseline in the PR description: `24 embedded examples valid, 58 closures still reject`; `10 predicates assertable by Gatling, 10 selection probes still rejected, 5 still rendered, 10 predicate probes still rejected, 14 still rendered`. Both MUST be byte-identical at every later checkpoint — this milestone touches neither the schema nor the corpus
+- [X] T002 [P] Record `docs/ideas.md`'s entry and condition counts — **16 and 16** — with `python3 -c "import re,io; t=io.open('docs/ideas.md',encoding='utf-8').read(); print(len(re.findall(r'^\*\*(.+?)\*\*',t,re.M)), t.count('*Would need*'))"`. The `26` the gate prints on the isolation line is its link count and is not this number
+- [X] T003 [P] Confirm #83 and #75 are both assigned to milestone **v0.7.0**: `gh issue list --repo galax-io/opennfr --milestone v0.7.0 --state open`
+- [X] T004 [P] Confirm the two permitted-and-must-stay-permitted sites still read as [research.md](research.md) R1 recorded them — `sed -n '477,479p' README.md` and `sed -n '564,567p' scripts/verify.sh`. If either has moved, the amended bullet must be re-checked against it before it is written
+
+**Checkpoint**: quickstart checks 1, 3 and 5 can now discriminate.
+
+---
+
+## Phase 2: Foundational (blocking prerequisite)
+
+**Purpose**: the spec-first rule. `AGENTS.md` requires the `specs/NNN-*/` artifacts to land in their
+own commit **before** any `fix`, never folded into one.
+
+**⚠️ CRITICAL**: no issue commit may be made until T005 is done.
+
+- [X] T005 Commit `specs/010-constitution-catches-up/` as `docs(speckit): add 010-constitution-catches-up spec/plan/tasks` — spec, plan, research, data-model, quickstart, both contracts, the checklist and this file, with no repository-root file in the same commit
+
+**Checkpoint**: the argument is reviewable before anything it argues for is written.
+
+---
+
+## Phase 3: #83 — the constitution permits the one home it already has (US1 P1 + US4 P4) 🎯 MVP
+
+**Goal**: Principle VI stops forbidding what the repository does, defines what it constrains, and the
+two files that quote it follow. After this phase `AGENTS.md` § *Architecture* and Principle VI can be
+read back to back with no third file.
+
+**Independent test**: quickstart checks 2, 3, 6 and 7. A reader who has never seen this milestone
+should find no statement in either document that the other prohibits, and should be able to answer
+"may adding a second target change an existing document?" from the principle alone.
+
+**Contract**: [contracts/principle-vi.md](contracts/principle-vi.md) carries the before/after text for
+every edit below.
+
+- [X] T006 [US1] Replace Principle VI's second bullet at `.specify/memory/constitution.md:143-146` with the three bullets in [contracts/principle-vi.md](contracts/principle-vi.md) § *Delta 1*: the definition of a target description, *exactly one per target*, *MAY be a section of an existing document*, the gate carve-out, and the prohibitions that survive — the format, the schema, the published corpus, and every existing document other than the one holding the target descriptions (FR-001, FR-002, FR-003, FR-005)
+- [X] T007 [US1] Verify the new bullet names **no file path** and that Principle VI's first bullet is untouched, so a reader can still tell a requirement document from the document that describes the format (FR-004, FR-006). `grep -n "README.md\|targets/" ` over the principle must return nothing
+- [X] T008 [US1] Check the new bullet against the four sites [research.md](research.md) R1 enumerated. `README.md:478` and `scripts/verify.sh:566` MUST be permitted by it; a second table of what Gatling can assert MUST NOT be. If either fails, the wording is wrong — not the repository (FR-005)
+- [X] T009 [US1] Append Principle VI's amendment record to `.specify/memory/constitution.md`, after the principle's existing rationale, per [contracts/principle-vi.md](contracts/principle-vi.md) § *Delta 2*: what the old bullet said and why it failed, that the departure was declared where contributors do not read rules, that the unit was wrong rather than the rule, and that **nothing checks this** (FR-007)
+- [X] T010 [US1] Rewrite the last sentence of the Compatibility Constraints rationale at `.specify/memory/constitution.md:225`. It MUST say the third surface was removed in 3.0.0 *when* nothing described a target, that one exists now — `README.md` § *What any tool can actually run* — and that the surface is not restored, with the reason (FR-009)
+- [X] T011 [US1] Confirm the bulleted list under `.specify/memory/constitution.md` § *Compatibility Constraints* still has exactly two items. Restoring the third is the recorded rejected alternative, not a silent addition (FR-010)
+- [X] T012 [US1] Set `**Version**: 4.0.0` and `**Last Amended**` to today's date in `.specify/memory/constitution.md`'s footer, and rewrite the Sync Impact Report in the HTML comment at the head of that file for the **Principle VI limb only** — MAJOR, *redefined in a way that permits what it previously forbade*, why the previous wording failed, and the templates reviewed. VII stays the only withdrawn number (FR-008, FR-011)
+- [X] T013 [P] [US1] Delete the parenthetical from `AGENTS.md:35`. The sentence keeps its rule; nothing replaces the citation (FR-012)
+- [X] T014 [P] [US4] Rewrite the Principle VI gate at `.specify/templates/plan-template.md:61-63` to ask about the format, the schema, the published corpus, and any existing document **other than the one holding the target descriptions**, and to ask whether there is still exactly one description per target (FR-013)
+- [X] T015 [P] [US4] Update the version pointer at `.specify/templates/plan-template.md:44` from `(v3.0.0)` to `(v4.0.0)` (FR-014)
+- [X] T016 [US1] Run `bash scripts/verify.sh`. The two baselines from T001 MUST be byte-identical, and the link check MUST stay green — the amendment names paths in code spans, never as markdown links
+- [X] T017 [US1] Commit as `fix(governance): the rule permits the one home it already has (#83)` with a `Closes #83` line. The commit MUST NOT touch `docs/ideas.md`, `README.md`, `GLOSSARY.md`, `schema/`, `examples/`, `scripts/`, or anything under `specs/`
+
+**Checkpoint**: #83 is closed, the document is a coherent 4.0.0 describing one amended principle, and
+`specs/008-path-denotation/plan.md`'s declared departure is now a historical record of a rule that has
+been changed rather than a live exception.
+
+---
+
+## Phase 4: #75 — Principle II stops carrying the false reason (US2 P2 + US3 P3)
+
+**Goal**: every quantity Principle II's derived clause names has an aggregation a reader can point to,
+apdex is named one clause down under a reason true of it, and the parked argument in `docs/ideas.md`
+passes its own check.
+
+**Independent test**: quickstart checks 4 and 5. Name the aggregation for each quantity in the derived
+clause; compare the enumeration in `docs/ideas.md` against the schema's `$defs/aggregation`.
+
+**Contract**: [contracts/principle-ii.md](contracts/principle-ii.md).
+
+- [X] T018 [US2] Split `.specify/memory/constitution.md:83-84` into two bullets per [contracts/principle-ii.md](contracts/principle-ii.md) § *Delta 1*: derived quantities keep throughput and error rate under the reason true of them, and a second bullet carries composite quantities — *they reduce to no construct the format has* — naming apdex (FR-017, FR-018)
+- [X] T019 [US2] Verify the composite bullet states the **rule** and not the argument. Why apdex needs a banded classification and a weighting aggregation stays in `docs/ideas.md`; the bullet points there in a **code span**, never as a markdown link (FR-019)
+- [X] T020 [US2] Verify the bullet is not written as the only thing refusing `loadtest.apdex`. `GLOSSARY.md` § *metric*, the reach tables' `any other` Metrics row and the parking in `docs/ideas.md` already do, and none of them stopped mattering (FR-020)
+- [X] T021 [US2] Confirm `README.md` is unchanged and that the two documents now agree on every name they both mention. `README.md` gains no counterpart to the composite bullet — § *Names* tells an author what they may write (FR-021)
+- [X] T022 [US2] Extend `.specify/memory/constitution.md`'s Sync Impact Report with the Principle II limb — MINOR, *existing guidance is materially expanded* — beside the MAJOR limb T012 wrote. The version stays **4.0.0**: one amendment, two limbs, highest governs (FR-011)
+- [X] T023 [P] [US2] Add composite quantities to the Principle II gate at `.specify/templates/plan-template.md:49-52`, so the gate and the amended principle name the same two classes (FR-015)
+- [X] T024 [P] [US3] Add `sum` to the aggregation enumeration at `docs/ideas.md:81`, and extend the sentence so it stays true with the seventh name present: `sum` adds up the values a metric carries, and nothing in the format classifies a request into a band or gives a band a weight (FR-022, FR-023)
+- [X] T025 [US3] Confirm the enumeration now equals `$defs/aggregation`'s enum exactly — `avg`, `min`, `max`, `count`, `rate`, `sum`, `stddev` — plus `p*` for the pattern: `python3 -c "import json; print(json.load(open('schema/opennfr.io/v1/requirementset.schema.json'))['\$defs']['aggregation']['anyOf'][0]['enum'])"`
+- [X] T026 [US3] Re-run T002's counter over `docs/ideas.md`. Entries and conditions MUST both still be **16**: the edit is inside the existing `**apdex**` entry and adds no line-initial bold and no second `*Would need*` (FR-024)
+- [X] T027 [US2] Run `bash scripts/verify.sh`, then `git rm -r --cached -q docs && bash scripts/verify.sh; git reset -q` to confirm Principle VIII's droppability still holds
+- [X] T028 [US2] Commit as `fix(governance): the reason names the class it is true of (#75)` with a `Closes #75` line. The commit MUST NOT touch `README.md`, `GLOSSARY.md`, `schema/`, `examples/`, `scripts/`, `AGENTS.md`, or anything under `specs/`
+
+**Checkpoint**: both issues closed; the constitution ships 4.0.0 with two amended principles and a
+report naming both limbs.
+
+---
+
+## Phase 5: Polish, and what this milestone found but does not fix
+
+- [X] T029 Run every check in [quickstart.md](quickstart.md), in order. Step 1's two `git diff --stat` commands are the scope proof: `schema/`, `examples/`, `scripts/`, `GLOSSARY.md`, `README.md` and `specs/008-path-denotation/` all empty, and exactly four files changed outside this feature's own directory (SC-007, SC-008)
+- [X] T030 [P] Verify each of the three commits is green **on its own** by checking it out in a scratch worktree — `git worktree add /tmp/onfr-green <sha> && (cd /tmp/onfr-green && bash scripts/verify.sh)`. Do not use `git stash`: this repository shares its stash stack across worktrees (FR-028)
+- [ ] T031 Open the pull request against `main` with milestone **v0.7.0**, both `Closes` lines, and a **first paragraph** stating that it amends the constitution and what breaks without it — the governance disclosure rule, honoured even though this amendment travels with no other work (FR-029, FR-030)
+- [ ] T032 [P] File an issue for the third defect of the same family, found by [plan.md](plan.md) § *Complexity Tracking*: nothing validates `.specify/memory/constitution.md`, and Principle III's third clause — *any artifact nothing validates MUST say so in its own text* — is unmet by the constitution itself. It is why both defects here survived two releases. The issue owes an argument about what such a check could decide, not a sentence
+- [ ] T033 [P] File an issue for `.copier-answers.yml:6`, a fourth copy of the `AGENTS.md` architecture sentence two revisions behind — it never gained *"or states what a target can assert"* and never gained the second-target rule ([research.md](research.md) R7). Not fixed here: it is not one of this milestone's issues, and work outside them does not ride along
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 (T001–T004, all [P])
+    ↓
+Phase 2 (T005)  ← blocks everything; spec-first
+    ↓
+Phase 3 (#83)   T006 → T007, T008 → T009 → T010 → T011 → T012 → T016 → T017
+                T013, T014, T015 in parallel with T009–T012
+    ↓
+Phase 4 (#75)   T018 → T019, T020, T021 → T022 → T027 → T028
+                T023, T024 in parallel; T025, T026 verify T024
+    ↓
+Phase 5 (T029–T033)
+```
+
+**Why Phase 4 waits on Phase 3**: not a content dependency — Principle II and Principle VI do not
+touch each other's text. It is the version footer and the Sync Impact Report, which T012 writes and
+T022 extends. Running #75 first would mean writing the report twice or bumping the version under the
+wrong limb.
+
+**Parallel within Phase 3**: T013 (`AGENTS.md`), T014 and T015 (`plan-template.md`) touch neither the
+constitution nor each other, and can be done while T009–T012 are in progress.
+
+**Parallel within Phase 4**: T023 (`plan-template.md`) and T024 (`docs/ideas.md`) are different files
+from the constitution and from each other.
+
+---
+
+## Implementation Strategy
+
+**The smallest shippable increment is Phase 3.** It closes #83, ends a contradiction that has stood
+for two releases, and leaves the repository consistent. #75 is a correction to a sentence nobody is
+currently blocked by; it rides this amendment because it needs one and would otherwise wait for its
+own version bump.
+
+**The contestable part is Phase 4, not Phase 3.** The one decision a reviewer might reverse is
+Principle II gaining a composite clause rather than mirroring `README.md`'s deletion — recorded in
+[spec.md](spec.md) § *Decisions*. It lands second, so disagreement costs one revert and no rebase.
+
+**Both issue commits must survive being read alone.** T017 and T028 each carry a `Closes` line, and
+T030 checks each is green in isolation. A commit that only makes sense beside its neighbour is a
+milestone that cannot be bisected.
+
+---
+
+## Notes
+
+- **Nothing here is verified by a script.** `bash scripts/verify.sh` reads none of the three files
+  this milestone edits except `docs/ideas.md`, and there only for the isolation counts. Every claim
+  the amendment makes is checked by reading, and the amendment says so in its own text (FR-005).
+- **The one number worth double-checking** is `docs/ideas.md`'s entry count. It is 16, not the 26 the
+  gate prints beside it — that 26 is how many links the isolation scan followed. T002 exists because
+  the first draft of this feature's research got that wrong.
+- **No task edits `specs/`** other than this feature's own directory. `specs/008-path-denotation/plan.md`
+  keeps its unchecked Principle VI box: it is the evidence the departure was disclosed, and rewriting
+  it to match the new rule would erase the only record that the old one was ever departed from.


### PR DESCRIPTION
**This pull request amends `.specify/memory/constitution.md`, and says so here because the amendment procedure requires it.** What breaks without it: the repository keeps shipping two normative documents that contradict each other. `AGENTS.md` § *Architecture* states that a second target is a second section in `README.md`; Principle VI says adding a target must not change any existing document; and Governance says that where the two disagree the constitution wins and the other document is wrong and MUST be fixed. The reconciliation exists only in `specs/008-path-denotation/plan.md`, under a directory `AGENTS.md` itself reads as history. Separately, Principle II calls apdex a derived quantity "computed by aggregation from metrics that already exist", which is false of apdex and was corrected in `README.md` a release ago. The amendment travels with no other work — it **is** the work.

Closes #83
Closes #75

## What changes

Milestone **v0.7.0**, two issues, three commits. Four files outside `specs/`, +113/−54. **Nothing the format owns moves**: `schema/`, `examples/`, `scripts/`, `GLOSSARY.md`, `README.md` and `specs/008-path-denotation/` have an empty diff, no term is added or renamed, and no example is touched.

| Commit | Files |
|---|---|
| `docs(speckit): add 010-constitution-catches-up spec/plan/tasks` | `specs/010-constitution-catches-up/` only |
| `fix(governance): the rule permits the one home it already has (#83)` | `constitution.md`, `plan-template.md`, `AGENTS.md` |
| `fix(governance): the reason names the class it is true of (#75)` | `constitution.md`, `plan-template.md`, `docs/ideas.md` |

**#83 — Principle VI.** The second bullet becomes two. A target's **description** is now defined — *what a renderer reads to turn a requirement document into that target's assertions* — there must be exactly **one** per target, a description **may** be a section of an existing document, and a gate implementing one is not a second description (it may name the reason a row gives; it may not carry a second copy of the rows). Adding a target still may not change the format, the schema or the published corpus. The principle carries its own amendment record, including the fact that nothing checks the rule. `AGENTS.md` loses the parenthetical that declared its rule a departure; the rule itself is unchanged.

Also in the same commit: the Compatibility Constraints sentence *"nothing in this repository describes a target"* has been false since v0.5.0 and is corrected. The list of compatibility-sensitive surfaces is unchanged at two items — restoring the third, *what a target's description may declare*, is recorded there as the rejected alternative, because it would put an argued issue and a `GLOSSARY.md` *Rejected* entry behind every edit to a reach row.

**#75 — Principle II.** apdex leaves the derived-quantities clause, where the stated reason is false of it, and is named in a new clause for **composite** quantities, which reduce to no construct the format has. The clause states the rule; the argument for why apdex reduces to nothing stays in `docs/ideas.md`. That entry also enumerated the format's aggregations and omitted `sum`, in the one document kept for arguing about constructs the format lacks — `sum` joins the list, with the reason it is not the one either.

**Version 3.0.0 → 4.0.0.** MAJOR at two limbs: Principle VI is *"redefined in a way that permits what it previously forbade"* (MAJOR), Principle II's new clause is *"existing guidance is materially expanded"* (MINOR). Highest governs; the Sync Impact Report names both. `.specify/templates/plan-template.md` follows — both gate questions and the version pointer.

## Why

The governing document was the last to know, twice.

**#83.** v0.5.0 consolidated the Gatling correspondence into `README.md` on the argument of #68: the tables existed in two places and had drifted, with four issues closed a release earlier live again in the copy on the page most readers meet. One home was the fix and it is not being reopened here — #83 says outright it is not asking for that. What the release did not do is take either route the constitution offers. This takes the second one.

What was wrong was the unit, not the rule. A separate file bought **singularity**, not separateness, and the drift #68 fixed was two copies disagreeing. The bullet now requires that property directly.

**#75.** apdex needs a banded classification carrying a second threshold and an aggregation weighting the bands, and the format has neither, so *"computed by aggregation from metrics that already exist"* is not true of it. Someone reading Principle II to decide whether apdex is reachable — `APDEX` is a literal key in the NFR-YAML this format replaces, so the question gets asked — was told something false, in the higher-authority document. apdex **moves** rather than being dropped: mirroring `README.md`'s deletion would make the two agree by making the constitution silent, and Principle II is the only place it says what may not become a metric name.

## What a reviewer should know

- **Phase 0 rewrote a requirement.** The spec first wrote the replacement containment as *"a fact about a target MUST NOT be stated outside a target's description"*. `research.md` R1 enumerated every target mention in the repository and found that rule **false at four sites**, two of them deliberate: `README.md:478` names what k6, Gatling and JMeter each call a request, which is the argument for `loadtest.request.name` existing, and `scripts/verify.sh:566` gives the reason one of its own rows gives — which v0.6.0's FR-023 explicitly required. Shipping it would have put a violated MUST into the document whose entire claim is that it wins. Hence the definition: a renderer reads neither, so neither is a description.
- **R1 also found a pre-existing violation of the *unamended* Principle VI**, at `README.md:478`. It is recorded rather than fixed — the new definition resolves it, and the alternative deletes the evidence for a debt `README.md` records on purpose.
- **Nothing validates this file.** `scripts/verify.sh` does not read `.specify/memory/constitution.md`, which is why both defects survived two releases. Principle III's third clause is therefore unmet by the constitution itself. It is **not** fixed here: it is not one of this milestone's issues, and the honest fix is an argument about what such a check could decide, not a sentence. `plan.md` § *Complexity Tracking* records it as a knowingly accepted cost.
- **`specs/` is untouched.** `specs/008-path-denotation/plan.md` keeps its unchecked Principle VI box and its Complexity Tracking row — that row is the evidence the departure was disclosed, and rewriting it would erase the only record that the old rule was ever departed from.
- **Each commit is green on its own**, verified in a scratch worktree. The two gate baselines — `24 embedded examples valid, 58 closures still reject` and `10 predicates assertable by Gatling, 10 selection probes still rejected, 5 still rendered, 10 predicate probes still rejected, 14 still rendered` — are byte-identical to the branch point at every commit. `docs/ideas.md` still has 16 ideas and 16 conditions, and `git rm -r docs && bash scripts/verify.sh` stays green.
- **Two follow-ups are owed and not filed yet**: a check on the constitution (above), and `.copier-answers.yml:6`, a fourth copy of the `AGENTS.md` architecture sentence two revisions behind. Both are recorded in `plan.md` and `tasks.md` (T032, T033) and both need their own issue.

## Checklist

- [x] Milestone assigned (CI fails without one) — **v0.7.0**
- [x] every `Closes #<issue>` above points at an issue in the same milestone — #83 and #75 are both in v0.7.0
- [x] `bash scripts/verify.sh` passes locally — and at each of the three commits independently
- [x] n/a — no term changed, so [GLOSSARY.md](../GLOSSARY.md) does not change. The one word that looks like a candidate, *composite*, classifies a quantity the format does not carry and is not a field, a value or a name a document may hold; `docs/ideas.md` already used it of apdex. Recorded as FR-026
- [x] n/a — no compatibility-sensitive surface changed. No borrowed OpenTelemetry name and no field name in a published example is touched, and the list of such surfaces is unchanged at two items
