### PR TITLE
feat(format): identity gets one scope, and the metrics get names of our own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ No code. One JSON Schema (`schema/opennfr.io/v1/requirementset.schema.json`), do
 <!-- A LIGHT search index, not a full tree. List only the entry points an agent needs
      to FIND code fast — one terse line per area (`dir/ -> what lives there`). Omit
      anything discoverable by looking; an exhaustive tree is noise and rots fast. -->
-`README.md` -> the format: what it is, every field, and what a target can actually assert; `schema/` -> the schema, which decides; `examples/` -> the validated corpus; `GLOSSARY.md` -> the terms; `CONTRIBUTING.md` -> how to propose a change; `scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`); `docs/ideas.md` -> constructs the format does not have; `specs/` -> spec-kit working dir, read as history. One file there is not history and says so in its own text: `specs/004-strip-to-schema/contracts/gatling-reach.md` is a redirect, kept only so the links written to it keep resolving.
+`README.md` -> the format: what it is, every field, and what a target can actually assert; `schema/` -> the schema, which decides; `examples/` -> the validated corpus; `GLOSSARY.md` -> the terms; `CONTRIBUTING.md` -> how to propose a change; `scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`, `identity.py`); `docs/ideas.md` -> constructs the format does not have; `specs/` -> spec-kit working dir, read as history. One file there is not history and says so in its own text: `specs/004-strip-to-schema/contracts/gatling-reach.md` is a redirect, kept only so the links written to it keep resolving.
 
 ## Architecture
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -118,8 +118,10 @@ as a request of that name already is.
 ### metric
 
 The name of what to measure of the selected requests. Borrowed from OpenTelemetry wherever an
-equivalent exists; never invented. The schema does not enumerate metric names and never will —
-enumerating them would make every new metric a change to the format.
+equivalent exists, and **equivalent means the quantity, not the string**: where a convention's name
+would import a producer this format is not, a name of our own under `loadtest.*` is required rather
+than merely permitted. The schema does not enumerate metric names and never will — enumerating them
+would make every new metric a change to the format.
 
 *Rejected*: an `indicator` object holding the metric and its own selection — it forced a
 requirement about one endpoint being fast *and* reliable to become two requirements with the same
@@ -129,8 +131,55 @@ of our own is permitted only under `loadtest.*` and only where semconv has none,
 name nothing emits is a vocabulary of one. The bar it did not clear is the durable part — **a name is minted only where something
 outside this repository already records the quantity under one**, and one target's feature is never
 sufficient grounds. A name for **what a group scope measures**, a cumulated response time, declined
-for the same reason and for a second one: it would not make the shape renderable, because no scope
-denotes the requests a path encloses.
+in v0.6.0 for the same reason and for a second one — that it would not make the shape renderable,
+because no scope denotes the requests a path encloses.
+
+**Both of those declines were reversed in v0.8.0, and the second was simply wrong.**
+`AssertionStatsRepository` carries `groupCumulatedResponseTimeGeneralStats`, and always did: the
+quantity was assertable while the entry said it was not (read with `javap` from
+`gatling-charts` 3.13.5 and `gatling-shared-model` 0.0.11, 2026-08-31). The first decline stands as
+a bar and is cleared rather than waived — the quantity is recorded outside this repository by
+Gatling, whose statistic for each is named, sourced and dated in `README.md` § *What any tool can
+actually run*. No second tool is claimed here: none has been checked and dated, and Principle IV
+does not allow one to be asserted from memory. The bar therefore rests on one target so far, which
+the Compatibility Constraints call necessary and not sufficient, and that is recorded as open. See § *loadtest.request.duration* and § *loadtest.group.duration*.
+
+### loadtest.request.duration
+
+The duration of one recorded operation, measured by the load generator's own clock. The protocol is
+an attribute of the operation, not part of the measurement: a generator does not measure "an HTTP
+request duration" as a quantity distinct from "a Kafka operation duration" — it measures the elapsed
+time of one thing it recorded. The unit under it is the addressable one, and `loadtest.request.name`
+is what selects it.
+
+*Rejected*: `http.client.request.duration`, which this replaces. It welds three independent things
+into one string — the vantage, the protocol and the granularity — and only the first is fixed by a
+load generator. Worse, it is published today by production instrumentation and by any OpenTelemetry
+HTTP client, where `client` means the instrumented calling service and not the generator. A
+requirement document and a production dashboard could carry one string for two measurements, with
+nothing in either to tell them apart — which is the substitution § *metric* and `README.md` § *Names*
+exist to forbid. `loadtest.*` has no such ambiguity by construction: the prefix **is** the vantage
+statement.
+
+*Rejected*: `loadtest.operation.duration`. `operation` would be a second word for what
+`loadtest.request.name` already addresses, and the format would carry two vocabularies for one
+concept. One word with a faint protocol flavour, used consistently, is the cheaper wart.
+
+### loadtest.group.duration
+
+The duration of one traversal of a group. Two quantities can answer to that — the sum of the enclosed
+operations' durations, and wall clock from entry to exit including any pause — and the format does
+not adjudicate between them: it names the requirement, and each target's description states which
+one that target computes. `README.md` § *Gatling* records that a Gatling run computes the first.
+
+*Rejected*: `aggregation: sum` over `loadtest.request.duration`. The quantity is a percentile
+across traversals of a sum across the operations each traversal encloses — two nested aggregations,
+and `aggregation` states one. It is a distinct measured quantity, so it takes a distinct name.
+
+*Rejected*: naming the wall-clock quantity instead, or as well. It is computed by Gatling
+(`groupDurationGeneralStats`) and is **not** on `AssertionStatsRepository`, so no assertion can read
+it and no configuration makes it assertable — a name for it would be a construct no surveyed target
+can assert, which the Compatibility Constraints forbid.
 
 ### bad / good
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -197,17 +197,26 @@ downstream — a report line, a CI annotation, a URL fragment — has to be able
 *Rejected*: free-form strings — nothing could point at one reliably. Indices (`criterion: 0`) —
 they break whenever the file is edited.
 
-### criterionId
+### predicateId
 
 The identity of a predicate: its `name` if set, otherwise its `aggregation`. What it must be unique
 within is stated in [README.md](README.md) § *A predicate*; JSON Schema cannot express that
 fallback, so the gate checks it.
 
+*Rejected*: `criterionId`, which this term replaces — it named the identity of a predicate after one
+of the two lists that hold predicates, and `criteria` and `guards` hold the same shape. The mismatch
+became load-bearing rather than untidy when uniqueness was scoped to the list: a guard carries an
+identity on the same terms a criterion does, and the gate's own failure message said `criterionId`
+of a guard. *Rejected*: `identity` — it collides with `README.md`'s Identity axis, which is about
+what a target does with the key, not what the key is.
+
 *Rejected*: requiring `name` on every predicate — a name is noise where `p99` and `max` already
 distinguish two statements. *Rejected*: scoping uniqueness to the whole requirement rather than to
-one list — `rate` over the requests and `rate` over a fraction are different quantities sharing a
-word, the predicate's own shape already tells them apart, and the wider scope would force a name
-onto a collision that is only lexical, which is the same noise the first rejection refuses.
+one list. A guard and a criterion are statements about different things — whether the run happened,
+and whether the system held — and a report separates them for that reason, so two `rate` predicates
+one on each side are never mistaken for one statement. Inside a single list there is no such
+separation, which is why the rule bites there and only there. The wider scope would force a name on
+the guard/criterion pair alone, buying nothing the split has already bought.
 
 ### annotations
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -191,11 +191,17 @@ is wanted.
 
 ### name
 
-The machine identifier: lowercase letters, digits and hyphens. Restricted because something
-downstream — a report line, a CI annotation, a URL fragment — has to be able to point at it.
+The machine identifier: lowercase letters, digits and hyphens. Restricted for two reasons this
+repository can check. An identity is compared for **equality** — `scripts/verify.sh` decides
+uniqueness by comparing one to another — so a closed character set is what makes two identities
+that look alike to a reader be alike to the check; `Peak` and `peak ` would otherwise read as one
+collision and compare as two. And `$defs/name` is a single spelling rule shared by `metadata.name`,
+a requirement's `name` and a predicate's `name`, so a reader learns it once and applies it in three
+places.
 
-*Rejected*: free-form strings — nothing could point at one reliably. Indices (`criterion: 0`) —
-they break whenever the file is edited.
+*Rejected*: free-form strings — two identities differing only in case or trailing space would read
+as one and compare as two, and a document a reader calls ambiguous would pass the uniqueness check.
+Indices (`criterion: 0`) — they break whenever the file is edited.
 
 ### predicateId
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -199,12 +199,15 @@ they break whenever the file is edited.
 
 ### criterionId
 
-The identity of a predicate within one requirement: its `name` if set, otherwise its `aggregation`.
-Two predicates in the same list may not share one. JSON Schema cannot express that fallback, so the
-gate checks it.
+The identity of a predicate: its `name` if set, otherwise its `aggregation`. What it must be unique
+within is stated in [README.md](README.md) § *A predicate*; JSON Schema cannot express that
+fallback, so the gate checks it.
 
 *Rejected*: requiring `name` on every predicate — a name is noise where `p99` and `max` already
-distinguish two statements.
+distinguish two statements. *Rejected*: scoping uniqueness to the whole requirement rather than to
+one list — `rate` over the requests and `rate` over a fraction are different quantities sharing a
+word, the predicate's own shape already tells them apart, and the wider scope would force a name
+onto a collision that is only lexical, which is the same noise the first rejection refuses.
 
 ### annotations
 

--- a/README.md
+++ b/README.md
@@ -354,17 +354,22 @@ the requirement's own selection, so it is never written twice.
 - {bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5, unit: "%"}
 ```
 
-**`name`.** Needed only when two predicates of one requirement would otherwise be
-indistinguishable. Identity is the `name` if set, and the `aggregation` otherwise:
+**`name`.** Needed only when two predicates of one list would otherwise be indistinguishable.
+Identity is the `name` if set, and the `aggregation` otherwise, and it must be unique
+**within one list** — `criteria` and `guards` are counted apart:
 
 ```yaml
-guards:   [{aggregation: rate, op: gte, threshold: 200, unit: "{request}/s"}]
-criteria: [{aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}]
-# both identities are "rate" — one of them must be named
+criteria:
+  - {bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5,   unit: "%"}
+  - {name: request-rate,     aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}
+# both identities would be "rate" — one is named, and either one could have been
 ```
 
-JSON Schema cannot express that fallback, so uniqueness is checked by `scripts/verify.sh`.
-`criteria` and `guards` are checked separately: a guard and a criterion may both be `rate`.
+A guard and a criterion may share an identity, because they are two lists.
+`examples/the-run-held-up.yaml` states an unnamed `rate` guard beside an unnamed `rate` criterion
+and is correct: one says the run reached the load it assumed, the other says what share of it
+failed, and the shape of each is what tells them apart. JSON Schema cannot express the fallback, so
+uniqueness is checked by `scripts/verify.sh`.
 
 ### `displayName` — optional, and inert
 

--- a/README.md
+++ b/README.md
@@ -714,6 +714,30 @@ number.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` 
 fine. Rounding is not an option: it moves the bar the author wrote, so the document states one
 limit and the run enforces another, and the report names neither.
 
+#### Identity
+
+A predicate's identity — its `name`, or the `aggregation` standing in where no `name` is set — is
+what tells it from the other predicates in its list. This axis is the one that decides nothing:
+every predicate below is assertable, and the verdict says what becomes of the key when the predicate
+is rendered, not whether the statement runs.
+
+| OpenNFR | Gatling | |
+|---|---|---|
+| `name`, and the `aggregation` that stands in for it | — | **not carried** — `Assertion` is `(path, target, condition)`, and no field of it holds a label. The predicate renders; the key does not travel with it, and two requirements that select the same requests and state the same criterion render to equal `Assertion` values |
+| `displayName` | — | **not carried**, and nothing is lost by it: the key is inert. Nothing selected, measured or compared depends on it, so a target that drops it drops nothing the format claims |
+
+**not carried** is a third verdict and says what neither of the others can: the predicate renders,
+and the key does not travel into what it renders to. It is not **cannot** — a predicate carrying a
+`name` is assertable, and a renderer refusing one would be narrowing the format to what a target
+happens to carry.
+
+**Sourced** to `io.gatling.commons.stats.assertion.Assertion`, read with `javap` from
+`gatling-shared-model` 0.0.11 — the release Gatling **3.13.5** pins. **Checked 2026-08-31.** That is
+a different version from the **3.15.1** the four sources above were read at, and it is named rather
+than rounded to match them: 3.15.1 was not available where this was checked. `Assertion` is
+byte-identical in the release Gatling 3.11.5 pins, so the shape held across two minors — which is
+what is known, and is not a claim about a third.
+
 #### Two things Gatling cannot do at all
 
 - **Abort a run on a violated assertion.** Assertions are evaluated after the run.
@@ -729,7 +753,12 @@ limit and the run enforces another, and the report names neither.
 #### How these tables are applied
 
 **The tables partition each axis.** A predicate is assertable only if it matches a row exactly;
-anything unlisted is rejected. That direction is load-bearing. The first implementation was
+anything unlisted is rejected. All nine of a predicate's keys have a row: seven decide whether it is
+assertable — `metric`, `aggregation`, `op`, `threshold`, `unit`, `bad`, `good` — and the two on the
+Identity axis do not, which is why their verdict is **not carried** rather than **can** or
+**cannot**. The gate implements no rejection from that axis, and the one thing there is to check
+about it is that it rejects nothing: `PREDICATE_RENDERS` carries a predicate with a `name`, and it
+renders. That direction is load-bearing. The first implementation was
 written as a denylist — reject `sum`, reject `neq`, accept the rest — and defaulting to *allow*
 is what let four unrenderable shapes through: a filtered `bad`, an empty `bad`, a percentile in
 percent, and a fractional millisecond. A gap in these tables must fail the corpus, not pass it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ side of a release.
 One fact is worth knowing before designing anything on OpenTelemetry, and it is negative. **No
 load generator publishes semantic convention names.** OTLP output is common — k6, Locust,
 Artillery, Gatling Enterprise all have it — but it is a transport, not a vocabulary: k6 emits
-`k6_http_req_duration` in milliseconds where the convention wants `http.client.request.duration`
+`k6_http_req_duration` in milliseconds where another tool names the same quantity something else
 in seconds. "The tool speaks OTel" does not mean "the tool is compatible". *(Checked against each
 tool's documentation, August 2026.)*
 
@@ -76,7 +76,7 @@ spec:
       selector:
         loadtest.request.name: POST /checkout
       criteria:
-        - metric: http.client.request.duration
+        - metric: loadtest.request.duration
           aggregation: p95
           op: lte
           threshold: 500
@@ -104,7 +104,7 @@ RequirementSet          the document — an envelope and a list
 Everything under `criteria` and `guards` is the same shape, a **predicate**:
 
 ```yaml
-metric: http.client.request.duration   # optional — what to measure, if anything
+metric: loadtest.request.duration   # optional — what to measure, if anything
 aggregation: p95                       # how to reduce many numbers to one
 op: lte                                # how to compare it
 threshold: 500                         # to what
@@ -129,7 +129,7 @@ Every criterion and every guard beneath it is about those requests.
   selector:
     loadtest.request.name: POST /checkout      # said once
   criteria:
-    - {metric: http.client.request.duration, aggregation: p99, op: lte, threshold: 500, unit: ms}
+    - {metric: loadtest.request.duration, aggregation: p99, op: lte, threshold: 500, unit: ms}
     - {bad: {error.type: "*"},               aggregation: rate, op: lte, threshold: 5,   unit: "%"}
 ```
 
@@ -290,7 +290,7 @@ Structurally identical. The difference is entirely in what a violation means:
 guards:
   - {name: reached-target-rate, aggregation: rate, op: gte, threshold: 200, unit: "{request}/s"}
 criteria:
-  - {metric: http.client.request.duration, aggregation: p95, op: lte, threshold: 500, unit: ms}
+  - {metric: loadtest.request.duration, aggregation: p95, op: lte, threshold: 500, unit: ms}
 ```
 
 > **Why guards are a construct and not a comment.** The most common lie in load testing reports is
@@ -418,7 +418,7 @@ no separate dictionary of abbreviations.
 **A limitation, recorded rather than implied**: the schema does **not** check that a unit fits the
 aggregation. An error share written in `ms`, or a p95 of a duration in `{vu}`, validates. Part of
 that is reachable — the schema knows which of the three shapes a predicate is — and part is not,
-because the schema deliberately does not know that `http.client.request.duration` is a time.
+because the schema deliberately does not know that `loadtest.request.duration` is a time.
 
 ---
 
@@ -436,7 +436,8 @@ same run without glue, because both sides already agree on what an endpoint is c
 
 | Name | Unit | Role |
 |---|---|---|
-| `http.client.request.duration` | `s` | the primary latency metric. A load generator **is** an HTTP client, so the client-side metric is the correct one — not `http.server.*`, and not the tool's own `http_req_duration` |
+| `loadtest.request.duration` | `s` | the primary latency metric: the duration of one recorded operation, by the generator's own clock. The protocol is an attribute of the operation, not part of the measurement |
+| `loadtest.group.duration` | `s` | the duration of one traversal of a group. Two quantities answer to that and tools compute different ones — see § *What any tool can actually run* for which one a given target computes |
 | `http.client.request.body.size` | `By` | volume sent |
 | `http.client.response.body.size` | `By` | volume received |
 | `http.server.request.duration` | `s` | when a requirement is stated over the system's own data rather than the generator's |
@@ -444,6 +445,26 @@ same run without glue, because both sides already agree on what an endpoint is c
 **Vantage point is not a detail.** A load generator measures latency as a client; a production stack
 usually measures it as a server. The two numbers are not comparable, and letting one stand in for
 the other is the failure this format exists to prevent.
+
+**Which is why the first two names are ours.** The rule is to borrow from semantic conventions
+wherever an equivalent exists — and **equivalent means the quantity, not the string**. semconv has a
+string for an HTTP client request duration; it has no name for *the duration of any recorded
+operation, whatever produced it, by the generator's own clock*, which is the quantity a load
+generator actually measures. Worse, `http.client.request.duration` is published today by production
+instrumentation and by any OpenTelemetry HTTP client, where `client` means the instrumented calling
+service. Borrowing it would let a requirement document and a production dashboard carry one string
+for two measurements — the substitution the paragraph above says this format exists to prevent,
+committed by the naming rule meant to prevent it. Where a convention's name would import a producer this format is not,
+semconv has no equivalent for what is being measured, so the rule already permits a `loadtest.*`
+name: the prefix is the vantage statement. That is a reading of *equivalent*, not a second rule —
+what may be minted is still exactly what `.specify/memory/constitution.md` Principle II permits.
+
+`http.client.request.duration` was that name until v0.8.0 and is **retired**, not aliased. Aliasing
+would make it definitionally mean "any recorded operation", so a document reading
+`metric: http.client.request.duration` over a Kafka run would be conformant and false — the defect
+enshrined rather than closed. The three names that remain keep theirs: the body sizes are volumes,
+and `http.server.request.duration` is the one name here whose whole point is a **different** vantage,
+so nothing about it is borrowed under a false pretence.
 
 **What these four names do not cover**, because the gap is a whole class of requirement rather than
 an edge case. A load generator records a duration for things that are not one HTTP client request,
@@ -454,14 +475,22 @@ and the two cases are not the same case:
   valid. It will not appear in [`examples/`](examples/), because no rendering of one has been
   checked and dated and § *What any tool can actually run* lists only what has.
 - **A span an author bracketed** — a business transaction across several requests plus think time.
-  Nothing names it. `http.client.request.duration` is not that name: it is the duration of one HTTP
-  client request, and writing it for a transaction states something false about what was measured,
-  which is the substitution the paragraph above says this format exists to prevent.
+  Where a target records that span as a **group**, `loadtest.group.duration` names it. Where it does
+  not, nothing does, and `loadtest.request.duration` is not that name: it is the duration of one
+  recorded operation, and writing it for a transaction states something false about what was
+  measured.
 
-The second is a gap in the format and is recorded as one. **No name is minted here**: a name of our
-own is permitted only under `loadtest.*` and only where semconv has none, and a `loadtest.*` name
-nothing emits is a vocabulary of one — the debt this page already records, doubled. What it would
-take is argued under `docs/`, which this page does not link into.
+The second is narrowed rather than closed, and what remains is recorded as a gap. **The bar for
+minting stayed where it was** — a name is minted only where something outside this repository
+already records the quantity under one, and one target's feature is never sufficient grounds. Both
+both names above clear it against Gatling, whose statistics for each are named,
+sourced and dated in § *What any tool can actually run*. Whether a second tool records either
+quantity is **not recorded here**: no such claim has been checked against that tool and dated, and
+Principle IV does not allow one to be made on memory. Until one is, the bar rests on one target,
+which the Compatibility Constraints call necessary and not sufficient — so the case for these two
+names is open on that point and is written down as open. A span no tool brackets for you is still a
+vocabulary of one, and what it would take is argued under `docs/`, which this page
+does not link into.
 
 ### Selection attributes
 
@@ -594,17 +623,20 @@ them apart.
 | `{loadtest.group.name: [G₁, …, Gₙ], loadtest.request.name: X}`, every part a string other than `"*"` | `details("G₁" / … / "Gₙ" / "X")` | **can** — **the request named `X` whose hierarchy is exactly `G₁…Gₙ`**, at any depth |
 | `{loadtest.request.name: "*"}` | `forAll()` | **can** — one statement per **request position** the run records, at any depth, not one number over all of them. `allRequestPaths()` `collect`s only the request keys of a map, so groups are discarded and each (hierarchy, name) pair appears exactly once |
 | `{loadtest.group.name: [G₁, …, Gₙ], loadtest.request.name: "*"}` | — | **cannot** — no scope both quantifies and carries a path, so "every request inside one group" has no correspondence |
-| `{loadtest.group.name: [..., "*", ...], loadtest.request.name: X}` | — | **cannot** — a group at that position with any name, and no scope carries a wildcard path part |
+| `{loadtest.group.name: [..., "*", ...]}`, with or without a request name | — | **cannot** — a group at that position with any name, and no scope carries a wildcard path part |
 | `loadtest.group.name` as a string, or `[]` | — | rejected by the **schema** before this table is reached: a hierarchy has one spelling, and "no enclosing group" is said by omitting the key. The gate carries the same two rejections, so each is probed |
-| `{loadtest.group.name: [G₁, …, Gₙ]}`, no request name | — | **cannot** — it denotes the requests whose hierarchy is exactly those groups, and **no scope denotes the requests a path encloses**: the scopes are `Global`, `ForAll` and `Details(parts)`, nothing else is addressable, and `details(...)` on a group's path resolves to the group, whose statistics are its own. So neither a duration of the enclosed requests nor a count of them is reachable — the refusal holds for a predicate carrying a `metric` and for one carrying none. What the group scope does compute is that group's *cumulated* response time, which no name in § *Names* is true of |
+| `{loadtest.group.name: [G₁, …, Gₙ]}`, no request name, every part a string other than `"*"` | `details("G₁" / … / "Gₙ")`, resolving to a **group** | **can**, and **only** paired with `loadtest.group.duration` — v0.8.0 minted the name the old refusal was waiting on. `details(...)` on a group's path resolves to the group, whose statistics are its own, so what is reachable here is the group's cumulated response time and nothing else: neither a duration of the enclosed requests individually nor a count of them. A predicate carrying `loadtest.request.duration`, any other metric, or no metric at all is still refused under this selection |
 | any path value that is not a string | — | **cannot** — a path is `AssertionPathParts(parts: List[String])`. `{loadtest.request.name: 200}` and `{loadtest.request.name: "200"}` are different documents and only the second is renderable |
 | `{http.route: ...}` | — | **cannot** |
 | `{http.request.method: ...}` | — | **cannot** |
 | `{http.response.status_code: ...}` | — | **cannot** |
 | any other attribute | — | **cannot** |
 
-**The two `details(...)` rows carry a precondition: the rendered path must not also be the full
-hierarchy of a recorded group.** Where it is, Gatling's own resolution is unspecified.
+**The three `details(...)` rows carry a precondition: the rendered path must not name both a
+request and a group.** For the two request rows that means the path must not also be the full
+hierarchy of a recorded group; for the group row it runs the other way — the path must not also be
+the full path of a recorded request, or a document asserting `loadtest.group.duration` can measure
+that request's response time instead. Where either holds, Gatling's own resolution is unspecified.
 `LogFileData.findPathByParts` is a single `collectFirst` over the keys of a `mutable.HashMap`
 holding request paths and group paths together, so which one matches depends on hash order — and
 where the group wins, the assertion measures that group's **cumulated** response time rather than
@@ -635,9 +667,26 @@ one table down.
 
 | OpenNFR `metric` | Gatling | |
 |---|---|---|
-| `http.client.request.duration` | `responseTime` | **can** |
+| `loadtest.request.duration` | `responseTime` | **can** — under any selection the Selection axis admits **except** a hierarchy with no request name, which resolves to a group and has no request statistics of its own |
+| `loadtest.group.duration` | `groupCumulatedResponseTimeGeneralStats` | **can** — and **only** under `{loadtest.group.name: [G₁, …, Gₙ]}` with no request name. Gatling computes the **sum of the durations of the operations the group encloses**, not the elapsed time of the traversal, so a run that pauses inside a group is not counted for the pause |
+| `http.client.request.duration` | — | **cannot** — **retired in v0.8.0** and not aliased. It named the vantage, the protocol and the granularity in one string when a load generator fixes only the first, and it is published by producers this format is not, so one string could carry two measurements. § *Names* has the argument |
 | `http.client.request.body.size`, `http.client.response.body.size` | — | **cannot** — the assertion DSL reaches response time and request counts only |
-| any other | — | **cannot** — `http.client.request.duration` is the only metric here whose rendering has been checked and dated, and nothing else has been. Three different cases sit under this row and § *Names* separates them: a measurement taken at another vantage point, which the vantage-point rule refuses outright; a name a convention already carries for another protocol's operation, which is a valid document with no dated rendering; and a duration recorded for a span an author bracketed, which has no name at all |
+| any other | — | **cannot** — the two `loadtest.*` names are the only metrics here whose rendering has been checked and dated, and nothing else has been. Three different cases sit under this row and § *Names* separates them: a measurement taken at another vantage point, which the vantage-point rule refuses outright; a name a convention already carries for another protocol's operation, which is a valid document with no dated rendering; and a duration recorded for a span an author bracketed, which has no name at all |
+
+**Sourced** for the two rows above to `io.gatling.shared.model.assertion.AssertionStatsRepository`,
+read with `javap` from `gatling-shared-model` 0.0.11 and `gatling-charts` 3.13.5 — the release
+Gatling **3.13.5** pins. **Checked 2026-08-31.** The interface carries four methods and two of them
+are statistics: `requestGeneralStats` and `groupCumulatedResponseTimeGeneralStats`. The wall-clock
+quantity is computed — `LogFileData.groupDurationGeneralStats` — and is **absent from the
+interface**, so no assertion can reach it and no configuration makes it assertable. Both statistics
+return one `Stats(min: Int, max: Int, count: Long, mean: Int, stdDev: Int, percentile, …)`, which is
+why a group admits the same aggregations, units and integer-threshold rule as a request.
+
+*Carried from [#89](https://github.com/galax-io/opennfr/issues/89) and not re-read here*:
+`gatling.charting.useGroupDurationMetric` (default `false`) reaches the report generator only, never
+the assertion path, so a run with it set shows wall clock in its charts while its assertions judged
+cumulated response time. It is consistent with what was read — the flag cannot change an assertion
+that has no access to the quantity it selects — but it is that issue's reading, dated to it.
 
 #### Aggregations
 
@@ -649,6 +698,14 @@ Over a metric:
 | `max`, `min` | `responseTime.max` / `.min` | **can** |
 | `avg` | `responseTime.mean` | **can** |
 | `stddev` | `responseTime.stdDev` | **can** |
+
+The statistic named is the one `loadtest.request.duration` resolves to. `loadtest.group.duration`
+takes the **same four rows** with `groupCumulatedResponseTime` in place of `responseTime` —
+`groupCumulatedResponseTime.percentile(n)`, `.max`, `.min`, `.mean`, `.stdDev` — because both
+resolve to one `Stats(min: Int, max: Int, count: Long, mean: Int, stdDev: Int, percentile, …)`, so
+the aggregations, the units and the integer target are shared and only the name differs. The rows
+are not repeated: one type, one set of rows, two names for the statistic. `scripts/verify.sh` holds
+the pair in `NATIVE` and the rows carry a placeholder for it.
 | `sum` | — | **cannot** — `responseTime` offers no sum and no arithmetic that would produce one |
 | `count` | — | **cannot** — none of the rows above is a count, and `allRequests.count` is the row *below*: it counts requests, not what a metric carries, and the two differ wherever a metric is not recorded for every request |
 | `rate` | — | **cannot** — the same, one row down: `requestsPerSec` is a rate of requests, and no row here is a rate of a metric's own observations |
@@ -700,6 +757,7 @@ for another. A percentile in `%` is not a Gatling assertion.
 | Statistic | Accepts | Native | Target |
 |---|---|---|---|
 | `responseTime.*` | `ms`, `s` | milliseconds | **`Int`** |
+| `groupCumulatedResponseTime.*` | `ms`, `s` | milliseconds | **`Int`** | 
 | `failedRequests.percent` | `%`, `1` | percent, 0..100 | `Double` |
 | `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Int`** |
 | `requestsPerSec` | `{request}/s` | per second | `Double` |
@@ -758,7 +816,11 @@ assertable — `metric`, `aggregation`, `op`, `threshold`, `unit`, `bad`, `good`
 Identity axis do not, which is why their verdict is **not carried** rather than **can** or
 **cannot**. The gate implements no rejection from that axis, and the one thing there is to check
 about it is that it rejects nothing: `PREDICATE_RENDERS` carries a predicate with a `name`, and it
-renders. That direction is load-bearing. The first implementation was
+renders. **One pair is judged jointly, and it is the only one.** A hierarchy with no request name and the
+metric `loadtest.group.duration` admit each other and nothing else: the selection resolves to a
+group, and a group's only assertable statistic is its cumulated response time. Every other axis
+decides alone, and this one says so rather than leaving a renderer to discover that two **can** rows
+do not compose. That direction is load-bearing. The first implementation was
 written as a denylist — reject `sum`, reject `neq`, accept the rest — and defaulting to *allow*
 is what let four unrenderable shapes through: a filtered `bad`, an empty `bad`, a percentile in
 percent, and a fractional millisecond. A gap in these tables must fail the corpus, not pass it.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -27,8 +27,9 @@ substance survives, split between the requirement's `selector` and the predicate
 `bad`. What killed it: holding the selection inside the shape forced a requirement about one
 endpoint being fast *and* reliable to become two requirements with the same selector written twice.
 A `ratio` also had to name a metric it did not measure — an error-rate requirement read
-`metric: http.client.request.duration`, because a histogram's count is the request count and
-OpenTelemetry defines no HTTP client request counter.
+`metric: http.client.request.duration`, the name the format carried before v0.8.0 retired it,
+because a histogram's count is the request count and OpenTelemetry defines no HTTP client request
+counter.
 
 *Would need*: an OpenTelemetry request counter, so a fraction stops having to name a metric it does not measure — and a reason to reverse ADR-0003's split, which none has appeared.
 
@@ -166,14 +167,17 @@ Attributes: `loadtest.phase`, `loadtest.scenario.name`, `loadtest.tool.name` / `
 
 Deliberately absent from it: `loadtest.throughput` (derived — `aggregation: rate`),
 `loadtest.error_rate` (derived — a `bad` fraction), `loadtest.response_time` (a duplicate of
-`http.client.request.duration`), `loadtest.apdex` (composite), `loadtest.run.id`
-(`cicd.pipeline.run.id` already exists). And, since v0.6.0, a name for **a span an author
-bracketed** — a business transaction across several requests, which no semantic convention names.
-It is the one duration a load test measures that the format cannot spell, and it is absent for the
-reason the rest of this registry is: a name nothing emits is a vocabulary of one.
+`loadtest.request.duration`, which the format now has), `loadtest.apdex` (composite),
+`loadtest.run.id` (`cicd.pipeline.run.id` already exists). A name for **a span an author bracketed**
+was absent here from v0.6.0 until v0.8.0 and is now **narrowed rather than absent**: where a target
+records the span as a group, `loadtest.group.duration` names it. What is left absent is a span no
+target brackets for you, and it is absent for the reason the rest of this registry is: a name
+nothing emits is a vocabulary of one.
 
-**The rest of the registry** stays an idea. two names from this registry — `loadtest.request.name` and `loadtest.group.name` — are **not** ideas
-any more. Every published example depends on them, and `README.md` defines them and records the debt.
+**The rest of the registry** stays an idea. Four of its names are not ideas any more:
+`loadtest.request.name` and `loadtest.group.name`, which every published example depends on, and
+since v0.8.0 `loadtest.request.duration` and `loadtest.group.duration`. `README.md` defines all four
+and records the debt.
 
 *Would need*: submission upstream, and something that emits the names. A namespace nobody has
 claimed and nothing publishes is a vocabulary of one, which is what the debt in `README.md` says.

--- a/examples/every-request-is-fast.yaml
+++ b/examples/every-request-is-fast.yaml
@@ -36,7 +36,7 @@ spec:
         loadtest.request.name: "*"                 # each recorded position, separately — not pooled
       criteria:
         - displayName: 95th percentile
-          metric: http.client.request.duration
+          metric: loadtest.request.duration
           aggregation: p95
           op: lte
           threshold: 3

--- a/examples/fast-and-reliable.yaml
+++ b/examples/fast-and-reliable.yaml
@@ -23,8 +23,8 @@ spec:
         loadtest.group.name: [Checkout]             # a group, and one request inside it
         loadtest.request.name: POST /checkout
       criteria:
-        - {displayName: 99th percentile, metric: http.client.request.duration, aggregation: p99, op: lte, threshold: 500, unit: ms}
-        - {displayName: Median,          metric: http.client.request.duration, aggregation: p50, op: lte, threshold: 200, unit: ms}
-        - {displayName: Slowest,         metric: http.client.request.duration, aggregation: max, op: lte, threshold: 1000, unit: ms}
+        - {displayName: 99th percentile, metric: loadtest.request.duration, aggregation: p99, op: lte, threshold: 500, unit: ms}
+        - {displayName: Median,          metric: loadtest.request.duration, aggregation: p50, op: lte, threshold: 200, unit: ms}
+        - {displayName: Slowest,         metric: loadtest.request.duration, aggregation: max, op: lte, threshold: 1000, unit: ms}
         - {displayName: Failed share,    bad: {error.type: "*"}, aggregation: rate,  op: lte, threshold: 5,  unit: "%"}
         - {displayName: Failed count,    bad: {error.type: "*"}, aggregation: count, op: lte, threshold: 20, unit: "{request}"}

--- a/examples/one-request-is-fast.yaml
+++ b/examples/one-request-is-fast.yaml
@@ -15,7 +15,7 @@ spec:
       selector:
         loadtest.request.name: POST /checkout      # the name the tool records for this call
       criteria:
-        - metric: http.client.request.duration     # an OpenTelemetry name, not ours
+        - metric: loadtest.request.duration     # ours: no convention names this quantity
           aggregation: p95
           op: lte
           threshold: 500

--- a/examples/the-run-held-up.yaml
+++ b/examples/the-run-held-up.yaml
@@ -28,5 +28,5 @@ spec:
           threshold: 200
           unit: "{request}/s"
       criteria:
-        - {displayName: 99th percentile, metric: http.client.request.duration, aggregation: p99, op: lte, threshold: 1000, unit: ms}
+        - {displayName: 99th percentile, metric: loadtest.request.duration, aggregation: p99, op: lte, threshold: 1000, unit: ms}
         - {displayName: Failed share,    bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5, unit: "%"}

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -127,7 +127,7 @@
       "properties": {
         "name": {
           "$ref": "#/$defs/name",
-          "description": "Optional. Identifies this predicate in a report; without it the aggregation is the identifier, so two predicates in one requirement may not then share an aggregation.",
+          "description": "Optional. Distinguishes this predicate from the others beside it; without it the aggregation is the identifier. What the identity must be unique within is in README.md; JSON Schema cannot express the fallback, so scripts/verify.sh checks it.",
           "examples": [
             "reached-target-rate"
           ]

--- a/schema/opennfr.io/v1/requirementset.schema.json
+++ b/schema/opennfr.io/v1/requirementset.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opennfr.io/schema/v1/requirementset.schema.json",
   "title": "RequirementSet",
-  "description": "The container a performance requirement is written into. Deliberately minimal: it fixes the shape and nothing else. Metric and attribute names are plain strings, borrowed from OpenTelemetry rather than defined here, so measuring something new never means changing the format.",
+  "description": "The container a performance requirement is written into. Deliberately minimal: it fixes the shape and nothing else. Metric and attribute names are plain strings, borrowed from OpenTelemetry wherever it has an equivalent quantity and minted under loadtest.* where it does not, so measuring something new never means changing the format.",
   "examples": [
     {
       "apiVersion": "opennfr.io/v1",
@@ -19,7 +19,7 @@
             },
             "criteria": [
               {
-                "metric": "http.client.request.duration",
+                "metric": "loadtest.request.duration",
                 "aggregation": "p95",
                 "op": "lte",
                 "threshold": 500,
@@ -101,7 +101,7 @@
               },
               "criteria": [
                 {
-                  "metric": "http.client.request.duration",
+                  "metric": "loadtest.request.duration",
                   "aggregation": "p95",
                   "op": "lte",
                   "threshold": 500,
@@ -153,7 +153,7 @@
         "metric": {
           "type": "string",
           "minLength": 1,
-          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions where one exists; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry — a count, a rate, or a fraction with `bad`/`good`."
+          "description": "What to measure of the selected requests. A name borrowed from OpenTelemetry semantic conventions wherever one names this quantity, and minted under loadtest.* where none does — see README.md § Names; this schema does not enumerate metric names and never will. Omit it to reduce the requests themselves rather than a quantity they carry — a count, a rate, or a fraction with `bad`/`good`."
         },
         "bad": {
           "$ref": "#/$defs/selector",
@@ -166,7 +166,7 @@
       },
       "examples": [
         {
-          "metric": "http.client.request.duration",
+          "metric": "loadtest.request.duration",
           "aggregation": "p99",
           "op": "lte",
           "threshold": 500,
@@ -341,7 +341,7 @@
           ],
           "criteria": [
             {
-              "metric": "http.client.request.duration",
+              "metric": "loadtest.request.duration",
               "aggregation": "p99",
               "op": "lte",
               "threshold": 500,

--- a/scripts/identity.py
+++ b/scripts/identity.py
@@ -1,0 +1,96 @@
+"""What a predicate's identity is, and where two of them collide.
+
+Shared by the two sections of scripts/verify.sh that check it — one over examples/, one over
+the schema's own root examples — so the two cannot drift into disagreeing about the same rule.
+The rule is stated in README.md > A predicate and is not restated here.
+
+Until v0.8.0 nothing exercised any of this. No document in the repository carries a colliding
+identity and none carries a `name` at all, so both branches could be replaced with `if False:`
+with the gate still printing PASS, and the `name` arm of the fallback had never been observed
+(issue #72).
+"""
+
+SECTIONS = ("criteria", "guards")
+
+
+def predicate_id(predicate):
+    """The identity of one predicate: its `name` if set, its `aggregation` otherwise."""
+    return predicate.get("name") or predicate.get("aggregation")
+
+
+def collisions(requirement, scanned):
+    """Yield every collision in one requirement, as (section, predicateId), in the order found.
+
+    A generator on purpose, and `scanned` gains one entry per list compared. The count the call
+    sites floor is therefore a by-product of CONSUMING this: a call site that keeps the count
+    while dropping the loop keeps nothing, because an unconsumed generator appends nothing.
+    An earlier shape counted lists through a second function, and both call sites could then
+    drop the check with their floors still satisfied.
+    """
+    for section in SECTIONS:
+        predicates = requirement.get(section)
+        if predicates is None:
+            continue
+        scanned.append(section)
+        seen = set()
+        for p in predicates:
+            cid = predicate_id(p)
+            if cid in seen:
+                yield section, cid
+            seen.add(cid)
+
+
+def duplicates(requirement):
+    """Every collision in one requirement, as a list. What the probes below judge."""
+    return list(collisions(requirement, []))
+
+
+# Each probe is a requirement paired with what duplicates() must return for it. Four must report a
+# collision and two must report none: a rejection probe cannot show that the rule still ACCEPTS,
+# and without that direction a rule hardened into "every pair collides" passes every probe here.
+# Same argument as SELECTION_RENDERS and PREDICATE_RENDERS, one rule over.
+PROBES = [
+    ({"criteria": [{"aggregation": "rate"}, {"aggregation": "rate"}]},
+     [("criteria", "rate")],
+     "two unnamed criteria sharing an aggregation"),
+
+    ({"criteria": [{"aggregation": "p95"}],
+      "guards": [{"aggregation": "rate"}, {"aggregation": "rate"}]},
+     [("guards", "rate")],
+     "two unnamed guards sharing an aggregation — the corpus holds one guard and can never collide"),
+
+    ({"criteria": [{"name": "peak", "aggregation": "p95"},
+                   {"name": "peak", "aggregation": "max"}]},
+     [("criteria", "peak")],
+     "the `name` arm: colliding names over differing aggregations"),
+
+    ({"criteria": [{"name": "a", "aggregation": "rate"},
+                   {"name": "b", "aggregation": "rate"}]},
+     [],
+     "distinct names over one aggregation — the direction no rejection probe can show"),
+
+    ({"criteria": [{"aggregation": "rate"}, {"name": "rate", "aggregation": "count"}]},
+     [("criteria", "rate")],
+     "a `name` equal to another predicate's aggregation — one namespace, not two"),
+
+    ({"guards": [{"aggregation": "rate"}], "criteria": [{"aggregation": "rate"}]},
+     [],
+     "a guard and a criterion sharing an identity — the exemption the-run-held-up.yaml relies on"),
+]
+
+# A pruned probe list reports nothing and reads exactly like a sound one. The floor is EXACT: each
+# probe above is the sole catcher of its own class, and adding one means raising this number.
+FLOOR = 6
+
+
+def selftest():
+    """Every probe this module gets wrong, as a list of strings. Empty when sound."""
+    wrong = []
+    if len(PROBES) < FLOOR:
+        wrong.append(f"the probe list has shrunk to {len(PROBES)}, expected at least {FLOOR} — "
+                     f"a rule nothing probes is a rule nothing checks")
+    for requirement, want, why in PROBES:
+        got = duplicates(requirement)
+        if got != want:
+            wrong.append(f"{why}: expected {want}, got {got}")
+    return wrong

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -179,7 +179,7 @@ for f in files:
 # A check that scanned nothing reads exactly like one that passed, and a probe cannot catch a
 # deleted CALL — the probes above call the module directly and would stay green. This count can,
 # because `collisions` is a generator that appends only while it is being consumed: drop the loop
-# and the count drops with it. Counting through a second function would NOT do that.
+# and the count drops with it. Counting through a second function did NOT do that.
 IDENTITY_LISTS = 5
 if len(identity_lists) < IDENTITY_LISTS:
     print(f"  FAIL  the identity check read {len(identity_lists)} lists, expected at least "
@@ -594,7 +594,12 @@ REQUEST = "loadtest.request.name"
 # pair is that request at whatever depth the list spells. {HIERARCHY} alone is absent on
 # purpose, and settled rather than pending: it has a meaning, the requests whose hierarchy is
 # exactly those groups, and no Gatling scope denotes the requests a path encloses.
-SELECTIONS = [set(), {REQUEST}, {HIERARCHY, REQUEST}]
+SELECTIONS = [set(), {REQUEST}, {HIERARCHY, REQUEST}, {HIERARCHY}]
+
+# Of those, the one that resolves to a GROUP rather than a request. `details(...)` on a
+# group's path resolves to the group, whose statistics are its own, so this selection
+# reaches exactly one quantity and every other selection reaches everything but it.
+GROUP_ONLY = {HIERARCHY}
 
 # Of those, the ones a quantifier has a scope for. `"*"` renders as forAll(), which takes no
 # path, so a quantified selection carrying one has no correspondence. It is admitted only as
@@ -603,8 +608,12 @@ SELECTIONS = [set(), {REQUEST}, {HIERARCHY, REQUEST}]
 # rejecting it.
 QUANTIFIABLE = [{REQUEST}]
 
-# responseTime is the only addressable metric family.
-METRIC = "http.client.request.duration"
+# Two addressable metrics, one per statistic on AssertionStatsRepository. `http.client.
+# request.duration` was the only one until v0.8.0 and is retired, not aliased (#89): it is
+# absent from METRICS, so a document carrying it is refused by the row that names it.
+METRIC = "loadtest.request.duration"
+GROUP_METRIC = "loadtest.group.duration"
+METRICS = (METRIC, GROUP_METRIC)
 
 # `bad` maps to failedRequests, which counts KO and nothing else, so the only numerator
 # with an exact correspondence is "an error happened". A narrower filter — a status code,
@@ -624,13 +633,19 @@ COUNT = {"{request}": Fraction(1)}
 PERSEC = {"{request}/s": Fraction(1)}
 def percentile(a): return a.startswith("p") and a[1:].replace(".", "", 1).isdigit()
 
+# The statistic each addressable metric resolves to. One `Stats` type serves both, so the units
+# and the integer target are shared and only the name differs — but the name belongs to the METRIC,
+# and the metric rows below carry a `{}` for it. Deriving it by rewriting the other name was a
+# silent no-op the moment a native stopped containing "responseTime", and nothing probed it.
+NATIVE = {METRIC: "responseTime", GROUP_METRIC: "groupCumulatedResponseTime"}
+
 TABLE = {
     "metric": {
-        "PERCENTILE": ("responseTime.percentile", TIME, True),
-        "max":        ("responseTime.max",        TIME, True),
-        "min":        ("responseTime.min",        TIME, True),
-        "avg":        ("responseTime.mean",       TIME, True),
-        "stddev":     ("responseTime.stdDev",     TIME, True),
+        "PERCENTILE": ("{}.percentile", TIME, True),
+        "max":        ("{}.max",        TIME, True),
+        "min":        ("{}.min",        TIME, True),
+        "avg":        ("{}.mean",       TIME, True),
+        "stddev":     ("{}.stdDev",     TIME, True),
     },
     "fraction": {
         "rate":  ("failedRequests.percent", SHARE, False),
@@ -698,7 +713,7 @@ def predicate_why(p):
     # two copies would be free to disagree. It was inline until v0.6.0, which is part of why the
     # predicate axes went unprobed — there was nothing a probe could call.
     why = []
-    if p.get("metric", METRIC) != METRIC:
+    if p.get("metric", METRIC) not in METRICS:
         why.append(f"metric {p['metric']} is not addressable")
 
     shape = shape_of(p, why)
@@ -715,6 +730,8 @@ def predicate_why(p):
 
     if row:
         native, units, integral = row
+        # A no-op on the fraction and requests rows, which carry no placeholder.
+        native = native.format(NATIVE.get(p.get("metric", METRIC), METRIC))
         factor = units.get(p.get("unit"))
         if factor is None:
             why.append(f"unit {p.get('unit')} is not a unit of {native}")
@@ -731,6 +748,13 @@ def predicate_why(p):
     return why
 
 def shape_of(p, why):
+    if ("bad" in p or "good" in p) and "metric" in p:
+        # `bad`/`good` count requests, so the shape below reads no metric at all. Discarding a
+        # key without a message is the #57 failure class, and it let a group metric ride a
+        # fraction into a group scope asserting failedRequests.
+        why.append(f"metric {p['metric']} is discarded by a fraction: `bad`/`good` counts "
+                   f"requests, not a metric's observations")
+        return None
     if "good" in p:
         # successfulRequests exists, but a selector matches presence and never absence,
         # so no OpenNFR fraction corresponds to it. See README > Names.
@@ -747,9 +771,63 @@ def shape_of(p, why):
 # documents that validate and are assertable. Each probe is a selector this contract says
 # cannot be rendered, paired with the reason its row gives. A probe that stops being
 # rejected FAILs the section instead of passing quietly.
+def pairing_why(sel, p):
+    # The one place two axes decide together, and README > How these tables are applied says so.
+    # A hierarchy with no request name resolves to a group, and a group's only assertable
+    # statistic is its cumulated response time — so that selection admits GROUP_METRIC and
+    # nothing else, and every other selection admits everything but it. Two `can` rows that do
+    # not compose is exactly the thing a renderer cannot discover from the tables alone.
+    group_sel = set(sel) == GROUP_ONLY
+    group_metric = p.get("metric") == GROUP_METRIC
+    if group_sel and not group_metric:
+        return [f"a hierarchy with no request name resolves to a group, whose only assertable "
+                f"statistic is {GROUP_METRIC}"]
+    if group_metric and not group_sel:
+        return [f"{GROUP_METRIC} is a group's own statistic, and this selection does not "
+                f"resolve to a group"]
+    return []
+
+def render_why(sel, p):
+    # Every rule the corpus is judged by, in one place. PAIRING_PROBES and PAIRING_RENDERS go
+    # through this and not through pairing_why alone, so dropping a rule from the composite
+    # reddens them — which is the only thing that can catch a rule deleted from the CALL rather
+    # than from its own body.
+    return selection_why(sel) + predicate_why(p) + pairing_why(sel, p)
+
+# Each entry is a (selector, predicate) pair the joint rule must REJECT, and the reason its row
+# gives. Neither axis alone can catch these: every one of them is built from a selection the
+# Selection axis accepts and a predicate the Metrics axis accepts.
+PAIRING_PROBES = [
+    ({HIERARCHY: ["Checkout"]}, {"metric": METRIC, "aggregation": "p95", "op": "lte",
+                                 "threshold": 500, "unit": "ms"},
+     f"a hierarchy with no request name resolves to a group, whose only assertable statistic "
+     f"is {GROUP_METRIC}"),
+    ({HIERARCHY: ["Checkout"]}, {"aggregation": "count", "op": "lte", "threshold": 20,
+                                 "unit": "{request}"},
+     f"a hierarchy with no request name resolves to a group, whose only assertable statistic "
+     f"is {GROUP_METRIC}"),
+    ({REQUEST: "POST /checkout"}, {"metric": GROUP_METRIC, "aggregation": "p95", "op": "lte",
+                                   "threshold": 500, "unit": "ms"},
+     f"{GROUP_METRIC} is a group's own statistic, and this selection does not resolve to a group"),
+    ({}, {"metric": GROUP_METRIC, "aggregation": "max", "op": "lte", "threshold": 500,
+          "unit": "ms"},
+     f"{GROUP_METRIC} is a group's own statistic, and this selection does not resolve to a group"),
+]
+
+# And the other direction. A rejection probe cannot show that the pair still RENDERS, and the
+# corpus cannot either: nothing published selects a group.
+PAIRING_RENDERS = [
+    ({HIERARCHY: ["Checkout"]}, {"metric": GROUP_METRIC, "aggregation": "p95", "op": "lte",
+                                 "threshold": 500, "unit": "ms"}),
+    ({HIERARCHY: ["Checkout", "Payment"]}, {"metric": GROUP_METRIC, "aggregation": "max",
+                                            "op": "lte", "threshold": 1, "unit": "s"}),
+    ({}, {"metric": METRIC, "aggregation": "p99", "op": "lte", "threshold": 500, "unit": "ms"}),
+    ({REQUEST: "POST /checkout"}, {"metric": METRIC, "aggregation": "avg", "op": "lte",
+                                   "threshold": 500, "unit": "ms"}),
+]
+
 SELECTION_PROBES = [
     ({"http.route": "/api/v1/checkout"}, NOT_A_PATH.format(["http.route"])),
-    ({HIERARCHY: ["Checkout"]}, NOT_A_PATH.format([HIERARCHY])),
     ({HIERARCHY: "Checkout", REQUEST: "POST /checkout"}, NOT_A_LIST),
     ({HIERARCHY: "*", REQUEST: "POST /checkout"}, NOT_A_LIST),
     ({HIERARCHY: [], REQUEST: "POST /checkout"}, NO_GROUPS),
@@ -765,6 +843,10 @@ SELECTION_PROBES = [
 # above would leave every check here green. These must produce no reason at all.
 SELECTION_RENDERS = [
     {},
+    # Was a REJECTION probe until v0.8.0, when #89 minted the name the old refusal was waiting
+    # on. It is not deleted, it changed direction — which is why the rejection floor below drops
+    # by one and this one rises by one, rather than either being quietly relaxed.
+    {HIERARCHY: ["Checkout"]},
     {REQUEST: "POST /checkout"},
     {REQUEST: "*"},
     {HIERARCHY: ["Checkout"], REQUEST: "POST /checkout"},
@@ -790,6 +872,21 @@ PREDICATE_PROBES = [
      "aggregation sum over a metric has no equivalent"),
     ({**RENDERABLE, "metric": "http.client.response.body.size"},
      "metric http.client.response.body.size is not addressable"),
+    # The retired name (#89). Its `cannot` row is the only published row whose rule is an
+    # ABSENCE — it is refused by not being in METRICS — so nothing else would notice it being
+    # let back in, and a mutation adding it survived every other probe here.
+    ({**RENDERABLE, "metric": "http.client.request.duration"},
+     "metric http.client.request.duration is not addressable"),
+    # The only probe that reads a group statistic's NAME. Without it the metric-to-native
+    # mapping could be wrong or absent and every other probe stayed green, because the group
+    # metric appeared solely in rendering probes, which assert no message at all.
+    ({**RENDERABLE, "metric": GROUP_METRIC, "unit": "%"},
+     "unit % is not a unit of groupCumulatedResponseTime.percentile"),
+    # And a fraction may not smuggle a metric past the shape, which discards it.
+    ({"metric": GROUP_METRIC, "bad": BAD, "aggregation": "rate", "op": "lte",
+      "threshold": 5, "unit": "%"},
+     f"metric {GROUP_METRIC} is discarded by a fraction: `bad`/`good` counts requests, "
+     f"not a metric's observations"),
     ({**RENDERABLE, "op": "neq"},
      "op neq has no equivalent"),
     ({**RENDERABLE, "unit": "%"},
@@ -823,6 +920,7 @@ PREDICATE_PROBES = [
 PREDICATE_RENDERS = [
     RENDERABLE,
     {**RENDERABLE, "name": "p95-latency"},
+    {"metric": GROUP_METRIC, "aggregation": "p95", "op": "lte", "threshold": 500, "unit": "ms"},
     {**RENDERABLE, "aggregation": "max"},
     {**RENDERABLE, "aggregation": "min"},
     {**RENDERABLE, "aggregation": "avg"},
@@ -838,7 +936,19 @@ PREDICATE_RENDERS = [
     {"bad": {"error.type": "*"}, "aggregation": "count", "op": "lte", "threshold": 20, "unit": "{request}"},
 ]
 
+# The gate's metric names must be the names README publishes. `METRIC` is anchored by the
+# corpus, which carries its literal; `GROUP_METRIC` is carried by no document, so renaming it
+# left the gate green while it rejected the published name as "not addressable".
 rc, checked = 0, 0
+_reach = open("README.md", encoding="utf-8").read().split("## What any tool can actually run", 1)
+if len(_reach) != 2:
+    print("  FAIL  README.md has no section 'What any tool can actually run' to implement")
+    sys.exit(1)
+for _name in (METRIC, GROUP_METRIC):
+    if f"`{_name}`" not in _reach[1]:
+        print(f"  FAIL  {_name} is not a metric README publishes — the gate and the page "
+              f"disagree about the name")
+        rc = 1
 
 # A pruned probe table reports no failures and reads exactly like a sound one. ALL FOUR floors are
 # EXACT, and that is deliberate — the closure floor above sits just under its count because its
@@ -858,8 +968,9 @@ rc, checked = 0, 0
 # of them share the aggregation-row lookup while catching three distinct regressions. Each RENDERING
 # probe is the sole catcher of one published `can` row being deleted, which no rejection probe and
 # no corpus document can show.
-FLOORS = [("rejection", SELECTION_PROBES, 10), ("rendering", SELECTION_RENDERS, 5),
-          ("predicate rejection", PREDICATE_PROBES, 10), ("predicate rendering", PREDICATE_RENDERS, 15)]
+FLOORS = [("rejection", SELECTION_PROBES, 9), ("rendering", SELECTION_RENDERS, 6),
+          ("predicate rejection", PREDICATE_PROBES, 13), ("predicate rendering", PREDICATE_RENDERS, 16),
+          ("pairing rejection", PAIRING_PROBES, 4), ("pairing rendering", PAIRING_RENDERS, 4)]
 for _label, _probes, _floor in FLOORS:
     if len(_probes) < _floor:
         print(f"  FAIL  {len(_probes)} {_label} probes, expected at least {_floor} — "
@@ -879,6 +990,17 @@ for probe, expected in PREDICATE_PROBES:
     got = predicate_why(probe)
     if expected not in got:
         print(f"  FAIL  probe {probe}: expected rejection {expected!r}, got {got or 'accepted'}")
+        rc = 1
+for sel, pred, expected in PAIRING_PROBES:
+    got = render_why(sel, pred)
+    if expected not in got:
+        print(f"  FAIL  pairing probe {sel} x {pred.get('metric')}: expected {expected!r}, "
+              f"got {got or 'accepted'}")
+        rc = 1
+for sel, pred in PAIRING_RENDERS:
+    got = render_why(sel, pred)
+    if got:
+        print(f"  FAIL  pairing render {sel} x {pred.get('metric')}: rejected — {got}")
         rc = 1
 for probe in PREDICATE_RENDERS:
     got = predicate_why(probe)
@@ -904,7 +1026,7 @@ for f in files:
             for section in ("guards", "criteria"):
                 for p in r.get(section) or []:
                     checked += 1
-                    why = selection_why(sel) + predicate_why(p)
+                    why = render_why(sel, p)
 
                     if why:
                         cid = identity.predicate_id(p)
@@ -919,7 +1041,9 @@ if rc == 0:
           f"{len(SELECTION_PROBES)} selection probes still rejected, "
           f"{len(SELECTION_RENDERS)} still rendered, "
           f"{len(PREDICATE_PROBES)} predicate probes still rejected, "
-          f"{len(PREDICATE_RENDERS)} still rendered")
+          f"{len(PREDICATE_RENDERS)} still rendered, "
+          f"{len(PAIRING_PROBES)} pairing probes still rejected, "
+          f"{len(PAIRING_RENDERS)} still rendered")
 sys.exit(rc)
 GATLING
 fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -124,10 +124,23 @@ except ImportError as e:
     # A gate that skips itself reads exactly like a passing one.
     print(f"  FAIL  {e.name} not installed (pip install jsonschema pyyaml)")
     sys.exit(1)
+sys.path.insert(0, "scripts")
+import identity
+
+# The identity rule is held to its own probes before either section trusts it. Both branches
+# that checked it could be replaced with `if False:` and this gate still printed PASS, and the
+# `name` arm of the fallback had never been observed at all — issue #72.
+wrong = identity.selftest()
+for m in wrong:
+    print(f"  FAIL  the identity rule is wrong: {m}")
+if wrong:
+    sys.exit(1)
+
 schema = json.load(open("schema/opennfr.io/v1/requirementset.schema.json", encoding="utf-8"))
 Draft202012Validator.check_schema(schema)
 v = Draft202012Validator(schema)
 rc = 0
+identity_lists = []
 files = sorted(glob.glob("examples/*.yaml"))
 if not files:
     print("  FAIL  examples/ holds no document to validate")
@@ -152,22 +165,29 @@ for f in files:
         for e in errs:
             where = "/".join(map(str, e.path)) or "(root)"
             print(f"  FAIL  {f}: {where}: {e.message}")
-        # criterionId is the name if set, otherwise the aggregation. The schema
-        # cannot express that fallback, so uniqueness is checked here.
-        for r in doc.get("spec", {}).get("requirements", []) or []:
-            for section in ("criteria", "guards"):
-                seen = set()
-                for p in r.get(section, []) or []:
-                    cid = p.get("name") or p.get("aggregation")
-                    if cid in seen:
-                        print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate criterionId {cid!r}")
-                        errs = errs or [1]
-                        rc = 1
-                    seen.add(cid)
+        # The identity rule, and why the schema cannot carry it, live in scripts/identity.py.
+        for r in (doc.get("spec") or {}).get("requirements", []) or []:
+            for section, cid in identity.collisions(r, identity_lists):
+                print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate criterionId {cid!r}")
+                errs = errs or [1]
+                rc = 1
         if errs:
             rc = 1
         else:
             print(f"  ok    {f}  [{kind}]")
+
+# A check that scanned nothing reads exactly like one that passed, and a probe cannot catch a
+# deleted CALL — the probes above call the module directly and would stay green. This count can,
+# because `collisions` is a generator that appends only while it is being consumed: drop the loop
+# and the count drops with it. Counting through a second function would NOT do that.
+IDENTITY_LISTS = 5
+if len(identity_lists) < IDENTITY_LISTS:
+    print(f"  FAIL  the identity check read {len(identity_lists)} lists, expected at least "
+          f"{IDENTITY_LISTS} — a check that scanned nothing reads exactly like one that passed")
+    rc = 1
+else:
+    print(f"  ok    identity: {len(identity.PROBES)} probes still hold, "
+          f"{len(identity_lists)} lists read")
 sys.exit(rc)
 SCHEMA
 fi
@@ -337,17 +357,25 @@ for where, node in slots:
 # The root's examples are whole documents, so they answer to what the corpus answers to.
 # The schema cannot express criterionId uniqueness — that is why examples/ is checked for it
 # by hand above — and the one document an editor offers first was the one nothing checked.
+# The rule itself lives in scripts/identity.py, shared with that section so the two cannot
+# drift into disagreeing about it.
+sys.path.insert(0, "scripts")
+import identity
+
+root_identity_lists = []
 for i, ex in enumerate(schema.get("examples", [])):
-    for r in (ex.get("spec", {}) or {}).get("requirements", []) or []:
-        for part in ("criteria", "guards"):
-            seen_ids = set()
-            for p in r.get(part, []) or []:
-                cid = p.get("name") or p.get("aggregation")
-                if cid in seen_ids:
-                    print(f"  FAIL  {path}: root example {i}: {r.get('name')}/{part}: "
-                          f"duplicate criterionId {cid!r}")
-                    rc = 1
-                seen_ids.add(cid)
+    for r in (ex.get("spec") or {}).get("requirements", []) or []:
+        for part, cid in identity.collisions(r, root_identity_lists):
+            print(f"  FAIL  {path}: root example {i}: {r.get('name')}/{part}: "
+                  f"duplicate criterionId {cid!r}")
+            rc = 1
+
+# As above: a deleted call reads as a clean scan, so the count is floored too.
+ROOT_IDENTITY_LISTS = 1
+if len(root_identity_lists) < ROOT_IDENTITY_LISTS:
+    print(f"  FAIL  {path}: the identity check read {len(root_identity_lists)} lists of the "
+          f"schema's own examples, expected at least {ROOT_IDENTITY_LISTS}")
+    rc = 1
 
 EXAMPLES = 20
 if checked < EXAMPLES:
@@ -544,6 +572,8 @@ else
   python3 - <<'GATLING' || fail=1
 import glob, sys
 from fractions import Fraction
+sys.path.insert(0, "scripts")
+import identity
 try:
     import yaml
 except ImportError as e:
@@ -871,7 +901,7 @@ for f in files:
                     why = selection_why(sel) + predicate_why(p)
 
                     if why:
-                        cid = p.get("name") or p.get("aggregation")
+                        cid = identity.predicate_id(p)
                         print(f"  FAIL  {f}: {r.get('name')}/{section}/{cid}: " + "; ".join(why))
                         rc = 1
 # A scan that checked nothing reads exactly like a scan that passed.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -168,7 +168,7 @@ for f in files:
         # The identity rule, and why the schema cannot carry it, live in scripts/identity.py.
         for r in (doc.get("spec") or {}).get("requirements", []) or []:
             for section, cid in identity.collisions(r, identity_lists):
-                print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate criterionId {cid!r}")
+                print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate predicateId {cid!r}")
                 errs = errs or [1]
                 rc = 1
         if errs:
@@ -355,7 +355,7 @@ for where, node in slots:
             rc = 1
 
 # The root's examples are whole documents, so they answer to what the corpus answers to.
-# The schema cannot express criterionId uniqueness — that is why examples/ is checked for it
+# The schema cannot express predicateId uniqueness — that is why examples/ is checked for it
 # by hand above — and the one document an editor offers first was the one nothing checked.
 # The rule itself lives in scripts/identity.py, shared with that section so the two cannot
 # drift into disagreeing about it.
@@ -367,7 +367,7 @@ for i, ex in enumerate(schema.get("examples", [])):
     for r in (ex.get("spec") or {}).get("requirements", []) or []:
         for part, cid in identity.collisions(r, root_identity_lists):
             print(f"  FAIL  {path}: root example {i}: {r.get('name')}/{part}: "
-                  f"duplicate criterionId {cid!r}")
+                  f"duplicate predicateId {cid!r}")
             rc = 1
 
 # As above: a deleted call reads as a clean scan, so the count is floored too.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -815,8 +815,14 @@ PREDICATE_PROBES = [
 # The first entry is the base every probe above mutates. Without it the whole table can pass on a
 # broken baseline: drop `lte` from OPS and all the rejection probes still fire their own reason
 # alongside the new one, because the check is membership and not equality.
+#
+# The `name` entry is the Identity axis's only probe, and it is a rendering one because that axis
+# rejects nothing: predicate_why never reads the key, and nothing else in the repository carries
+# one — not a corpus document, not a probe. A rejection added on `name` would be caught by nothing
+# at all (#82).
 PREDICATE_RENDERS = [
     RENDERABLE,
+    {**RENDERABLE, "name": "p95-latency"},
     {**RENDERABLE, "aggregation": "max"},
     {**RENDERABLE, "aggregation": "min"},
     {**RENDERABLE, "aggregation": "avg"},
@@ -853,7 +859,7 @@ rc, checked = 0, 0
 # probe is the sole catcher of one published `can` row being deleted, which no rejection probe and
 # no corpus document can show.
 FLOORS = [("rejection", SELECTION_PROBES, 10), ("rendering", SELECTION_RENDERS, 5),
-          ("predicate rejection", PREDICATE_PROBES, 10), ("predicate rendering", PREDICATE_RENDERS, 14)]
+          ("predicate rejection", PREDICATE_PROBES, 10), ("predicate rendering", PREDICATE_RENDERS, 15)]
 for _label, _probes, _floor in FLOORS:
     if len(_probes) < _floor:
         print(f"  FAIL  {len(_probes)} {_label} probes, expected at least {_floor} — "

--- a/specs/011-identity-has-one-scope/checklists/requirements.md
+++ b/specs/011-identity-has-one-scope/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Identity Has One Scope
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Iteration 1** raised three questions the user owns, answered on 2026-08-30 and recorded in spec.md § *Decisions*:
+  - **Identity scope** — the **list**, `criteria` and `guards` counted apart. The requirement scope, which the schema states today, is the rejected alternative and is recorded as one in FR-007.
+  - **How the four places are reconciled** — **one home and pointers**, not four corrected copies. `README.md` § *A predicate* states the scope; the schema and `GLOSSARY.md` name it without repeating it.
+  - **The shape of the `name` reach row** — a new `#### Identity` subsection carrying a **third verdict**. A bullet under *Two things Gatling cannot do at all* and a narrowed partition claim were the rejected alternatives, recorded in the Assumptions.
+- **Iteration 2** re-ran the checklist with all three resolved. All items pass.
+- "Non-technical stakeholders" reads as *a consumer of the format who did not write it* here — concretely, the author of the first OpenNFR renderer, who is named as the reader of all four user stories. There is no end user below that: this repository ships a vocabulary, a schema and a gate, and the people downstream of it build tools.
+- Every functional requirement names a document, a sentence or a published row, and every success criterion is decidable by reading the shipped files or running the gate. `scripts/verify.sh` appears throughout because it is the repository's gate and one of the artifacts this milestone changes — it is a deliverable here, not an implementation detail of one. The same is true of the schema.
+- **SC-004**, **SC-005**, **SC-006** and **SC-009** are stated as mutations that must redden the gate. That is the standard `scripts/verify.sh` already sets for itself — *"a rule nothing probes is a rule nothing checks"* — and the phrasing is deliberate: #72 exists because a rule that was merely *stated* read as a rule that was checked.
+- **One dependency is external and is flagged.** FR-025 and FR-026 rest on Gatling's `Assertion` field list, which cannot be checked from this repository. It is the only claim in the milestone in that position, and the milestone description says so.
+- **Iteration 3 (Phase 0)** amended three items and is recorded in spec.md § *What Phase 0 changed* and [research.md](../research.md) § *What Phase 0 changed*. FR-026 stopped requiring a version nobody could open — the row is dated at Gatling **3.13.5**, which `javap` was actually run against. FR-034 went from four files to six: the two identity checks are in separate processes, so the single implementation FR-019 requires has to be a module on disk, and `AGENTS.md` § *Structure* names what the gate shares. SC-008 now requires the version difference to be visible on the page. All three move the spec toward claiming less, and the checklist still passes at every item.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`. None are.

--- a/specs/011-identity-has-one-scope/contracts/identity-module.md
+++ b/specs/011-identity-has-one-scope/contracts/identity-module.md
@@ -1,0 +1,247 @@
+# Contract — #72: the branch fires, and stays fired
+
+**Commit**: `fix(gate): the identity rule is probed in both directions (#72)`
+**Files**: `scripts/identity.py` *(new)*, `scripts/verify.sh`, `AGENTS.md`
+
+Today both uniqueness branches can be replaced with `if False:` and the gate still prints **PASS**. This commit makes each of four things fail: deleting the rule, deleting either call site, deleting a probe, and hardening the rule into "every pair collides".
+
+---
+
+## 1. `scripts/identity.py` — new
+
+The module holds the rule once. It does **not** restate the scope in prose: that lives in `README.md` § *A predicate*, and a comment repeating it is the copy #58 is about.
+
+```python
+"""What a predicate's identity is, and where two of them collide.
+
+Shared by the two sections of scripts/verify.sh that check it — one over examples/, one over the
+schema's own root examples — so the two cannot drift into disagreeing about the same rule. The
+rule is stated in README.md > A predicate and is not restated here.
+
+Until v0.8.0 nothing exercised any of this. No document in the repository carries a colliding
+identity and none carries a `name` at all, so both branches could be replaced with `if False:`
+with the gate still printing PASS, and the `name` arm of the fallback had never been observed.
+"""
+
+SECTIONS = ("criteria", "guards")
+
+
+def predicate_id(predicate):
+    """The identity of one predicate: its `name` if set, its `aggregation` otherwise."""
+    return predicate.get("name") or predicate.get("aggregation")
+
+
+def collisions(requirement, scanned):
+    """Yield every collision, appending to `scanned` once per list compared.
+
+    A generator, so the count each call site floors is a by-product of CONSUMING the check.
+    """
+    for section in SECTIONS:
+        predicates = requirement.get(section)
+        if predicates is None:
+            continue
+        scanned.append(section)
+        seen = set()
+        for p in predicates:
+            cid = predicate_id(p)
+            if cid in seen:
+                yield section, cid
+            seen.add(cid)
+
+
+def duplicates(requirement):
+    """Every collision as a list. What the probes judge."""
+    return list(collisions(requirement, []))
+
+
+
+
+# Each probe is a requirement paired with what duplicates() must return for it. Four must report a
+# collision and two must report none: a rejection probe cannot show that the rule still ACCEPTS,
+# and without that direction a rule hardened into "every pair collides" passes every probe here.
+# Same argument as SELECTION_RENDERS and PREDICATE_RENDERS, one rule over.
+PROBES = [
+    ({"criteria": [{"aggregation": "rate"}, {"aggregation": "rate"}]},
+     [("criteria", "rate")],
+     "two unnamed criteria sharing an aggregation"),
+
+    ({"criteria": [{"aggregation": "p95"}],
+      "guards": [{"aggregation": "rate"}, {"aggregation": "rate"}]},
+     [("guards", "rate")],
+     "two unnamed guards sharing an aggregation — the corpus holds one guard and can never collide"),
+
+    ({"criteria": [{"name": "peak", "aggregation": "p95"},
+                   {"name": "peak", "aggregation": "max"}]},
+     [("criteria", "peak")],
+     "the `name` arm: colliding names over differing aggregations"),
+
+    ({"criteria": [{"name": "a", "aggregation": "rate"},
+                   {"name": "b", "aggregation": "rate"}]},
+     [],
+     "distinct names over one aggregation — the direction no rejection probe can show"),
+
+    ({"criteria": [{"aggregation": "rate"}, {"name": "rate", "aggregation": "count"}]},
+     [("criteria", "rate")],
+     "a `name` equal to another predicate's aggregation — one namespace, not two"),
+
+    ({"guards": [{"aggregation": "rate"}], "criteria": [{"aggregation": "rate"}]},
+     [],
+     "a guard and a criterion sharing an identity — the exemption examples/the-run-held-up.yaml relies on"),
+]
+
+# A pruned probe list reports nothing and reads exactly like a sound one. The floor is EXACT: each
+# probe above is the sole catcher of its own class, and adding one means raising this number.
+FLOOR = 6
+
+
+def selftest():
+    """Every probe this module gets wrong, as a list of strings. Empty when sound."""
+    wrong = []
+    if len(PROBES) < FLOOR:
+        wrong.append(f"the probe list has shrunk to {len(PROBES)}, expected at least {FLOOR} — "
+                     f"a rule nothing probes is a rule nothing checks")
+    for requirement, want, why in PROBES:
+        got = duplicates(requirement)
+        if got != want:
+            wrong.append(f"{why}: expected {want}, got {got}")
+    return wrong
+```
+
+### What each probe is the sole catcher of
+
+| # | Catches |
+|---|---|
+| 1 | the aggregation arm, in `criteria` — the rule itself |
+| 2 | the rule reaching `guards` at all. The corpus has one guard and can never collide |
+| 3 | the **`name` arm**, which nothing in the repository has ever exercised |
+| 4 | the rule hardened into "every pair collides" |
+| 5 | the two arms silently becoming two namespaces |
+| 6 | the per-list reset — the exemption #58 settles |
+
+Probe 6 overlaps what the corpus already shows: flatten the two lists and `examples/the-run-held-up.yaml` fails. FR-017 requires that be said rather than assumed. It is included anyway, because the corpus exists to hold what a target can run and is free to change for reasons unrelated to this rule, and a probe is here to hold the rule.
+
+---
+
+## 2. `scripts/verify.sh` — § *Examples validate against the schema*
+
+The `SCHEMA` heredoc (lines 118–172).
+
+**Add at the top of the heredoc**, beside the existing imports, in the shape `LINKS` already uses at `:901-911`:
+
+```python
+sys.path.insert(0, "scripts")
+import identity
+
+# The rule is held to its own probes before anything trusts it. Both branches that checked it
+# could be replaced with `if False:` and this gate still printed PASS — issue #72.
+wrong = identity.selftest()
+for m in wrong:
+    print(f"  FAIL  the identity rule is wrong: {m}")
+if wrong:
+    sys.exit(1)
+
+identity_lists = 0
+```
+
+**Replace lines 157–166** — the inline rule, and *not* the comment above it — with a call:
+
+```python
+        for r in doc.get("spec", {}).get("requirements", []) or []:
+            for section, cid in identity.collisions(r, identity_lists):
+                print(f"  FAIL  {f}: {r.get('name')}/{section}: duplicate criterionId {cid!r}")
+                errs = errs or [1]
+                rc = 1
+```
+
+**And replace the comment at `:155-156`** (FR-008). It reads *"criterionId is the name if set, otherwise the aggregation. The schema cannot express that fallback, so uniqueness is checked here"* — after the extraction that is a second copy of the module's own docstring **and** a false sentence, because the check is no longer here. It becomes a pointer:
+
+```python
+        # The identity rule, and why the schema cannot carry it, live in scripts/identity.py.
+```
+
+Note the boundary: the comment is lines **155–156** and the rule is **157–166**. Replacing from 156 deletes half a sentence and leaves the other half standing.
+
+**Add before `sys.exit(rc)`** — the floor, and the line that says what ran (FR-020):
+
+```python
+IDENTITY_LISTS = 5
+if identity_lists < IDENTITY_LISTS:
+    print(f"  FAIL  the identity check read {identity_lists} lists, expected at least "
+          f"{IDENTITY_LISTS} — a check that scanned nothing reads exactly like one that passed")
+    rc = 1
+elif not rc:
+    print(f"  ok    identity: {len(identity.PROBES)} probes still hold, "
+          f"{identity_lists} lists read")
+```
+
+`rc = 1` rather than `sys.exit(1)`, because the section reports every failure it finds before exiting; that is what the rest of this heredoc does.
+
+The `ok` line exists because this section had no aggregate line at all — it printed one line per file and nothing about the rule it was also applying. § *Examples are assertable by Gatling* reports its four probe counts on one line for exactly this reason, and a rule whose probes ran is worth the same sentence. Its counts are what a reviewer compares against a later release: **6 probes, 5 lists** at v0.8.0.
+
+**`selftest()` runs here and not in both consumers**, which is what `mdlinks` does: it is called in `LINKS` and not in `ISOLATION`. This section runs first, and a failure here reddens the run before the second consumer is reached.
+
+---
+
+## 3. `scripts/verify.sh` — § *The schema holds up its own examples, and still rejects*
+
+The `SELFCHECK` heredoc (lines 198–522).
+
+**Replace lines 340–350** with:
+
+```python
+sys.path.insert(0, "scripts")
+import identity
+
+root_identity_lists = 0
+for i, ex in enumerate(schema.get("examples", [])):
+    for r in (ex.get("spec", {}) or {}).get("requirements", []) or []:
+        for part, cid in identity.collisions(r, root_identity_lists):
+            print(f"  FAIL  {path}: root example {i}: {r.get('name')}/{part}: "
+                  f"duplicate criterionId {cid!r}")
+            rc = 1
+
+ROOT_IDENTITY_LISTS = 1
+if root_identity_lists < ROOT_IDENTITY_LISTS:
+    print(f"  FAIL  {path}: the identity check read {root_identity_lists} lists of the schema's "
+          f"own examples, expected at least {ROOT_IDENTITY_LISTS}")
+    rc = 1
+```
+
+The comment above the old loop — that the root examples answer to what the corpus answers to, and that the one document an editor offers first was the one nothing checked — is kept.
+
+---
+
+## 4. `AGENTS.md` § *Structure*
+
+One clause.
+
+| | |
+|---|---|
+| **Before** | ``scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`)` |
+| **After** | ``scripts/` -> the gate (`verify.sh`) and what it shares (`mdlinks.py`, `identity.py`)` |
+
+A map correction, not a rule. It rides with this commit because this commit adds the file the sentence describes.
+
+---
+
+## The seven mutations this commit makes fail
+
+Four *classes* — deleting the rule, hardening it, deleting a call site, deleting a probe — and seven mutations that exercise them. The list is the same seven [quickstart.md](../quickstart.md) § 3 runs; there is one canonical set and this is it.
+
+| Mutation | What fails |
+|---|---|
+| `duplicates()` returns `[]` always | probes 1, 2, 3, 5 — `selftest()` |
+| `duplicates()` reports every pair | probes 4, 6 — `selftest()` |
+| the `name` arm removed from `predicate_id` | probe 3, and probe 5 |
+| the per-section reset removed | probe 6, and `examples/the-run-held-up.yaml` |
+| the `SCHEMA` collisions loop dropped, every other line kept | `IDENTITY_LISTS`: `read 0 lists, expected at least 5` |
+| the `SELFCHECK` collisions loop dropped, every other line kept | `ROOT_IDENTITY_LISTS`: `read 0 lists … expected at least 1` |
+| a probe deleted | `FLOOR` |
+
+Today, every one of these is green.
+
+## Acceptance
+
+- `bash scripts/verify.sh` green, and § *Examples validate against the schema* prints `ok    identity: 6 probes still hold, 5 lists read`.
+- Each mutation above, applied alone, makes the gate exit non-zero.
+- `git diff --stat` over `examples/`, `README.md`, `GLOSSARY.md` and `schema/` is empty for this commit.

--- a/specs/011-identity-has-one-scope/contracts/identity-reach.md
+++ b/specs/011-identity-has-one-scope/contracts/identity-reach.md
@@ -1,0 +1,119 @@
+# Contract — #82: identity has no slot in a Gatling assertion
+
+**Commit**: `docs(format): identity has no slot in a Gatling assertion (#82)`
+**Files**: `README.md`, `scripts/verify.sh`
+
+The reach tables claim to partition every axis and to admit a predicate only on an exact row match. A predicate has nine keys; `name` and `displayName` have no row anywhere. This commit gives them one, on an axis that decides nothing about assertability, and adds the one probe that can show it decides nothing.
+
+**The row stops at the assertion.** A target description is what a renderer reads to turn a requirement into assertions; what Gatling does with an assertion afterwards is not something this format describes, and the row must not drift into describing it.
+
+---
+
+## 1. `README.md` § *Gatling* — a new `#### Identity`
+
+Placed **after § *Units*** and **before § *Two things Gatling cannot do at all***, with the other axes (FR-022).
+
+```markdown
+#### Identity
+
+A predicate's identity — its `name`, or the `aggregation` standing in where no `name` is set — is
+what tells it from the other predicates in its list. This axis is the one that decides nothing:
+every predicate below is assertable, and the verdict says what becomes of the key when the predicate
+is rendered, not whether the statement runs.
+
+| OpenNFR | Gatling | |
+|---|---|---|
+| `name`, and the `aggregation` that stands in for it | — | **not carried** — `Assertion` is `(path, target, condition)`, and no field of it holds a label. The predicate renders; the key does not travel with it, and two requirements that select the same requests and state the same criterion render to equal `Assertion` values |
+| `displayName` | — | **not carried**, and nothing is lost by it: the key is inert. Nothing selected, measured or compared depends on it, so a target that drops it drops nothing the format claims |
+
+**not carried** is a third verdict and says what neither of the others can: the predicate renders,
+and the key does not travel into what it renders to. It is not **cannot** — a predicate carrying a
+`name` is assertable, and a renderer refusing one would be narrowing the format to what a target
+happens to carry.
+
+**Sourced** to `io.gatling.commons.stats.assertion.Assertion`,
+read with `javap` from `gatling-shared-model` 0.0.11 — the release Gatling
+**3.13.5** pins. **Checked 2026-08-31.** That is a different version from the **3.15.1** the four
+sources above were read at, and it is named rather than rounded to match them: 3.15.1 was not
+available where this was checked. `Assertion` is byte-identical in the release Gatling 3.11.5 pins,
+so the shape held across two minors — which is what is known, and is not a claim about a third.
+```
+
+### Why each part
+
+| Part | Requirement | Why |
+|---|---|---|
+| the axis covers the `aggregation` fallback, not just `name` | FR-023 | an unnamed predicate still has an identity, and it is the arm every published document uses |
+| the reason stops at `Assertion` | FR-025 | `AssertionResult` and `AssertionMessage` were read too ([research.md](../research.md) R1) and are **left out**: they are about what a target does with an assertion, and a target description says what a renderer produces, not what happens to it afterwards. The claim needs only the three fields and the absence of a fourth |
+| the version is 3.13.5 and the difference is stated | FR-026 | Principle IV wants the version read and the date checked. Borrowing the header's 3.15.1 would date a claim at a version nobody opened, which is the defect the row is being written to fix |
+| `displayName` gets its own row and its own reason | FR-027 | it is the second key the partition claim was false for. #82 argues it needs no row *because* it is inert; the row is how "inert" gets said and the partition gets fixed at once |
+| **not carried** is explained under the table | FR-024 | a third verdict in a target's description is a cost, and a reader meeting it needs to know it is not a softer **cannot** |
+
+`AssertionModel.scala`, where `Assertion` is defined, is **already** among the four sources § *Gatling*'s header names. The section gains a differently dated reading of a file it already cites, not a new source.
+
+---
+
+## 2. `README.md` § *How these tables are applied*
+
+Added after the existing paragraph beginning **"The tables partition each axis."** (line 726).
+
+```markdown
+All nine of a predicate's keys now have a row. Seven decide whether it is assertable — `metric`,
+`aggregation`, `op`, `threshold`, `unit`, `bad`, `good` — and the two on the Identity axis do not,
+which is why their verdict is **not carried** rather than **can** or **cannot**. The gate therefore
+implements no rejection from that axis, and the one thing there is to check about it is that it
+rejects nothing: `PREDICATE_RENDERS` carries a predicate with a `name`, and it renders.
+```
+
+FR-028. The claim stops being false without being narrowed, and the sentence says where the gate stands, so a reader does not have to infer that an axis with no rejection is an axis with no implementation.
+
+---
+
+## 3. `scripts/verify.sh` — one rendering probe, one floor
+
+Nothing in the repository puts a `name` on a predicate: not the 10 corpus predicates, not the schema's root example, not one of the 24 `PREDICATE_PROBES` and `PREDICATE_RENDERS` entries ([research.md](../research.md) R7). A line added to `predicate_why` refusing a `name` would be caught by nothing.
+
+**`PREDICATE_RENDERS` gains one entry**, beside the existing base:
+
+```python
+    {**RENDERABLE, "name": "p95-latency"},
+```
+
+**The floor beside it goes 14 → 15**:
+
+```python
+FLOORS = [("rejection", SELECTION_PROBES, 10), ("rendering", SELECTION_RENDERS, 5),
+          ("predicate rejection", PREDICATE_PROBES, 10), ("predicate rendering", PREDICATE_RENDERS, 15)]
+```
+
+**And a sentence joins the comment above `PREDICATE_RENDERS`**, in the register the existing ones use:
+
+```python
+# The `name` entry is the Identity axis's only probe, and it is a rendering one because that axis
+# rejects nothing: `predicate_why` never reads the key, and nothing else in the repository carries
+# one — not a corpus document, not a probe. A rejection added on `name` would otherwise be caught
+# by nothing at all.
+```
+
+`verify.sh:826` already states the cost as a rule — *"Adding a probe means raising the number beside it, which is the intended cost"* — and it is paid here rather than waived (FR-030).
+
+**No rejection is added** (FR-031). `predicate_why` is untouched: it reads `metric`, `aggregation`, `op`, `threshold`, `unit`, `bad` and `good`, and that is the behaviour the row publishes.
+
+---
+
+## What this commit does **not** touch
+
+| | Why |
+|---|---|
+| `GLOSSARY.md` | the row records what a target does with an existing term and introduces none (FR-032) |
+| `examples/` | unchanged, as throughout the milestone |
+| the § *Gatling* header's version and dates | it stays at 3.15.1 for its four sources. The Identity row carries its own, and says why they differ |
+| § *Two things Gatling cannot do at all* | it keeps its name. Identity is not a third thing Gatling cannot do — the assertion runs — which is why it is an axis and not a bullet there |
+| `predicate_why` | see FR-031 |
+
+## Acceptance
+
+- `bash scripts/verify.sh` green, and § *Examples are assertable by Gatling* reports **15** predicate rendering probes.
+- Adding `if "name" in p: why.append(...)` to `predicate_why` makes the gate exit non-zero. Today it does not.
+- Listing the nine predicate keys against the reach section leaves none unaddressed.
+- The Identity row states a Gatling version and a date, and a reader can tell they are not the header's.

--- a/specs/011-identity-has-one-scope/contracts/identity-scope.md
+++ b/specs/011-identity-has-one-scope/contracts/identity-scope.md
@@ -1,0 +1,158 @@
+# Contract — #58: one scope, and one place that states it
+
+**Commit**: `fix(format): identity is unique within one list (#58)`
+**Files**: `README.md`, `schema/opennfr.io/v1/requirementset.schema.json`, `GLOSSARY.md`
+**No gate change.** `scripts/verify.sh` already implements this reading; #72 is what makes it fire.
+
+---
+
+## 1. `README.md` § *A predicate* — the one home
+
+Replaces lines **357–367** in full.
+
+### Before
+
+```markdown
+**`name`.** Needed only when two predicates of one requirement would otherwise be
+indistinguishable. Identity is the `name` if set, and the `aggregation` otherwise:
+
+```yaml
+guards:   [{aggregation: rate, op: gte, threshold: 200, unit: "{request}/s"}]
+criteria: [{aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}]
+# both identities are "rate" — one of them must be named
+```
+
+JSON Schema cannot express that fallback, so uniqueness is checked by `scripts/verify.sh`.
+`criteria` and `guards` are checked separately: a guard and a criterion may both be `rate`.
+```
+
+### After
+
+```markdown
+**`name`.** Needed only when two predicates of one list would otherwise be indistinguishable.
+Identity is the `name` if set, and the `aggregation` otherwise, and it must be unique
+**within one list** — `criteria` and `guards` are counted apart:
+
+```yaml
+criteria:
+  - {bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5,   unit: "%"}
+  - {name: request-rate,     aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}
+# both identities would be "rate" — one is named, and either one could have been
+```
+
+A guard and a criterion may share an identity, because they are two lists.
+`examples/the-run-held-up.yaml` states an unnamed `rate` guard beside an unnamed `rate` criterion
+and is correct: one says the run reached the load it assumed, the other says what share of it
+failed, and the shape of each is what tells them apart. JSON Schema cannot express the fallback, so
+uniqueness is checked by `scripts/verify.sh`.
+```
+
+### What each edit is for
+
+| Edit | Requirement | Why |
+|---|---|---|
+| *"of one requirement"* → *"of one list"* | FR-003 | the sentence named the scope this milestone removes |
+| *"and it must be unique within one list"* added | FR-002 | the scope is now stated here, because it is stated nowhere else |
+| the snippet's collision moves into `criteria` | FR-003 | its old collision was a guard against a criterion, which the sentence below it permits — it taught the rule being removed |
+| the snippet shows the resolved form | FR-003 | `# one is named, and either one could have been` states the rule and the freedom in one line |
+| `examples/the-run-held-up.yaml` named | FR-005 | the exemption is the part a reader is likeliest to take for an oversight, and the corpus is where it is already load-bearing |
+
+### Renderability of the new snippet
+
+FR-004. Both predicates match a **can** row exactly ([research.md](../research.md) R8):
+
+| Predicate | Gatling | Verdict |
+|---|---|---|
+| `{bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5, unit: "%"}` | `failedRequests.percent` | **can** |
+| `{aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}` | `requestsPerSec` | **can** |
+
+Both shapes are already in `PREDICATE_RENDERS`, so the illustration is of a document the gate would accept — which the example it replaces was only by accident.
+
+---
+
+## 2. `schema/opennfr.io/v1/requirementset.schema.json` — `$defs/predicate.name`
+
+One string, at line **130**.
+
+### Before
+
+```json
+"description": "Optional. Identifies this predicate in a report; without it the aggregation is the identifier, so two predicates in one requirement may not then share an aggregation."
+```
+
+### After
+
+```json
+"description": "Optional. Distinguishes this predicate from the others beside it; without it the aggregation is the identifier. What the identity must be unique within is in README.md; JSON Schema cannot express the fallback, so scripts/verify.sh checks it."
+```
+
+**Why a pointer and not a corrected copy** (FR-006). The schema does not decide this rule — it says so itself, and has since the rule existed. A description that restates a scope it cannot enforce is a copy that nothing keeps in step, which is how this one came to disagree with the document that does state it. `$defs/unit` already uses the shape: *"Closed list, from README.md."*
+
+**And it stops saying "in a report"** (FR-006a). That phrase is the last downstream claim in the schema: a report is something a consumer builds out of results, and this format describes neither results nor consumers — a renderer turns a requirement into a target's assertions and stops. What `name` actually does is distinguish a predicate from the ones beside it, which is a fact about the document and is what a field description is for. It rides here because it is the same sentence #58 is rewriting.
+
+The description keeps three things: that the key is optional, what it distinguishes, and that the aggregation stands in when it is absent.
+
+---
+
+## 3. `GLOSSARY.md` § *criterionId*
+
+Lines **200–207**.
+
+### Before
+
+```markdown
+### criterionId
+
+The identity of a predicate within one requirement: its `name` if set, otherwise its `aggregation`.
+Two predicates in the same list may not share one. JSON Schema cannot express that fallback, so the
+gate checks it.
+
+*Rejected*: requiring `name` on every predicate — a name is noise where `p99` and `max` already
+distinguish two statements.
+```
+
+### After
+
+```markdown
+### criterionId
+
+The identity of a predicate: its `name` if set, otherwise its `aggregation`. What it must be unique
+within is stated in [README.md](README.md) § *A predicate*; JSON Schema cannot express that
+fallback, so the gate checks it.
+
+*Rejected*: requiring `name` on every predicate — a name is noise where `p99` and `max` already
+distinguish two statements. *Rejected*: scoping uniqueness to the whole requirement rather than to
+one list — `rate` over the requests and `rate` over a fraction are different quantities sharing a
+word, the predicate's own shape already tells them apart, and the wider scope would force a name
+onto a collision that is only lexical, which is the same noise the first rejection refuses.
+```
+
+### What each edit is for
+
+| Edit | Requirement | Why |
+|---|---|---|
+| *"within one requirement"* leaves the definition | FR-007 | it was the entry's own contradiction: the definition said requirement, the rule two lines later said list |
+| *"Two predicates in the same list may not share one"* → a pointer | FR-007 | the rule has one home, and this is not it |
+| a second *Rejected* line | FR-007, Principle I | the requirement scope is the alternative this milestone refuses, and Principle I says the rejection outlives the term it protects |
+| the derivation stays | — | it is the definition, and defining the term is what this page is for |
+
+**The link style** matches the page's own: `[README.md](README.md)` as at `GLOSSARY.md:7`, with the section named in prose as `§ *A predicate*`. No anchor is written, because nothing in the repository resolves one.
+
+---
+
+## What this commit does **not** touch
+
+| | Why |
+|---|---|
+| `examples/` | every published document is already valid under this reading (FR-009). `the-run-held-up.yaml` keeps both unnamed `rate` predicates |
+| `scripts/verify.sh` | it implements this reading today. Making it *fire* is #72 |
+| `README.md:546` | *"That two predicates have distinct identities. The gate checks it; the schema cannot"* states which artifact checks the rule, not what the rule is (FR-010). #72 makes it true |
+| `README.md` § `criteria` and `guards` — one shape, two meanings | its snippet names a guard `reached-target-rate` beside a `p95` criterion. No collision, so nothing in it depends on the scope |
+| the `name` pattern, length or optionality | unchanged (FR-011) |
+
+## Acceptance
+
+- `bash scripts/verify.sh` green.
+- `git diff --stat` over `examples/` is empty.
+- Searching the repository for a statement of what an identity is unique within returns exactly one: `README.md` § *A predicate*.
+- Deleting that paragraph leaves no other document making the claim.

--- a/specs/011-identity-has-one-scope/data-model.md
+++ b/specs/011-identity-has-one-scope/data-model.md
@@ -1,0 +1,120 @@
+# Phase 1 — Data Model: Identity Has One Scope
+
+**Feature**: `011-identity-has-one-scope` | **Date**: 2026-08-31 | **Spec**: [spec.md](spec.md)
+
+No field is added, removed or retyped. What this milestone changes is what an existing derived value is **scoped to**, what **checks** it, and what a target does with it. The entities below are the ones that scope, check and description each name.
+
+---
+
+## Identity (`criterionId`)
+
+**What it is**: what tells one predicate from the others in its list.
+
+| | |
+|---|---|
+| **Derivation** | the predicate's `name` if set, its `aggregation` otherwise |
+| **Type** | string. The `name` arm matches `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` and is at most 253 characters; the `aggregation` arm is one of the closed set or a percentile matching `^p\d{1,2}(\.\d+)?$` |
+| **Unique within** | **one list** — after #58. `criteria` and `guards` are two lists |
+| **Stated in** | `README.md` § *A predicate*, and nowhere else |
+| **Checked by** | `scripts/verify.sh`, through `scripts/identity.py` |
+| **Defined in** | `GLOSSARY.md` § *criterionId* |
+| **Expressible in JSON Schema** | no. The fallback is a conditional over two keys and a set membership across siblings |
+
+**The two arms are one namespace.** `name: rate` beside an unnamed `rate` collides, because both predicates produce the identity `rate`. This falls out of the derivation rather than being an extra rule, and probe 5 exists so nothing quietly turns it into two namespaces.
+
+**It is unique within a list, not within a document.** `(requirement.name, list, criterionId)` is what is unique across a whole document, and that is what "unique within one list" amounts to. It is why the flagship example is legal — its two `rate` predicates differ in the middle component.
+
+**Not a field.** `criterionId` never appears in a document. It is a derived value with a name, which is why it has a `GLOSSARY.md` entry and no schema property.
+
+---
+
+## A list
+
+**What it is**: `criteria` or `guards` on one requirement — the unit an identity is unique within.
+
+| | |
+|---|---|
+| **Members** | predicates, structurally identical between the two lists |
+| **Cardinality** | `criteria` is required and `minItems: 1`; `guards` is optional and, when present, `minItems: 1` |
+| **Meaning of the split** | a violated criterion says *the system did not hold*; a violated guard says *the run did not happen as intended* |
+| **In the corpus** | 5 lists across 4 requirements, holding 10 predicates |
+
+**Why the list and not the requirement.** `rate` over the requests, `rate` over a metric's observations and `rate` over a fraction are three quantities under one word, and `README.md` § *A predicate* already says the predicate's shape decides which. Two of them meeting inside one requirement is a lexical coincidence, not an ambiguous document — and the two lists are already statements about different things, a guard about whether the run happened and a criterion about whether the system held.
+
+---
+
+## A predicate's nine keys, against the reach axes
+
+The reach section claims to partition every axis. After #82 it does.
+
+| Key | Axis | Decides assertability |
+|---|---|---|
+| `metric` | Metrics | yes |
+| `aggregation` | Aggregations | yes |
+| `op` | Operators | yes |
+| `unit` | Units | yes |
+| `threshold` | Units — the integer-target rule | yes |
+| `bad` | Aggregations — the fraction rows | yes |
+| `good` | Aggregations — the fraction rows | yes |
+| `name` | **Identity** *(new)* | **no** |
+| `displayName` | **Identity** *(new)* | **no** |
+
+Seven decide; two do not. The two that do not are the two that had no row.
+
+---
+
+## A reach row
+
+**What it is**: one line of a target's description, matched exactly, carrying a verdict and a reason.
+
+| Verdict | Means | Gate behaviour |
+|---|---|---|
+| **can** | the target asserts this exactly | `predicate_why` returns no reason |
+| **cannot** | the target has no correspondence | `predicate_why` returns the row's reason |
+| **not carried** *(new)* | the predicate renders; the key does not travel into the assertion | `predicate_why` returns no reason, and never reads the key |
+
+**not carried** is not a weaker **cannot**. A predicate carrying a `name` is assertable, and a gate that started refusing one would be narrowing the format to what a target happens to carry — which is what `scripts/verify.sh` is explicitly forbidden from doing.
+
+**It says nothing about what the target does afterwards.** A target description is what a renderer reads to produce assertions. Where an assertion goes, how a target reports it and what a consumer makes of it are outside this page, and the row stops at the boundary.
+
+---
+
+## The identity check
+
+**What it is**: the rule `README.md` states, implemented once and reached from two places.
+
+| | |
+|---|---|
+| **Home** | `scripts/identity.py` |
+| **Surface** | `predicate_id(predicate)`, `collisions(requirement, scanned)`, `duplicates(requirement)`, `selftest()` |
+| **Consumers** | `scripts/verify.sh` § *Examples validate against the schema* (over `examples/*.yaml`) and § *The schema holds up its own examples, and still rejects* (over the schema's root `examples`) |
+| **Why a module** | the two consumers are separate `python3` heredocs — separate processes. `scripts/mdlinks.py` is the same problem, solved the same way, for the reason its own comment gives |
+| **Trusted after** | `selftest()` returns empty. Called before the first consumer uses it, as `mdlinks.selftest()` is |
+
+---
+
+## An identity probe
+
+**What it is**: a requirement paired with the collisions `duplicates()` must report for it.
+
+| | |
+|---|---|
+| **Shape** | `(requirement, expected, why)` where `expected` is a list of `(list, criterionId)` |
+| **Directions** | both. Four probes must report a collision; two must report none |
+| **Count** | 6, floored at 6 |
+| **Floor message** | *a rule nothing probes is a rule nothing checks* — the sentence `scripts/verify.sh` already uses |
+
+The classes each probe is the sole catcher of are in [research.md](research.md) R4.
+
+---
+
+## A counted scan
+
+**What it is**: what fails when a *call site* is deleted rather than a rule.
+
+| Site | Unit counted | Today | Floor |
+|---|---|---|---|
+| `examples/*.yaml` | lists offered to the check | 5 | 5 |
+| the schema's root `examples` | lists offered to the check | 1 | 1 |
+
+Probes cannot catch this: they call the module directly, and a deleted call leaves them green. Principle III requires it in terms — *any check that scanned nothing MUST say so* — and `scripts/verify.sh` already does the same thing twice, at `EXAMPLES = 20` and at the isolation section's `scanned`.

--- a/specs/011-identity-has-one-scope/plan.md
+++ b/specs/011-identity-has-one-scope/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Identity Has One Scope
+
+**Branch**: `011-identity-has-one-scope` | **Date**: 2026-08-31 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/011-identity-has-one-scope/spec.md`
+
+## Summary
+
+Milestone **v0.8.0**, three issues, one question under all of them: *what tells two statements in one document apart?*
+
+The milestone stays inside what a renderer does — turning a requirement document into a target's assertions. Nothing here describes a report, a verdict, or anything a consumer builds after the run.
+
+- **#58**: identity is scoped to the requirement by the schema and to the list by `README.md`, the gate and the corpus. [research.md](research.md) R2 found seven sites, and two documents that each state both readings. The list wins, the schema's sentence is the one that changes, and the rule ends up in one place with the others naming it. The same sentence also stops saying the key identifies the predicate *"in a report"* (**FR-006a**) — a report is downstream of the assertions a renderer produces, this format describes neither, and it is the last downstream claim the schema carries.
+- **#72**: both uniqueness branches can be replaced with `if False:` and the gate still prints **PASS**. No document anywhere carries a colliding identity, and no predicate anywhere carries a `name`, so the `name` arm of the fallback has never been observed by anything. It gets what its two struck neighbours got in v0.6.0: probes that fire, in both directions, and a floor.
+- **#82**: the reach tables claim to partition every axis; two of the nine predicate keys have no row. Gatling's `Assertion` is `(path, target, condition)` and has no field that holds a label, so the key does not travel into what the predicate renders to. A new axis says so, and says nothing about what Gatling does afterwards.
+
+**The work is six files.** `README.md` (a rewritten `name` paragraph, a new `#### Identity` subsection, one sentence in § *How these tables are applied*), `schema/…/requirementset.schema.json` (one description), `GLOSSARY.md` (one entry), `scripts/verify.sh` (two call sites, two counted floors, one probe table, one rendering probe), a new `scripts/identity.py`, and one clause of `AGENTS.md` § *Structure*.
+
+**`examples/` does not change**, and that is the point rather than a convenience: every published document is already valid under the reading this milestone settles on, and the corpus is not where coverage gets installed.
+
+The plan's three load-bearing decisions:
+
+- **The rule gets one home.** `README.md` § *A predicate* states the scope. The schema's `name` description and `GLOSSARY.md` § *criterionId* say what identity *is* and name where its uniqueness is decided, in the shape `$defs/unit`'s description already uses for the unit enumeration. Four corrected copies was the alternative and is the state #58 describes.
+- **Nothing here describes what happens after an assertion.** A renderer turns a requirement into a target's assertions; reports, verdicts and what a consumer builds from a failure are outside the surface. This is why FR-006a strips *"in a report"* from the schema, why the Identity row's reason stops at `Assertion`'s three fields, and why `AssertionResult` and `AssertionMessage` were read (R1) and deliberately left out of `README.md`.
+- **One implementation, in a module, because two processes need it.** The identity checks are in separate `python3` heredocs (R3). `scripts/mdlinks.py` is the same problem already solved in this file, with a `selftest()` and its own fixture floor, and its comment gives this milestone's motive verbatim. `scripts/identity.py` follows it.
+- **The Identity row is dated at 3.13.5, which is what was read.** R1 could not open 3.15.1 here and a download was declined. `Assertion` was read with `javap` from the jar Gatling 3.13.5 pins, and is byte-identical to the one 3.11.5 pins. The row says so and does not borrow the header's version number.
+
+## Technical Context
+
+**Language/Version**: none for the format. The gate is POSIX `bash` driving `python3` heredocs; `scripts/mdlinks.py` and the new `scripts/identity.py` are plain Python 3 modules with no dependencies beyond the standard library. The gate's own dependencies are `jsonschema` and `pyyaml`, both already required.
+
+**Primary Dependencies**: unchanged. Nothing is added to the gate's imports.
+
+**Storage**: N/A.
+
+**Testing**: `bash scripts/verify.sh` is the only gate, and this feature adds to two of its sections. There is no test runner and nothing to compile.
+
+**Target Platform**: N/A — the artifacts are a JSON Schema, three markdown documents and a shell gate.
+
+**Project Type**: format specification with a validating gate.
+
+**Performance Goals**: N/A. The gate reads four YAML documents and one schema.
+
+**Constraints**: `examples/` is byte-identical before and after. No compatibility-sensitive surface is touched: no borrowed OpenTelemetry name changes, and no field name appearing in a published example is added, removed or renamed. `git rm -r docs && bash scripts/verify.sh` stays green.
+
+**Scale/Scope**: six files. One new module of roughly the size of `mdlinks.py`'s core, one new README subsection with two rows, one rewritten paragraph, two edited descriptions, six new probes, three new floors and one raised floor.
+
+**External claim**: one, and it is the milestone's stated risk. Gatling's `Assertion` field list, read at 3.13.5 on 2026-08-31 — R1.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 research and re-evaluated after Phase 1 design. Both passes recorded.*
+
+See `.specify/memory/constitution.md` (v4.0.0).
+
+- [x] **I. Vocabulary Before Features** — no term is introduced and none is renamed. `criterionId`, `name` and `displayName` all exist and keep their spellings. `GLOSSARY.md` § *criterionId* is edited because its **scope** changes, which Development Workflow requires in the same PR, and the edit adds a second *Rejected* line recording the requirement scope and why it was refused. The naming disagreement that is **not** settled here — whether `criterionId` should be `predicateId`, since it names the identity of a guard too — is in spec § *Out of Scope* with the reason: Principle I requires it be argued in an issue before files change, and no issue argues it.
+- [x] **II. Borrow Names, Never Invent Them** — no metric or attribute name is touched. `not carried` is a table verdict in a target's description, not a name a document may contain, and it classifies a target's behaviour rather than a quantity. No alias, no derived or composite quantity.
+- [x] **III. No Silent Green** — this principle is the whole of #72, and the feature is written from it. Every check added fails rather than skips: `scripts/identity.py` carries a `selftest()` called before either site trusts it, with a floor on its own fixtures (R3); both call sites count the lists they scanned and floor the count, so a deleted call site fails instead of scanning nothing (R5); the probe table carries an exact floor. The one claim `README.md:546` makes about the gate becomes true rather than merely stated.
+- [x] **IV. Honest Status** — the one external claim carries its source, its artifact and its date, and names the version it was **actually** read at rather than the one the section header carries. The difference is stated on the page (R1), not left for a reader to reconcile. Nothing is described as checked that is not. FR-006a belongs to this principle too: a field description claiming the key identifies a predicate *"in a report"* describes machinery this repository does not have and does not build, which is a document reading as more settled than it is.
+- [x] **V. Structure Over Grammar** — no field is added and no value set changes. `name` keeps its pattern and its optionality. The uniqueness rule remains what it has always been: something JSON Schema cannot express, checked by the gate and said so in both places.
+- [x] **VI. The Requirement Is Target-Blind** — no requirement document names a target; `examples/` does not change at all. The new `#### Identity` subsection is part of `README.md` § *What any tool can actually run*, which is the **one** description Gatling has, and no second copy is created. The gate implements the section and carries no copy of its rows: FR-029's probe exercises `predicate_why`, the same function the corpus is judged by, and asserts only that the axis rejects nothing. Adding this axis changes no format, no schema and no published corpus.
+- [x] **VII** — *withdrawn in 3.0.0. No gate.*
+- [x] **VIII. Ideas Are Parked, Not Merged** — nothing under `docs/` is touched, no construct is proposed or parked, and no document outside `docs/` gains a link into it. `git rm -r docs && bash scripts/verify.sh` is unaffected.
+- [x] **Compatibility** — no borrowed OpenTelemetry name is touched. No field name in a published example is added, removed or renamed: `name` is an existing optional predicate key whose *description* changes and whose published usage stays exactly as it is. No construct enters the format, so the "at least one surveyed target can assert it exactly" bar has nothing to clear. The published corpus does not narrow.
+
+**Post-Phase-1 re-check**: unchanged, with three things later passes made explicit and none a violation.
+
+1. `scripts/identity.py` is a new file under `scripts/`. `AGENTS.md` § *Structure* describes that directory as the gate "and what it shares (`mdlinks.py`)"; with a second shared module the parenthetical names half of what it names, so it gains one clause. That is a map correction to a non-normative sentence, not a rule change, and it is disclosed here because a new file in a five-file repository is not a detail.
+2. The Identity row is dated 3.13.5 while § *Gatling*'s header is dated 3.15.1. Principle IV is satisfied by saying so on the page, and the row's source file — `AssertionModel.scala` — is one the header already lists, so the section gains a differently dated reading rather than a new source.
+3. `/speckit-analyze` found FR-008 resting on a premise the module extraction removes: it required the gate's inline comment to survive, and after #72 that comment is both a second copy of `scripts/identity.py`'s docstring and a false sentence — *"uniqueness is checked here"*. The reason now travels with the implementation. Keeping the comment would have reproduced #58 inside the commit that closes #72, which is Principle I's cost argument pointed at a code comment.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-identity-has-one-scope/
+├── spec.md
+├── plan.md                     # this file
+├── research.md                 # Phase 0 — eight questions, two changed a requirement
+├── data-model.md               # Phase 1 — identity, the list, the axis, the probe
+├── quickstart.md               # Phase 1 — how to check the milestone landed
+├── contracts/
+│   ├── identity-scope.md       # the exact text of the one home and the two pointers  (#58)
+│   ├── identity-module.md      # the shared module's surface and the probe table      (#72)
+│   └── identity-reach.md       # the exact #### Identity subsection                   (#82)
+└── checklists/
+    └── requirements.md
+```
+
+### Repository (what this feature edits)
+
+```text
+README.md                                      # § A predicate — the one home; new #### Identity;
+                                               #   one sentence in § How these tables are applied
+GLOSSARY.md                                    # § criterionId — definition + a second Rejected line
+schema/opennfr.io/v1/requirementset.schema.json # $defs/predicate.name — one description
+scripts/verify.sh                              # two call sites, two counted floors, IDENTITY_PROBES
+                                               #   and its floor, one PREDICATE_RENDERS entry, 14 -> 15
+scripts/identity.py                            # NEW — predicate_id, collisions, duplicates, selftest, floor
+AGENTS.md                                      # § Structure — one clause names the second shared module
+
+# untouched, and checked to be untouched (quickstart step 1)
+examples/                                      # byte-identical; every document keeps its verdict
+docs/                                          # no idea added, moved or edited
+.specify/memory/constitution.md                # stays at 4.0.0; no amendment is needed
+specs/                                         # except this feature's own directory
+```
+
+**Structure Decision**: the repository has no source tree. The format is `schema/`, explained by `README.md`, its terms in `GLOSSARY.md`, its corpus in `examples/`, and its gate in `scripts/`. This feature edits four of those five and adds one module beside the gate; `examples/` is deliberately untouched.
+
+## Implementation Order
+
+Three commits, one per issue, in the milestone's own order, preceded by the spec commit. Each is green on its own.
+
+1. **`docs(speckit): add 011-identity-has-one-scope spec/plan/tasks`** — this directory.
+2. **`fix(format): identity is unique within one list (#58)`** — `README.md` § *A predicate*, `schema/…:130`, `GLOSSARY.md` § *criterionId*. No gate change: the gate already implements this reading. The contract is [contracts/identity-scope.md](contracts/identity-scope.md).
+3. **`fix(gate): the identity rule is probed in both directions (#72)`** — `scripts/identity.py`, both call sites, the counted floors, `IDENTITY_PROBES` and its floor, `AGENTS.md` § *Structure*. The contract is [contracts/identity-module.md](contracts/identity-module.md).
+4. **`docs(format): identity has no slot in a Gatling assertion (#82)`** — `README.md` § *Identity* and § *How these tables are applied*, one `PREDICATE_RENDERS` entry and its floor. The contract is [contracts/identity-reach.md](contracts/identity-reach.md).
+
+#58 is first because #72's probes encode its answer and #82's row describes an identity that has to mean one thing. `AGENTS.md` rides with #72 because it is that commit that adds the file the sentence describes.
+
+## Complexity Tracking
+
+> Two costs are paid deliberately. Neither is a Constitution Check violation; both are recorded because a reviewer should meet them here rather than find them in a diff.
+
+| Cost | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| A new file, `scripts/identity.py` | The two identity checks are in separate `python3` heredocs, so one implementation reachable from both must be a module on disk (R3). Spec FR-019 forbids a second implementation for probes to call. | **Duplicating the function into both heredocs** is #58 reproduced one directory over — two copies of one rule, free to drift, which is the defect this milestone exists to remove. **Moving the schema's root-example check into the `SCHEMA` heredoc** needs no new file and was rejected too: it takes a check out of the section named for checking the schema's own examples, so both sections' summary lines stop describing what they ran. `scripts/mdlinks.py` is the same problem solved the same way, and its comment states this milestone's motive. |
+| A third verdict in a target's description | **can** and **cannot** answer "is this assertable". The identity axis answers "what becomes of this key when the predicate is rendered", and the predicate is assertable either way. A **cannot** row would tell a renderer to reject a predicate carrying a `name`, which is wrong and would narrow the format to what a target happens to carry. | **A third bullet under § *Two things Gatling cannot do at all*** misfiles it: nothing there is about a key surviving, and both entries there change a verdict. **Narrowing the partition claim** to "axes that decide assertability" fixes the false sentence by promising less, and leaves the fact a renderer needs stated in passing rather than as a row with a reason — which is how `good`, `sum`, `neq` and `bad: {}` are handled and is the standard the section already sets. |

--- a/specs/011-identity-has-one-scope/quickstart.md
+++ b/specs/011-identity-has-one-scope/quickstart.md
@@ -1,0 +1,216 @@
+# Quickstart — Validating: Identity Has One Scope
+
+**Feature**: `011-identity-has-one-scope` | **Date**: 2026-08-31 | **Spec**: [spec.md](spec.md)
+
+How to check that the milestone landed. Every step below is runnable from the repository root, and every claim it makes is decidable without opening Gatling — except step 5, which says so.
+
+**Prerequisites**: `python3` with `jsonschema` and `pyyaml`, and `bash`. Nothing else; there is nothing to build.
+
+---
+
+## 0. Baseline — the gate is green and stays green
+
+```bash
+bash scripts/verify.sh
+```
+
+Expected: `PASS`, at **every** commit of the pull request, not only the last (FR-033).
+
+Two lines in that output are new. § *Examples validate against the schema* ends with:
+
+```text
+  ok    identity: 6 probes still hold, 5 lists read
+```
+
+and § *Examples are assertable by Gatling* reports **15** predicate rendering probes where it reported 14:
+
+```text
+  ok    10 predicates assertable by Gatling, 10 selection probes still rejected, 5 still rendered, 10 predicate probes still rejected, 15 still rendered
+```
+
+---
+
+## 1. The corpus did not move
+
+```bash
+git diff --stat main -- examples/
+```
+
+Expected: **empty** (FR-009, FR-021). Every published document is already valid under the reading this milestone settles on, and the corpus is not where coverage gets installed.
+
+And the whole diff is six files plus this directory (FR-034):
+
+```bash
+git diff --name-only main | grep -v '^specs/011-'
+```
+
+Expected exactly:
+
+```text
+AGENTS.md
+GLOSSARY.md
+README.md
+schema/opennfr.io/v1/requirementset.schema.json
+scripts/identity.py
+scripts/verify.sh
+```
+
+---
+
+## 2. #58 — the scope is stated once, and it is the list
+
+**a. Exactly one place states it.**
+
+```bash
+grep -rn "within one list" README.md GLOSSARY.md schema/ scripts/
+```
+
+Expected: one hit, in `README.md` § *A predicate*. The schema's `name` description and `GLOSSARY.md` § *criterionId* name that section without repeating the rule.
+
+**b. Nothing still says "requirement".**
+
+```bash
+grep -rn "in one requirement\|of one requirement\|within one requirement" \
+  README.md GLOSSARY.md schema/opennfr.io/v1/requirementset.schema.json
+```
+
+Expected: **no hits**. Three sites carried that wording before this milestone ([research.md](research.md) R2).
+
+**c. The flagship example is valid under the schema's own description.**
+
+```bash
+python3 - <<'PY'
+import json, yaml
+schema = json.load(open("schema/opennfr.io/v1/requirementset.schema.json"))
+print(schema["$defs"]["predicate"]["properties"]["name"]["description"])
+doc = next(yaml.safe_load_all(open("examples/the-run-held-up.yaml")))
+r = doc["spec"]["requirements"][0]
+for sec in ("criteria", "guards"):
+    print(sec, [p.get("name") or p.get("aggregation") for p in r.get(sec, [])])
+PY
+```
+
+Expected: the description defers the scope to `README.md`, and the two lists print `['p99', 'rate']` and `['rate']` — two `rate` identities in one requirement, in two lists, and nothing in the repository calls that malformed.
+
+**d. Read the two paragraphs back to back.** `README.md` § *A predicate*'s worked example and the sentence below it. The example's collision must be one the sentence forbids. Before this milestone it was one the sentence permits.
+
+---
+
+## 3. #72 — the rule fires, in both directions
+
+Each mutation below is applied **alone**, the gate is run, and it must exit non-zero. Undo before the next. **Mutate one line, not two**: an earlier version of row 5 said "delete the call", which readers took to include the counting line beside it — and with both gone the floor fired for the wrong reason, hiding that the check alone could be dropped green.
+
+| # | Mutation | Expected failure |
+|---|---|---|
+| 1 | in `scripts/identity.py`, make `duplicates()` `return []` | probes 1, 2, 3, 5 — `the identity rule is wrong: …` |
+| 2 | make `duplicates()` report every pair it sees | probes 4 and 6 |
+| 3 | in `predicate_id`, drop the `name` arm: `return predicate.get("aggregation")` | probes 3 and 5 |
+| 4 | move `seen = set()` above the `for section` loop | probe 6, **and** `examples/the-run-held-up.yaml` |
+| 5 | in the `SCHEMA` heredoc, replace the `identity.collisions(r, identity_lists)` loop with an empty iterable, **keeping every other line** | the counted floor: `read 0 lists, expected at least 5`. The count is appended to by `collisions` while it is consumed, so dropping the loop drops the count with it |
+| 6 | the same, for the root-example loop in the `SELFCHECK` heredoc | its own floor: `read 0 lists … expected at least 1` |
+| 7 | delete any one entry from `PROBES` | `the probe list has shrunk to 5, expected at least 6` |
+| 8 | drop `pairing_why` from `render_why` | the four pairing rejection probes, which go through the composite the corpus is judged by, not through `pairing_why` alone |
+| 9 | rename `GROUP_METRIC` | the README anchor: the gate's metric names must be names the page publishes |
+
+**Every one of these is green at `7cf314a`.** That is the whole of #72: the rule was stated, claimed in `README.md` § *What the schema does not check*, and enforced by nothing that could notice its absence.
+
+Revert between mutations with a checkout rather than the stash — this repository is worked in several worktrees at once and the stash stack is shared:
+
+```bash
+git checkout -- scripts/identity.py scripts/verify.sh
+```
+
+---
+
+## 4. #82 — the axis exists and rejects nothing
+
+**a. Every axis exists, and the two keys that had none are on it.**
+
+A word-match over the section decides this in neither direction, which the baseline run proved:
+`aggregation`, `threshold` and `unit` are written as headings or inside `threshold: 0.5, unit: ms`
+and never as a bare backticked token, so a strict match calls three renderable axes missing; while
+`name` appears all through the Selection table as `loadtest.request.name` and `loadtest.group.name`,
+which are selector attributes and not the predicate key, so a loose match passes before the row
+exists. The check is structural instead — the axes are subsections, and the two keys must be rows of
+the new one:
+
+```bash
+python3 - <<'PY'
+import re
+reach = open("README.md").read().split("## What any tool can actually run", 1)[1]
+print("subsections:", re.findall(r'^#### (.+)$', reach, re.M))
+ident = reach.split("#### Identity", 1)[1].split("\n#### ", 1)[0] if "#### Identity" in reach else ""
+for k in ("name", "displayName"):
+    print(f"  {k:12} {'on the Identity axis' if f'`{k}`' in ident else 'MISSING'}")
+PY
+```
+
+Expected: six axis subsections — Selection, Metrics, Aggregations, Operators, Units, **Identity** —
+and neither key `MISSING`. Before this milestone there were five and both were missing.
+
+**b. The axis rejects nothing, and something says so.**
+
+```bash
+grep -n "not carried" README.md
+grep -n '"name": "p95-latency"' scripts/verify.sh
+```
+
+Expected: two `not carried` rows plus the paragraph explaining the verdict, and one rendering probe carrying a `name`.
+
+**c. The probe is load-bearing.** Add a rejection on the key and confirm it is caught:
+
+```bash
+# in predicate_why, after the metric check:
+#     if "name" in p:
+#         why.append("name has no equivalent")
+bash scripts/verify.sh   # must fail
+```
+
+At `7cf314a` this passes, which is why the probe exists.
+
+---
+
+## 5. The one claim this repository cannot check
+
+The Identity row's reason is about Gatling's `Assertion`, and there is no Scala here and no build. It was read with `javap` from a jar on the machine that planned this feature:
+
+```bash
+javap -p -cp ~/.m2/repository/io/gatling/gatling-shared-model_2.13/0.0.11/gatling-shared-model_2.13-0.0.11.jar \
+  io.gatling.commons.stats.assertion.Assertion \
+  io.gatling.shared.model.assertion.AssertionResult \
+  io.gatling.shared.model.assertion.AssertionMessage
+```
+
+Expected: `Assertion` carries `path`, `target` and `condition` and no label; `AssertionResult` is `Resolved(assertion, success, actualValue)` or `ResolutionError(assertion, error)`; `AssertionMessage.message` takes an `Assertion` and returns a `String`.
+
+**This will not run on a machine without that jar, and that is the point.** The row names the version it was read at — **3.13.5**, via `gatling-shared-model` 0.0.11 — rather than the 3.15.1 the section header carries, because 3.15.1 could not be opened. A reviewer who has 3.15.1 and finds a difference has found a fact, not a formatting slip: record what 3.15.1 says and date it.
+
+---
+
+## 6. The milestone contract
+
+```bash
+scripts/check-linkage.sh --pr <N>
+```
+
+Expected: the pull request carries milestone **v0.8.0**, and closing links for **#58**, **#72** and **#82**, all three in that milestone.
+
+Commits, in order (FR-035):
+
+```text
+docs(speckit): add 011-identity-has-one-scope spec/plan/tasks
+fix(format): identity is unique within one list (#58)
+fix(gate): the identity rule is probed in both directions (#72)
+docs(format): identity has no slot in a Gatling assertion (#82)
+```
+
+---
+
+## What "done" looks like
+
+- `bash scripts/verify.sh` is `PASS` at all four commits.
+- `examples/` is byte-identical to `main`.
+- One sentence in the repository states what an identity is unique within; deleting it leaves none.
+- Seven mutations in step 3 each redden the gate. All seven are green today.
+- Nine predicate keys, nine rows, and an axis whose verdict is neither **can** nor **cannot**.
+- `.specify/memory/constitution.md` is untouched and still 4.0.0 (FR-037).

--- a/specs/011-identity-has-one-scope/research.md
+++ b/specs/011-identity-has-one-scope/research.md
@@ -1,0 +1,213 @@
+# Phase 0 — Research: Identity Has One Scope
+
+**Feature**: `011-identity-has-one-scope` | **Date**: 2026-08-31 | **Spec**: [spec.md](spec.md)
+
+Eight questions. Two changed a functional requirement. R1 found that the version the spec told the Identity row to cite is a version this machine cannot read, so the row now cites the one that was actually opened. R3 found that the two identity checks live in separate processes, so the single implementation the spec requires has to be a module on disk — which adds a file the spec had not counted, and a clause to `AGENTS.md`. The rest is verification: exact text, exact line, exact count, so the plan edits sentences it has read.
+
+Everything about this repository was read at `7cf314a` on 2026-08-30 and re-confirmed on 2026-08-31. R1 is the one claim about an external tool and carries its own source and date.
+
+---
+
+## R1 — What are Gatling's `Assertion` fields, and at which version can that be checked here?
+
+**Question**: spec FR-025 and FR-026 rest on `Assertion` having no slot for a label. #82 checked it with `javap` at Gatling 3.13.5; § *Gatling* is sourced to 3.15.1. The milestone says this is the one claim that cannot be checked in this repository. What can be?
+
+**Answer**: **3.13.5 and 3.11.5, from jars already on this machine. 3.15.1 cannot be read here, and the row will say 3.13.5.**
+
+`~/.m2/repository/io/gatling/` holds `gatling-core` at 3.11.5 and 3.13.5 and `gatling-shared-model_2.13` at 0.0.6 and 0.0.11. The poms pin them to each other:
+
+| Gatling | pins `gatling-shared-model_2.13` |
+|---|---|
+| 3.11.5 | 0.0.6 |
+| 3.13.5 | 0.0.11 |
+
+3.15.1 is not present in any form, and fetching it was offered and declined — see § *What Phase 0 changed*.
+
+`javap -p` on `io/gatling/commons/stats/assertion/Assertion.class` from 0.0.11, **read 2026-08-31**:
+
+```text
+Compiled from "AssertionModel.scala"
+public final class io.gatling.commons.stats.assertion.Assertion implements scala.Product, java.io.Serializable {
+  private final io.gatling.commons.stats.assertion.AssertionPath path;
+  private final io.gatling.commons.stats.assertion.Target target;
+  private final io.gatling.commons.stats.assertion.Condition condition;
+  ...
+}
+```
+
+Three fields. None is a label, a name, an id or a description. `productArity` is 3.
+
+The same class file in 0.0.6 has the **same SHA-256**, `b58c26f79b6d6f4e9b89e48a00bc1b68bf8ad004fcbc12a2011349ccfa3ae8e9` — byte-identical across the two Gatling minors available here. That is not evidence about 3.15.1 and is not offered as any; it is the reason the row can say the shape has been stable rather than only that it was true once.
+
+Two further findings, read while `Assertion` was open. Both are **kept out of the row** and are recorded here only as what was seen: they describe what Gatling does with an assertion once it has one, and a target description says what a renderer produces, not what becomes of it afterwards. The row's claim needs the three fields and the absence of a fourth, and nothing below.
+
+**A result carries the assertion and nothing that points at a document.** `AssertionResult` is sealed with two cases:
+
+```text
+AssertionResult.Resolved(assertion: Assertion, success: Boolean, actualValue: Double)
+AssertionResult.ResolutionError(assertion: Assertion, error: String)
+```
+
+`Resolved` adds the observed value; `ResolutionError` adds a message about resolution. Neither adds anything an author wrote.
+
+**The failure text is a pure function of the assertion.** `AssertionMessage.message(Assertion): String` takes the `Assertion` and nothing else.
+
+What the row states is the rendering fact and only that: two requirements selecting the same requests with the same criterion render to equal `Assertion` values, because the three fields are all there is and the key is not among them. Where those assertions go next is Gatling's, and this repository does not describe it.
+
+**Source**: `io.gatling.commons.stats.assertion.Assertion`, read with `javap -p` from `gatling-shared-model_2.13-0.0.11.jar`, the release Gatling **3.13.5** pins. **Checked 2026-08-31.** `AssertionResult` and `AssertionMessage` were read from the same jar on the same date and are not cited by the row.
+
+Note for the row's wording: `Assertion` is compiled from `AssertionModel.scala`, which § *Gatling*'s header **already lists** among its four sources at 3.15.1. The Identity row is therefore not introducing a new source file — it is a differently dated reading of one the section already names, and the text should say exactly that rather than leaving a reader to reconcile two version numbers on their own.
+
+**Alternatives considered**: fetching `gatling-core-3.15.1.pom` and the shared-model jar it pins from Maven Central. Offered with sizes and declined. Writing the row at 3.15.1 anyway on the strength of the two versions that were read — rejected: Principle IV requires a claim about an external tool to be dated and sourced, and a date attached to a version nobody opened is the defect, not the discipline.
+
+---
+
+## R2 — Where is identity's scope stated today, and what does each site say?
+
+**Question**: the milestone says "one scope, in four places". Is four the count, and does any site say both things?
+
+**Answer**: **Seven sites, and two documents contradict themselves.**
+
+| Site | Reading | Exact text |
+|---|---|---|
+| `schema/…/requirementset.schema.json:130` | requirement | "…so two predicates **in one requirement** may not then share an aggregation." |
+| `README.md:357` | requirement | "Needed only when two predicates **of one requirement** would otherwise be indistinguishable." |
+| `README.md:360-364` | requirement | a `guards:`/`criteria:` pair, both `rate`, commented "one of them must be named" |
+| `README.md:366-367` | **list** | "`criteria` and `guards` are checked separately: a guard and a criterion may both be `rate`." |
+| `README.md:546` | — | "That two predicates have distinct identities. The gate checks it; the schema cannot." |
+| `GLOSSARY.md:202-204` | **both** | "The identity of a predicate **within one requirement**… Two predicates **in the same list** may not share one." |
+| `scripts/verify.sh:157-166`, `:341-350` | **list** | `for section in ("criteria", "guards")`, `seen` reset per section |
+| `examples/the-run-held-up.yaml` | **list** | two unnamed `rate` predicates in `whole-run`, one guard and one criterion |
+
+`README.md` states the requirement reading in prose and in its worked example, then exempts the guard/criterion pair three lines below. `GLOSSARY.md` names the requirement in its definition and the list in its rule. So the "one against three" the milestone describes is really "two documents that each say both, one that says one, and two artifacts that do one thing" — which is why correcting copies was rejected in favour of one home.
+
+**What the plan must not miss**: `README.md:546` is *not* a statement of scope and is not edited by #58. It says which artifact checks the rule. #72 makes it true.
+
+---
+
+## R3 — Can one implementation of the identity check serve both sites?
+
+**Question**: spec FR-019 forbids a second implementation for probes to call. Can the two sites share a function?
+
+**Answer**: **Not inside `verify.sh` alone. They are in separate `python3` heredocs — separate processes.**
+
+| Section | Heredoc | Lines | Identity check |
+|---|---|---|---|
+| *Examples validate against the schema* | `SCHEMA` | 118–172 | `:157-166`, over `examples/*.yaml` |
+| *The schema holds up its own examples, and still rejects* | `SELFCHECK` | 198–522 | `:341-350`, over the schema's root `examples` |
+
+Nothing crosses that boundary except a file on disk. The repository already solved this once, for the same reason. `scripts/mdlinks.py` holds what a markdown link is, and both the link-resolution and the `docs/`-isolation sections import it via `sys.path.insert(0, "scripts")`. Its comment at `scripts/verify.sh:895` states the motive in this milestone's own terms:
+
+> shared with the isolation section below so the two cannot drift into disagreeing about the same text
+
+`mdlinks.py` also shows the rest of the shape: a `selftest()` returning every fixture it gets wrong, called before anything trusts the module, carrying **its own floor** on the fixture list — `if len(SELFTEST) < 15 or len(RESOLVE_SELFTEST) < 5` — because "an emptied fixture list would otherwise read as a sound extractor".
+
+**Decision**: `scripts/identity.py`, imported by both heredocs, with `selftest()` and a fixture floor.
+
+**Alternatives considered**: moving the schema's root-example identity check into the `SCHEMA` heredoc, which does already hold the parsed schema (`verify.sh:127`) and could walk `schema["examples"]`. It needs no new file and was rejected anyway: it moves a check out of the section named for checking the schema's own examples, so both sections' summary lines would stop describing what they ran. Duplicating the function into both heredocs was rejected outright — it is #58 reproduced one directory over, and spec FR-019 forbids it by name.
+
+**Cost recorded**: `AGENTS.md` § *Structure* describes `scripts/` as "the gate (`verify.sh`) and what it shares (`mdlinks.py`)". With a second shared module that parenthetical names half of what it claims to name, so it gains one clause. This is the whole of the AGENTS.md change and it is a map correction, not a rule.
+
+---
+
+## R4 — What must each identity probe catch, and what is the floor?
+
+**Question**: `FLOORS` requires each probe to be the sole catcher of something, and the number beside it to be exact. What are the classes?
+
+**Answer**: **six probes, floor six.** Two directions, and the exemption.
+
+| # | Probe | Sole catcher of |
+|---|---|---|
+| 1 | two criteria, both `rate`, neither named | the aggregation arm of the fallback, in `criteria` |
+| 2 | two guards, both `rate`, neither named | the rule reaching `guards` at all — the corpus has one guard and can never collide |
+| 3 | two criteria, `name: a`/`name: b` colliding, aggregations differing | the **`name` arm**, which nothing in the repository has ever exercised |
+| 4 | two criteria, same aggregation, different `name`s | the check hardening into "every pair collides" — no rejection probe can show this |
+| 5 | `name: rate` beside an unnamed `rate` | the two arms being one namespace, not two |
+| 6 | one `rate` guard and one `rate` criterion | the per-list reset — the exemption #58 settles, and the reading `examples/the-run-held-up.yaml` depends on |
+
+Probe 6 duplicates coverage the corpus already provides — flatten the two lists and `the-run-held-up.yaml` fails. Spec FR-017 requires this be said rather than assumed, and it is included anyway: the corpus is what a target can run and is free to change for reasons that have nothing to do with this rule, whereas a probe is here to hold the rule.
+
+Probes 4 is the direction `SELECTION_RENDERS` and `PREDICATE_RENDERS` were added for in v0.6.0, and its absence is the reason a "return every pair" mutation would otherwise pass every other probe here.
+
+---
+
+## R5 — What catches a deleted call site rather than a deleted rule?
+
+**Question**: probes call the shared function. Deleting a *call* at `:162` or `:346` leaves every probe green. What fails?
+
+**Answer**: **a count with a floor, which is the idiom this file already uses twice.**
+
+`verify.sh:352` floors the schema's embedded examples at `EXAMPLES = 20`, with the message *"the check is reading less than it was written to read"*. The isolation section counts `scanned` for the same reason. Principle III requires it in terms: *"any check that scanned nothing MUST say so"*.
+
+So each site counts the lists it scanned and floors the number:
+
+| Site | Unit | Count today | Floor |
+|---|---|---|---|
+| `examples/*.yaml` | lists (`criteria` and `guards` bodies) | **5** across 4 requirements, 10 predicates | 5 |
+| the schema's root `examples` | lists | **1** across 1 requirement, 1 predicate | 1 |
+
+Lists rather than predicates or requirements, because the list is the unit uniqueness is checked within after #58. Deleting either call drops its count to zero and fails on the floor; adding an example raises the count and the floor is a minimum, not an equality.
+
+---
+
+## R6 — What does the third verdict say, and where does the subsection go?
+
+**Question**: FR-024 forbids **can** and **cannot**. What word, and placed where?
+
+**Answer**: **not carried**, in a `#### Identity` subsection between § *Units* and § *Two things Gatling cannot do at all*.
+
+The word has to survive two readings that the existing pair cannot hold together: the predicate renders (so not **cannot**), and the key does not travel into what it renders to (so not **can**). **not carried** is about the key rather than the predicate, which is exactly the distinction the axis draws.
+
+Placement is with the axes, because it is one: § *How these tables are applied* claims the tables partition each axis, and an axis kept somewhere other than among the axes is how a partition claim goes stale. It is not a third bullet under § *Two things Gatling cannot do at all*, because nothing there fails and this does not either — that section is about aborting a run and about absent data, both of which change a verdict.
+
+Two rows, because two of the nine predicate keys have no row today:
+
+| Key | Verdict | Why the reason differs |
+|---|---|---|
+| `name`, and the `aggregation` standing in for it | **not carried** | the key is live — it is what makes two statements in one list distinguishable — and `Assertion` has no field for it |
+| `displayName` | **not carried** | and nothing is lost, because the key is declared inert: nothing selected, measured or compared depends on it |
+
+Recording `displayName` as **not carried** rather than omitting it is what makes the partition claim true for all nine keys. #82 argues `displayName` "needs no row" because it is inert, and then observes the partition is false for two keys; the row is how both are satisfied at once, and its verdict and its reason are not `name`'s.
+
+---
+
+## R7 — Does anything today catch a rejection added on `name`?
+
+**Question**: FR-029 wants a rendering probe carrying `name`. Is one needed, or is it already covered?
+
+**Answer**: **Nothing covers it. Nothing in the repository puts a `name` on a predicate.**
+
+All 10 predicates in `examples/*.yaml` carry `name = None`; so does the schema's single root example; so do all 24 `PREDICATE_PROBES` and `PREDICATE_RENDERS` entries. A line added to `predicate_why` refusing a `name` would be caught by no document and no probe, and the corpus could not be asked to catch it — spec FR-021 keeps the corpus out of the coverage business.
+
+`predicate_why(p)` (`verify.sh:665`) reads `metric`, `aggregation`, `op`, `threshold`, `unit`, `bad` and `good`. It never reads `name`, which is the behaviour the row publishes and therefore the behaviour that needs a probe.
+
+**Decision**: `PREDICATE_RENDERS` gains `{**RENDERABLE, "name": "p95-latency"}` and its floor goes **14 → 15**. `verify.sh:826` states that cost as a rule — *"Adding a probe means raising the number beside it, which is the intended cost"* — and it is paid rather than waived.
+
+---
+
+## R8 — What replaces the worked example, and is the replacement renderable?
+
+**Question**: FR-003 requires the example's collision be one the rule forbids; FR-004 requires it be renderable.
+
+**Answer**: **two criteria in one list, and both rows are `can`.**
+
+The present example collides a guard against a criterion, which the sentence three lines below permits — it teaches the reading being removed. The replacement puts both predicates in `criteria`:
+
+| Predicate | Gatling row | Verdict |
+|---|---|---|
+| `{bad: {error.type: "*"}, aggregation: rate, op: lte, threshold: 5, unit: "%"}` | `failedRequests.percent` | **can** |
+| `{aggregation: rate, op: lte, threshold: 400, unit: "{request}/s"}` | `requestsPerSec` | **can** |
+
+Two identities, both `rate`, in one list, so one must be named — and naming one is what the snippet shows. Both shapes are already in `PREDICATE_RENDERS`, so the illustration is of a document the gate would accept, which is not true of the example it replaces only by accident.
+
+The guard/criterion case does not disappear from the page. It moves to the sentence that states the exemption, where it names `examples/the-run-held-up.yaml` as the document that relies on it — spec FR-005.
+
+---
+
+## What Phase 0 changed
+
+- **FR-026** required the row be dated at Gatling **3.15.1**. R1 could not read 3.15.1: it is not on this machine, and fetching `gatling-core-3.15.1.pom` and the shared-model jar it pins from Maven Central was offered with sizes and declined. The row now says **3.13.5**, which is what `javap` was run against, and adds that `Assertion.class` is byte-identical at the release Gatling 3.11.5 pins. A date on a version nobody opened is the Principle IV failure the row is being written to fix.
+- **FR-034** said four files. R3 makes it six: `scripts/identity.py` is new, because the two checks are in separate processes and spec FR-019 forbids a second implementation; and `AGENTS.md` § *Structure* names what the gate shares and would otherwise name half of it.
+- **SC-008** now requires a reader to be able to see that the row's version is not the section header's. R1 made that a fact about the shipped page rather than a detail of how it was checked.
+
+Nothing else in the spec moved. The three decisions recorded in spec.md § *Decisions* were all confirmed by what Phase 0 read: the corpus and the gate hold the list reading (R2), the one-home route has a working precedent in the same file (R3), and the third verdict is the only wording that states the fact without misfiling it (R6).

--- a/specs/011-identity-has-one-scope/spec.md
+++ b/specs/011-identity-has-one-scope/spec.md
@@ -1,0 +1,289 @@
+# Feature Specification: Identity Has One Scope
+
+**Feature Branch**: `011-identity-has-one-scope`
+
+**Created**: 2026-08-30
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/opennfr/milestone/10" — milestone **v0.8.0**, three open issues: #58, #72 and #82, in that order.
+
+**Scope note**: One question runs through all three: *what tells two statements in one document apart?* Identity is the answer the format gives — the `name` if set and the `aggregation` otherwise — and the repository currently says incompatible things about what it must be unique within (#58), checks it with a branch nothing reaches (#72), and never says what becomes of it when a predicate is rendered (#82).
+
+Nothing here is about a report, a verdict or anything a consumer displays. A renderer turns a requirement document into a target's assertions, which is what the constitution defines one to be, and this milestone stays inside that.
+
+No term is added and no term is renamed. `examples/` does not change; every published document is already valid under the answer this milestone settles on, and stays valid. Four files change: `README.md`, `GLOSSARY.md`, `schema/opennfr.io/v1/requirementset.schema.json` and `scripts/verify.sh`.
+
+#58 comes first because the other two are written from its answer: a probe has to encode a scope, and a reach row has to describe an identity that means one thing.
+
+## Decisions
+
+### Session 2026-08-30
+
+- **Q**: Identity is scoped to the **requirement** by the schema and to the **section** — `criteria` and `guards` counted apart — by `README.md`, `scripts/verify.sh` and the corpus. Which is right? → **A**: **The section.** `rate` over the requests themselves and `rate` over a `bad` fraction are different quantities that share a word, and `README.md` § *A predicate* already says the predicate's own shape is what distinguishes the three readings of `rate`. Forcing a name on a collision that is purely lexical is the noise `GLOSSARY.md`'s own *Rejected* line was written against. The schema's sentence is the one that was not updated when guards arrived, and it is the one that changes.
+
+- **Q**: The milestone calls this "one scope, in four places". Do the four places each get a corrected copy, or does the rule get one home and the others point at it? → **A**: **One home, and pointers.** `README.md` § *A predicate* is where the scope is stated. The schema's `name` description and `GLOSSARY.md` § *criterionId* stop carrying a second statement of it; `scripts/verify.sh` implements it and does not restate it. Four agreeing copies is the state #58 describes — nothing makes copies converge, and this one drifted the moment guards were added.
+
+- **Q**: What shape does the `name` row take in the reach section — a table row, a third bullet under *Two things Gatling cannot do at all*, or a rewritten partition claim? → **A**: **A new `#### Identity` subsection with a third verdict.** The fact a renderer needs is not "you cannot assert this" — the predicate is perfectly assertable — but "the identity you carry does not reach the report". **can** and **cannot** cannot both say that, so the axis needs a verdict of its own. This is the only option that makes the partition claim true rather than narrowing it.
+
+### What "four places" actually counts
+
+The milestone counts coarsely — schema, `README.md`, gate, corpus. Read at `7cf314a`, the scope is stated or depended on at seven sites, and two documents contradict themselves:
+
+| Site | What it says today |
+|---|---|
+| `schema/…/requirementset.schema.json:130` | "two predicates **in one requirement** may not then share an aggregation" |
+| `README.md:357` | "Needed only when two predicates **of one requirement** would otherwise be indistinguishable" |
+| `README.md:360-364` | a worked example whose collision is a **guard against a criterion** — "one of them must be named" |
+| `README.md:366-367` | "`criteria` and `guards` are **checked separately**: a guard and a criterion may both be `rate`" |
+| `README.md:546` | "That two predicates have distinct identities. The gate checks it; the schema cannot" — silent on scope, and false in the sense #72 is about |
+| `GLOSSARY.md:202-204` | "The identity of a predicate **within one requirement** … Two predicates **in the same list** may not share one" |
+| `scripts/verify.sh:157-166`, `:341-350` | `for section in ("criteria", "guards")`, `seen` reset per section |
+| `examples/the-run-held-up.yaml` | two unnamed `rate` predicates in `whole-run` — valid only under the section reading |
+
+`README.md` states the requirement scope in its prose and its worked example, then exempts the guard/criterion pair from it one paragraph later. `GLOSSARY.md` names the requirement in its scope phrase and the list in its rule. Neither document is wrong about the *answer* so much as it is two documents.
+
+### What review added
+
+Two things this specification listed under *Out of Scope* were brought in after the first three issues had landed, on the maintainer's call. Both were parked for the same reason — no issue in the milestone reached them — and both now have one: **#91** and **#92**, filed against v0.8.0 **before** any file changed, which is what Principle I requires of a naming disagreement.
+
+They belong here rather than in v0.9.0 because each is a defect this milestone's own work created or exposed:
+
+- **#91** — `criterionId` names the identity of a guard as well as a criterion. #58 settled that identity is unique within one **list**, which is precisely what makes a guard a first-class carrier of identity, and #72 shipped a probe whose whole subject is a guard's identity. The release that promoted the guard left the term saying `criterion`.
+- **#92** — `GLOSSARY.md` § *name* justifies its character restriction with *"a report line, a CI annotation, a URL fragment"*. FR-006a removed that framing from the schema and #82's row stops at the assertion; § *name* is what is left of it. And #82 makes the reason false for the one target described: the identity is **not carried** into a Gatling assertion, so nothing downstream of a run points at a `name`.
+
+The milestone still changes six files: both issues land inside `GLOSSARY.md`, `scripts/verify.sh` and `scripts/identity.py`, which were already among them.
+
+### What `/speckit-analyze` changed
+
+One requirement, and it was a premise rather than a wording.
+
+**FR-008 was written for a gate that keeps the rule inline.** It required `scripts/verify.sh`'s existing comment — *"criterionId is the name if set, otherwise the aggregation. The schema cannot express that fallback, so uniqueness is checked here"* — to survive unchanged. Once #72 moves the rule into `scripts/identity.py`, that comment becomes two defects at once: a second copy of the derivation the module's own docstring carries, and a false sentence, because uniqueness is no longer checked *here*. Keeping it would reproduce #58 one directory over, in the commit whose whole purpose is to stop that. The reason now travels with the implementation, and the call site names what it calls.
+
+The cross-artifact check also found the instruction that would have done the damage: the contract and T012 said to replace `scripts/verify.sh:156-166`, and the comment occupies **155–156**. Following it literally would have deleted half a sentence and left the other half standing. Both now say **157–166**.
+
+### What Phase 0 changed
+
+Three requirements, all in the direction of claiming less.
+
+**FR-026 named a version nobody read.** It required the Identity row be checked at Gatling **3.15.1**, the version § *Gatling* is sourced to. 3.15.1 is not on this machine and nothing in this repository fetches it. What is here is `gatling-shared-model` 0.0.6 and 0.0.11 — the releases Gatling 3.11.5 and 3.13.5 pin — and [research.md](./research.md) R1 read both: `Assertion` carries `path`, `target` and `condition`, no field is a label, and `Assertion.class` is **byte-identical** across the two. The row now says 3.13.5, which is what was read. Dating a claim at a version nobody opened is the Principle IV defect the row exists to fix, one line further down the same page.
+
+**FR-034 undercounted the files, by two.** The two identity checks live in two separate `python3` heredocs — separate processes — so one implementation reachable from both has to be a module on disk. That pattern already exists here: `scripts/mdlinks.py`, whose own comment gives this milestone's reason for it, that the two sections sharing it *"cannot drift into disagreeing about the same text"*. `scripts/identity.py` joins it, and `AGENTS.md` § *Structure* — which names what the gate shares — names it too, in one clause.
+
+**SC-008 asked for less than the row now owes.** A reader must be able to see that the row's version is not the section header's, because it is not, and a target description that quietly mixes two source versions is the thing § *Gatling* dates its sources to prevent.
+
+## User Scenarios & Testing *(mandatory)*
+
+The reader throughout is the author of the first OpenNFR renderer — someone turning a requirement document into a target's assertions, which is all a renderer does. The four stories are the four things that reader currently cannot learn from the repository: what identity is unique within, where that is decided, whether anything enforces it, and what becomes of the key when the predicate is rendered.
+
+### User Story 1 - Identity is unique within one thing (#58, Priority: P1)
+
+A renderer author needs to know when a document holds two statements it cannot tell apart, because that is the one thing about identity that constrains what they may be handed. The schema tells them the unit is the requirement — and under that reading `examples/the-run-held-up.yaml`, the document the repository holds up to explain guards, is malformed. `README.md`, the gate and the corpus tell them the unit is the list, under which it is correct. Both readings are sourced, and the two sources are the schema, which decides, and `README.md`, which explains.
+
+After this story the answer is one answer: an identity is unique within one list, and `criteria` and `guards` are two lists. The flagship example is correct under the only reading there is, and the worked example in `README.md` teaches a collision the rule actually forbids.
+
+**Why this priority**: the other two issues are written from its answer. A probe has to encode a scope (#72) and a reach row has to describe an identity that means one thing (#82). It is also the only one of the three that a consumer can get wrong today without noticing.
+
+**Independent Test**: read the schema's `name` description, `README.md` § *A predicate* and `GLOSSARY.md` § *criterionId* in any order, then apply each reading to `examples/`. No two of the three disagree about which documents are well-formed, and every published document is well-formed under all of them.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected documents, **When** a renderer author asks what an identity must be unique within, **Then** the answer is one list, `criteria` and `guards` counted apart, and no document in the repository says otherwise.
+2. **Given** `examples/the-run-held-up.yaml` unchanged, **When** it is checked against the schema's `name` description, **Then** it is valid — the reading under which it was malformed no longer exists.
+3. **Given** `README.md` § *A predicate*, **When** a reader reaches the worked example, **Then** its collision is one the rule stated below it forbids, and the exemption sentence does not contradict the example it follows.
+4. **Given** a document with two unnamed `rate` criteria in one requirement, **When** the gate reads it, **Then** it fails, and the message names the requirement and the list.
+5. **Given** a document with an unnamed `rate` guard and an unnamed `rate` criterion in one requirement, **When** the gate reads it, **Then** it passes, and that is what the flagship example relies on.
+
+---
+
+### User Story 2 - The scope is stated once (#58 part 2, Priority: P2)
+
+The same author now wants to know where the rule lives, because they will have to re-read it when the format moves. They find it in the schema, in `README.md` twice, in `GLOSSARY.md` and in the gate — five statements of one rule, which is how it came to be two rules. Nothing in the repository makes those copies converge, and guards arriving is all it took to split them.
+
+After this story `README.md` § *A predicate* is where the scope is written. The schema's description says what identity *is* and points at where its uniqueness is decided and what checks it; `GLOSSARY.md` defines the term and does the same; the gate implements the rule and restates nothing.
+
+**Why this priority**: second because it is the durable half of #58 — correcting five copies fixes today's contradiction and leaves the mechanism that produced it in place. It ships in the same commit as Story 1 because a corrected copy and a deleted copy are the same edit to the same sentence.
+
+**Independent Test**: delete `README.md` § *A predicate*'s `name` paragraph and no other document still states what an identity is unique within. Nothing else in the repository is a second copy of that sentence.
+
+**Acceptance Scenarios**:
+
+1. **Given** the four documents, **When** a reader searches for a statement of what identity is unique within, **Then** exactly one is normative and the others name it rather than repeating it.
+2. **Given** the schema's `name` description, **When** an editor surfaces it to an author writing a predicate, **Then** it says what identity is and what happens without a `name`, and defers the scope to the document that states it — as `$defs/unit`'s description already defers its enumeration.
+3. **Given** `GLOSSARY.md` § *criterionId*, **When** a reader looks up the term, **Then** it defines the identity, records the requirement scope as the alternative that was rejected and why, and states no scope of its own.
+4. **Given** a future change to the scope, **When** a contributor makes it, **Then** one sentence and one gate change, and no document is left behind.
+
+---
+
+### User Story 3 - The check that is claimed is a check that runs (#72, Priority: P3)
+
+`README.md` § *What the schema does not check* tells the reader the gate checks that two predicates have distinct identities. Both branches that do so can be replaced with `if False:` and the gate still prints **PASS**. All ten predicates in `examples/*.yaml` carry `name = None`, the schema's one root example likewise, so no colliding pair exists anywhere and the `name` arm of the fallback has never been observed at all — only the aggregation arm has, and only where it did not collide.
+
+`scripts/verify.sh` states its own standard, *"a rule nothing probes is a rule nothing checks"*, and this rule fails it. Its two neighbours failed it too and were fixed in v0.6.0; this one was left.
+
+After this story the rule gets what they got: probes that fire, in both directions, and a floor that stops them being deleted quietly.
+
+**Why this priority**: third because it enforces the answer Stories 1 and 2 settle — a probe encodes a scope, so it cannot be written first. It is not last because a claim in `README.md` that nothing backs is the failure mode Principle III exists for, and it is currently being made.
+
+**Independent Test**: replace either uniqueness branch with `if False:` and run the gate. It fails, and it names which rule stopped holding.
+
+**Acceptance Scenarios**:
+
+1. **Given** the identity check over `examples/`, **When** it is neutered, **Then** the gate fails.
+2. **Given** the identity check over the schema's root examples, **When** it is neutered, **Then** the gate fails — separately, and for its own reason.
+3. **Given** a probe of two predicates in one list sharing an aggregation and carrying no `name`, **When** the gate runs, **Then** the collision is reported.
+4. **Given** a probe of two predicates in one list whose `name`s collide while their aggregations differ, **When** the gate runs, **Then** the collision is reported — the `name` arm of the fallback is exercised for the first time.
+5. **Given** a probe of two predicates in one list whose aggregations collide while their `name`s differ, **When** the gate runs, **Then** nothing is reported, so a check hardened into "always duplicate" cannot pass the section.
+6. **Given** the section scope, **When** the per-section reset is removed, **Then** something fails — the guard-and-criterion exemption is exercised, not merely assumed.
+7. **Given** a contributor deleting a probe, **When** the gate runs, **Then** the floor beside them fails with a count.
+
+---
+
+### User Story 4 - A renderer is told what happens to the identity (#82, Priority: P4)
+
+The reach tables claim to partition every axis and to admit a predicate only on an exact row match. A predicate has nine keys. `name` has no row anywhere, so a renderer meeting one has no instruction at all — while Gatling's `Assertion` is `(path, target, condition)` and has no field that holds a label. The predicate renders; the key does not travel with it, and two requirements that select the same requests and state the same criterion render to equal `Assertion` values.
+
+`displayName` needs no such row because it is declared inert: a target that drops it loses nothing the format claims. `name` is not inert — it is what makes two statements in one list distinguishable, and the format restricts its character set precisely so that something can point at it.
+
+After this story the section carries an Identity axis, the row says what a renderer must know, and the partition claim is true for all nine keys.
+
+**Why this priority**: last because it changes no rule and blocks no author — it records a fact about a target. It is in the milestone because a renderer meeting a `name` has no instruction at all, and because a claim to partition every axis that is false for two of nine keys is the honesty defect Principle IV names, in the section that is a target's description.
+
+**Independent Test**: list the nine predicate keys against the reach section. Every one is addressed by a row, and each row's verdict says either whether the predicate is assertable or what becomes of the key.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reach section, **When** a reader enumerates the nine predicate keys, **Then** each is covered by a row, and none is covered only by silence.
+2. **Given** the Identity row, **When** a renderer author reads it, **Then** it says the predicate is assertable and the key is not carried into what it renders to, and it does not read as a rejection.
+3. **Given** the Identity row, **When** a reader asks why, **Then** the reason names `Assertion`'s three fields and the absence of a fourth, and carries the Gatling version it was read at and the date it was checked.
+4. **Given** the `displayName` row, **When** a reader asks why its loss costs nothing, **Then** the reason is the one already stated: the key is inert.
+5. **Given** § *How these tables are applied*, **When** a reader asks whether the Identity axis rejects anything, **Then** the text says it does not, and says the gate therefore implements no rejection from it.
+6. **Given** a predicate carrying a `name`, **When** the gate judges it against the reach tables, **Then** it is rendered and not rejected, and a probe says so.
+
+---
+
+### Edge Cases
+
+- **A guard and a criterion collide inside one requirement.** The exemption is the whole of #58's answer and is what `examples/the-run-held-up.yaml` relies on. It must be stated where the rule is stated, and it must be exercised by something — today only a published example stands behind it.
+- **Two guards collide.** Guards are a list like criteria, and nothing exempts a list from itself. The rule reaches guards on their own terms, and the corpus has no case: `the-run-held-up.yaml` carries exactly one guard.
+- **A predicate carries a `name` that equals another's `aggregation`.** `name: rate` beside an unnamed `rate` in one list is a collision, because the identity is one value and both predicates produce it. This falls out of the definition and needs no extra rule, but the probe set should not accidentally assume the two arms are separate namespaces.
+- **A `name` on a predicate nothing collides with.** Permitted and unaffected. `name` stays optional, and no document is obliged to carry one; the reach row says what happens to it when it is there.
+- **The corpus after the fix.** No published document gains or loses a `name`. The `name` arm of the fallback is exercised by probes only, and that is a deliberate limit: the corpus is what a target can run, not a place to install coverage.
+- **The schema's root example.** It is one document and carries no colliding identity, so the second check site has nothing in the corpus to prove it fires. It needs a probe of its own, or the two sites need to share what a probe can reach.
+- **The Identity axis and the gate.** It decides nothing about assertability, so it adds no rejection. The published-row standard still applies — a row nothing probes is a row nothing checks — and the only thing there is to probe is that the axis rejects nothing.
+- **`displayName` and the third verdict.** It is inert and is dropped, which is not the same fact as `name` being dropped. Both belong on the axis; only one of them costs a renderer anything.
+- **The subsection count.** § *Two things Gatling cannot do at all* keeps its name. Identity is not a third thing Gatling cannot do — the assertion runs — which is exactly why it is an axis and not a bullet there.
+- **A term that does not fit.** `criterionId` names the identity of a guard as well as a criterion. That read badly, and it *became* this milestone's argument: #91, filed after the first three issues landed and precisely because #58 and #72 made the guard first-class.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**#58 — one scope, and one place that states it**
+
+- **FR-001**: The identity of a predicate MUST be unique within one list. `criteria` and `guards` are two lists, and a guard and a criterion in one requirement MAY share an identity. This is the reading `README.md`, `scripts/verify.sh` and `examples/` already hold, and it is the reading every artifact touched here is brought to.
+- **FR-002**: `README.md` § *A predicate* MUST be the one place the scope is stated. The paragraph MUST say what identity is, what a missing `name` falls back to, what the identity must be unique within, and that `criteria` and `guards` are counted apart.
+- **FR-003**: `README.md:357`'s *"two predicates of one requirement"* MUST stop naming the requirement as the scope, and `README.md:360-364`'s worked example MUST show a collision the rule forbids. Its present collision is a guard against a criterion, which the sentence three lines below it permits — the example teaches the rule the milestone is removing.
+- **FR-004**: The replacement worked example MUST be renderable by Gatling under § *What any tool can actually run*. It is prose rather than a published document and the reach tables do not gate it, but an illustration of a legal shape that no target can run teaches a second wrong thing while correcting the first.
+- **FR-005**: `README.md` § *A predicate* MUST name `examples/the-run-held-up.yaml` as the case the exemption exists for. The exemption is the one part of the rule a reader is most likely to think is an oversight, and the corpus is where it is already load-bearing.
+- **FR-006**: The schema's `$defs/predicate.name` description MUST stop stating the scope. It MUST keep saying that the key is optional and that the aggregation is the identifier without it, and it MUST defer the uniqueness rule to `README.md` and name `scripts/verify.sh` as what checks it, in the manner `$defs/unit`'s description already defers its enumeration to `README.md`.
+- **FR-006a**: The same description MUST stop saying that the key identifies the predicate *"in a report"*. What `name` does is distinguish a predicate from the ones beside it in the document; a report is downstream of the assertions a renderer produces, and this format describes neither. The phrase is the sentence #58 is already rewriting, so it goes in the same edit rather than being left as the last downstream claim in the schema.
+- **FR-007**: `GLOSSARY.md` § *criterionId* MUST define the term and MUST NOT carry a second statement of the scope. The entry MUST record the requirement scope as a rejected alternative and why it was rejected — a name forced onto a collision that is purely lexical, where the predicate's own shape already distinguishes the two quantities — alongside the rejection it already carries.
+- **FR-008**: `scripts/verify.sh` MUST keep implementing the rule and MUST NOT restate it. The reason the rule exists — that identity falls back to the aggregation, and that JSON Schema cannot express the fallback — travels **with** the implementation into `scripts/identity.py`. The call site names what it calls and does not repeat the derivation, because a comment restating what the module says is the second copy this milestone exists to remove, and the existing one ends *"uniqueness is checked here"*, which the extraction makes false.
+- **FR-009**: `examples/` MUST NOT change. Every published document is valid under FR-001 today and is valid after it. `the-run-held-up.yaml` in particular keeps both unnamed `rate` predicates.
+- **FR-010**: `README.md:546` — *"That two predicates have distinct identities. The gate checks it; the schema cannot"* — MUST NOT be edited by this issue. It states which artifact checks the rule, not what the rule is, and it becomes true rather than merely stated once #72 lands.
+- **FR-011**: No term is **added**, and no `GLOSSARY.md` entry is created. The entry edited by FR-007 changes what `criterionId` is scoped to, which is why it MUST land in the same commit as the schema and `README.md` edits. One term is **renamed**, under #91 and in its own commit — see FR-038.
+
+**#72 — the branch fires, and stays fired**
+
+- **FR-012**: The identity check over `examples/` MUST be exercised by a probe that fails the gate when the check is removed. Replacing `scripts/verify.sh:162`'s branch with `if False:` MUST make the gate exit non-zero.
+- **FR-013**: The identity check over the schema's root examples MUST be exercised the same way and separately. Replacing `scripts/verify.sh:346`'s branch with `if False:` MUST make the gate exit non-zero, and MUST NOT be caught only because the other site's probe caught something.
+- **FR-014**: A colliding-identity probe MUST exist: two predicates in one list, sharing an aggregation, neither carrying a `name`. It MUST be reported as a duplicate.
+- **FR-015**: A `name`-arm probe MUST exist: two predicates in one list whose `name`s collide while their aggregations differ. It MUST be reported as a duplicate. This arm of the fallback has never been observed by anything in the repository.
+- **FR-016**: A non-colliding probe MUST exist in the other direction: two predicates in one list whose aggregations collide while their `name`s differ, reported as no duplicate. Without it a check hardened to report every pair passes every rejection probe, which is the hole `SELECTION_RENDERS` and `PREDICATE_RENDERS` were added to close on their own axes.
+- **FR-017**: The guard-and-criterion exemption MUST be exercised by something that fails when the per-section reset is removed. If the corpus already provides that — `the-run-held-up.yaml` fails a requirement-scoped check — the plan MUST say so and MUST say why a probe is or is not additionally required, rather than leaving the coverage implicit.
+- **FR-018**: A floor MUST sit beside the identity probes, in the manner of `FLOORS`, failing with a count and the existing sentence *"a rule nothing probes is a rule nothing checks"* when a probe is deleted. The floor MUST be exact, and the plan MUST state what each probe is the sole catcher of, as the four existing floors do.
+- **FR-019**: Probes MUST exercise the same code the corpus is judged by, never a copy of it. Where that requires the two check sites to share a function, the extraction is part of this issue; a second implementation written for the probes to call is not acceptable and would recreate #58 one file over.
+- **FR-020**: The gate's summary line MUST report the identity probes it ran, as the Gatling section reports its four probe counts. A section that ran nothing must not read like a section that passed.
+- **FR-021**: `examples/` MUST NOT change to provide coverage. The corpus is restricted to what a real target can run and is not a probe table; the `name` arm is exercised by probes.
+
+**#82 — the identity axis gets a row**
+
+- **FR-022**: `README.md` § *What any tool can actually run* → § *Gatling* MUST gain a `#### Identity` subsection, placed with the other axes: after § *Units* and before § *Two things Gatling cannot do at all*.
+- **FR-023**: The subsection MUST carry a row for `name` — and for the `aggregation` fallback, since an unnamed predicate still has an identity — stating that the predicate is assertable and that the key is not carried into the assertion it renders to. It MUST NOT state anything about a target's report, a verdict, or what a consumer does with a failure: a target description says what a renderer reads to produce assertions, and stops there.
+- **FR-024**: That row's verdict MUST NOT be **can** or **cannot**. Neither says what a renderer needs: the assertion runs, and the key does not survive it. A third verdict MUST be introduced for the axis, and § *How these tables are applied* MUST say what it means.
+- **FR-025**: The row's reason MUST name the evidence and no more of it than the claim needs: `io.gatling.commons.stats.assertion.Assertion` is `(path, target, condition)`, no field of it holds a label, and two requirements selecting the same requests with the same criterion therefore render to equal `Assertion` values. What Gatling then does with an assertion is outside what this format describes and MUST NOT enter the row.
+- **FR-026**: The reason MUST carry the Gatling version it was read at and the date it was checked, as Principle IV requires and as the section header already does for its four sources. It MUST name **3.13.5**, which is what was read, and MUST NOT claim 3.15.1, which was not. It MUST also record that `Assertion` is unchanged between the `gatling-shared-model` releases Gatling 3.11.5 and 3.13.5 pin, because a shape that held across two minors is the only evidence available here about a third. This claim cannot be checked inside this repository, which makes the version and the date the whole of what a later reader has to go on.
+- **FR-027**: The subsection MUST carry a row for `displayName` stating that it is inert and that a target dropping it loses nothing the format claims. It is the second of the two keys the partition claim was false for, and its reason is not `name`'s reason.
+- **FR-028**: § *How these tables are applied* MUST stop being false. *"The tables partition each axis"* MUST hold for all nine predicate keys, and the text MUST say that the Identity axis decides nothing about assertability, rejects nothing, and therefore adds no rule for the gate to implement.
+- **FR-029**: `scripts/verify.sh` MUST gain a rendering probe carrying a `name`, confirming the Identity axis rejects nothing. No corpus document carries a `name` and no existing probe does, so a rejection added on that key today would be caught by nothing — which is the standard § *Examples are assertable by Gatling* already holds every published row to.
+- **FR-030**: The floor beside `PREDICATE_RENDERS` MUST be raised by one with FR-029's probe. Adding a probe means raising the number beside it; that cost is stated in the file and is not waived here.
+- **FR-031**: The gate MUST gain no rejection from this issue. `predicate_why` decides assertability, the Identity axis decides none of it, and a gate that started refusing a `name` would narrow the format to what a target happens to carry.
+- **FR-032**: `GLOSSARY.md` MUST NOT change for this issue. The row records what a target does with an existing term; it introduces none.
+
+**#91 — the term covers what it names**
+
+- **FR-038**: `criterionId` MUST be renamed to `predicateId`. The value it names is the identity of a *predicate*, and `criteria` and `guards` hold the same shape — which #58 made load-bearing by scoping uniqueness to the list, and #72 exercised with a probe whose subject is a guard's identity.
+- **FR-039**: The rename MUST update `GLOSSARY.md` in the same change, and the entry MUST record what the old term got wrong, as Principle I requires of every rename. The existing *Rejected* lines MUST survive: they protect decisions the rename does not reopen.
+- **FR-040**: Every site MUST move together — `GLOSSARY.md` § *criterionId*, both failure messages and the one comment in `scripts/verify.sh`, and the docstring in `scripts/identity.py`. After the commit no artifact outside `specs/` may still **use** `criterionId` as the term. The exception is `GLOSSARY.md`'s own *Rejected* line, which names it as the spelling that was replaced — Principle I requires the entry to record what the old term got wrong, so that occurrence is the rename working rather than a site it missed. `README.md` does not use the term and MUST NOT gain it.
+- **FR-041**: No compatibility-sensitive surface moves. `criterionId` is a derived value with a name, never a field: it appears in no published example, in no schema property and in no OpenTelemetry name.
+
+**#92 — the restriction is justified by something the format has**
+
+- **FR-042**: `GLOSSARY.md` § *name* MUST stop justifying its character restriction with consumers this format does not describe. *"a report line, a CI annotation, a URL fragment"* names three things, two of which are downstream of the assertions a renderer produces, and the third of which #82 shows is unreachable for the one target described — the identity is **not carried** into a Gatling assertion.
+- **FR-043**: The replacement reason MUST rest on what the repository has. Both of these are available and true: an identity is compared for **equality** by the gate, so a closed character set is what makes two identities that look alike to a reader be alike to the check; and `$defs/name` is shared by `metadata.name`, a requirement's `name` and a predicate's `name`, so one spelling rule serves three places. The `*Rejected*` line — *"free-form strings — nothing could point at one reliably"* — rests on the same absent consumer and MUST be replaced on the same grounds, keeping the alternative it rejects.
+
+**Across the milestone**
+
+- **FR-033**: `bash scripts/verify.sh` MUST exit green at every commit, and every document in `examples/` MUST keep both its validity and its Gatling verdict.
+- **FR-034**: Six files change and no others, beside this feature's own directory under `specs/`. #91 and #92 add no file to the list — both land inside files already on it: `README.md`, `GLOSSARY.md`, `schema/opennfr.io/v1/requirementset.schema.json`, `scripts/verify.sh`, a new `scripts/identity.py`, and one clause of `AGENTS.md` § *Structure*, which names what the gate shares and would otherwise name only half of it.
+- **FR-035**: The milestone lands as one pull request carrying milestone **v0.8.0**: the spec commit first, then one commit per issue in the order #58, #72, #82, #91, #92, with a `Closes` line for each. #91 follows #82 because its argument rests on both — #58 made the guard first-class and #72 probed it; #92 follows #91 because both edit `GLOSSARY.md` and the second reads better against the renamed entry.
+- **FR-036**: No compatibility-sensitive surface changes. No OpenTelemetry name the format borrows is touched, and no field name appearing in a published example is added, removed or renamed — `name` is an existing optional key whose description changes and whose published usage does not.
+- **FR-037**: No constitutional amendment is required or made. `.specify/memory/constitution.md` stays at 4.0.0.
+
+### Key Entities
+
+- **Identity (`criterionId`)**: what tells one predicate from the others in its list — its `name` if set, its `aggregation` otherwise. Unique within one list after FR-001. Defined in `GLOSSARY.md`, scoped in `README.md` § *A predicate*, checked by `scripts/verify.sh`, and — per #82 — not carried into the assertion a predicate renders to.
+- **A list**: `criteria` or `guards` on one requirement. The unit identity is unique within, and the reason the flagship example is legal.
+- **A reach row**: one line of a target's description, matched exactly, carrying a verdict and a reason. Gains a third verdict for an axis that decides nothing about assertability.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Exactly one sentence in the repository states what a predicate identity must be unique within. Deleting it leaves no other document making the claim, and every other mention names it rather than repeating it.
+- **SC-002**: The schema, `README.md`, `GLOSSARY.md`, `scripts/verify.sh` and `examples/` admit exactly one reading of identity scope, and it is the list. No document contradicts another, and neither `README.md` nor `GLOSSARY.md` contradicts itself.
+- **SC-003**: `examples/` is byte-identical before and after the milestone, and `the-run-held-up.yaml` is valid under the schema's own `name` description for the first time.
+- **SC-004**: Replacing either identity branch in `scripts/verify.sh` with `if False:` makes the gate exit non-zero, and each does so for its own reason. Both are currently replaceable with the gate still printing **PASS**.
+- **SC-005**: The `name` arm of the identity fallback is exercised by at least one probe that fails when it stops working. Nothing exercises it today.
+- **SC-006**: Deleting any identity probe fails the gate on a count, and the failure names the probe class that shrank.
+- **SC-007**: All nine predicate keys are addressed by a reach row, and § *How these tables are applied* claims a partition that holds. Two keys are unaddressed today.
+- **SC-008**: A renderer author reading the Identity subsection can say what a target does with an identity without opening Gatling's source, and can say which Gatling version and which date that answer was checked at — and can tell that it is not the version the section header names.
+- **SC-009**: A rejection added to `predicate_why` on the `name` key fails the gate. Nothing catches it today.
+- **SC-010**: `bash scripts/verify.sh` exits green at every commit of the pull request, and the probe counts in its summary lines are higher than at `7cf314a` for every table that gained one.
+- **SC-011**: All five issues are closed by the commits that land their fixes, and the pull request carries milestone **v0.8.0** before it merges.
+- **SC-012**: `criterionId` survives outside `specs/` in exactly one place — the *Rejected* line of `GLOSSARY.md` § *predicateId*, where Principle I requires it. Nowhere else, and in particular not in the gate's failure message on a colliding guard, which now names a term that is true of a guard.
+- **SC-013**: Every reason `GLOSSARY.md` § *name* gives for restricting the character set is checkable inside this repository. None of them names a report, a CI annotation or anything downstream of the assertions a renderer produces.
+
+## Assumptions
+
+- **The section reading wins on its merits, not by count.** Three sources against one is how the milestone describes it, but `README.md` and `GLOSSARY.md` each carry both readings, so the count is closer than it looks. The argument that decides it is that `rate` over requests and `rate` over a fraction are different quantities sharing a word — `README.md` § *A predicate* says the shape distinguishes them — and forcing a name on that collision is the noise `GLOSSARY.md`'s existing *Rejected* line refuses.
+- **The two lists are already two statements about different things.** A violated guard says the run did not happen; a violated criterion says the system did not hold. Two predicates that share a word across that line are not an ambiguous document, and requiring a name there buys nothing the shape has not already bought.
+- **Identity is a property of the document.** It is what makes two statements in one list distinguishable, and the rule is well-formedness, checkable by the gate without reference to anything downstream. Nothing in this milestone rests on what a consumer builds out of a failure.
+- **`criterionId` does not keep its name.** It read badly of a guard, and #91 renames it to `predicateId`. Principle I requires the argument to be in an issue before files change, and it is: #91 was filed against v0.8.0 first. This assumption held until review moved the rename into scope — see § *What review added*.
+- **Nothing about `name`'s syntax changes.** The pattern, the length bound and the optionality are untouched.
+- **The Gatling claim is verified before the row is written, at the version that could be read.** `Assertion`'s field list is the one claim in this milestone that cannot be checked from this repository — there is no Scala here and no build. It was read during planning from the `gatling-shared-model` jars already on the machine, and the row carries that version and that date. § *Gatling*'s header stays at 3.15.1 and the row says 3.13.5, and the text says why rather than letting a reader assume one number covers both.
+- **The third verdict is a cost, and a smaller one than the alternatives.** A new word in a target's description is a permanent cost under Principle I's reasoning. It is paid because the two existing verdicts answer a question this axis does not ask, and because the alternatives — a bullet under *Two things Gatling cannot do at all*, or narrowing the partition claim — either misfile a fact the assertion does not fail on, or fix the claim by making it promise less.
+- **The gate stays the only implementation of the tables.** `scripts/verify.sh` implements the reach section and never restates it, which is what Principle VI requires of a gate. FR-029's probe checks a row without copying one.
+- **Three commits, one per issue**, as `AGENTS.md` requires, with the spec commit preceding all three and folded into none.
+
+## Out of Scope
+
+- ~~**Renaming `criterionId`.**~~ **Moved into scope** as **#91** — see § *What review added*. The issue was filed before any file changed, which is what Principle I asks of a naming disagreement.
+- ~~**`GLOSSARY.md` § *name*.**~~ **Moved into scope** as **#92** — see § *What review added*.
+- **Requiring `name` on every predicate.** Already rejected in `GLOSSARY.md`, and this milestone reaffirms the rejection rather than reopening it.
+- **A second target.** The Identity row is a fact about Gatling. Whether another target carries an identity is that target's description's problem, and there is no second description.
+- **Anything downstream of the assertion.** How a target reports, what a consumer displays, how a failure might be traced back to the document that stated it — none of it is described here, and the Identity row must not drift into describing it. A renderer turns a requirement into assertions; that is the whole surface. Compensating for what a target does afterwards is the thing § *Two things Gatling cannot do at all* explicitly declines to do.
+- **A check on the reach section's dates.** Principle IV requires a claim about an external tool to carry the date it was checked; nothing verifies that the dates are current, here or for the four sources already in the section. That is a defect of the same family as #72 one document over, and it needs its own issue and its own argument about what such a check could decide.
+- **`README.md:546`'s wording.** It stays as it is. #72 makes it true; nothing about it is wrong to begin with.
+- **Anything under `docs/`.** No construct is proposed or parked by this milestone.

--- a/specs/011-identity-has-one-scope/tasks.md
+++ b/specs/011-identity-has-one-scope/tasks.md
@@ -1,0 +1,287 @@
+---
+
+description: "Tasks for 011-identity-has-one-scope"
+---
+
+# Tasks: Identity Has One Scope
+
+**Input**: Design documents from `specs/011-identity-has-one-scope/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: no separate test tasks. Two of the three issues *add checks* — six identity probes and one
+rendering probe — and those are deliverables, not tests of the feature. What validates the feature is
+the mutation set in [quickstart.md](quickstart.md) § 3 and § 4c: every mutation must redden the gate,
+and every one of them is green today. Those appear below as **T016** and **T022**, inside the commits
+that make them fail.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different file, no dependency on an unfinished task
+- **[Story]**: which user story the task serves (US1–US4)
+- Every task names the file it touches, and most name the line
+
+## Path Conventions
+
+No source tree. Six files outside `specs/`, and line numbers below are as of `7cf314a`:
+
+```text
+README.md                                        # :357-367 the `name` paragraph; a new #### Identity
+                                                 #   after § Units; :726 the partition claim
+schema/opennfr.io/v1/requirementset.schema.json  # :130 $defs/predicate.name description
+GLOSSARY.md                                      # :200-207 § criterionId
+scripts/identity.py                              # NEW
+scripts/verify.sh                                # :157-166 and :341-350 the two call sites;
+                                                 #   :788-803 PREDICATE_RENDERS; :825-826 FLOORS
+AGENTS.md                                        # § Structure, the scripts/ clause
+```
+
+**Line numbers move.** T005 rewrites `README.md:357-367` and T018 adds a subsection further down the
+same file; T012–T014 and T020–T021 edit `scripts/verify.sh` in four places. Locate by the quoted text
+in the contracts, never by the number alone.
+
+---
+
+## Phases are commits, and the first one carries two stories
+
+Three repository rules shape this list:
+
+- **1 issue = 1 commit**, each green on `bash scripts/verify.sh` on its own. Three issues, three issue
+  commits, and a phase is a commit. US1 and US2 are both #58.
+- **#58 first**, as the milestone orders it: a probe has to encode a scope (#72) and a reach row has
+  to describe an identity that means one thing (#82).
+- **Spec first.** `specs/011-*/` lands as its own commit before any `fix`/`docs`, never folded in.
+
+The one asymmetry worth naming: **#58 changes no gate and #72 changes no document.** #58 corrects what
+the repository *says*; #72 makes the gate notice when a document disobeys it. That is why #58's commit
+can be green without a single new probe, and why #72's commit adds no prose.
+
+---
+
+## Phase 1: Setup (baselines)
+
+**Purpose**: write down the before-state. Four of the quickstart's checks are comparisons, and the
+most important one — that the identity rule can be deleted green — stops being reproducible the
+moment Phase 4 lands. Record it while it is still true.
+
+- [X] T001 Record the three sites that scope identity to the requirement: run `grep -rn "in one requirement\|of one requirement\|within one requirement" README.md GLOSSARY.md schema/opennfr.io/v1/requirementset.schema.json` and keep the output. Expect exactly three hits — `GLOSSARY.md:202`, `README.md:357`, `schema/…:130`. This is the baseline for [quickstart.md](quickstart.md) § 2b.
+- [X] T002 Record that the identity rule is currently unenforced: replace `scripts/verify.sh:162`'s `if cid in seen:` with `if False:`, run `bash scripts/verify.sh`, confirm **PASS**; revert with `git checkout -- scripts/verify.sh`; repeat for `:346`'s `if cid in seen_ids:`. Keep both outputs. This is #72's central claim and the only baseline that cannot be reconstructed after T012–T014.
+- [X] T003 Record the current probe counts and the coverage gap — **after T002 has reverted its mutation**, since this task reads the gate T002 temporarily breaks and would otherwise record a baseline taken against a broken one: run `bash scripts/verify.sh` and keep the § *Examples are assertable by Gatling* line (expect `14 still rendered`), then run [quickstart.md](quickstart.md) § 4a's axis script and keep its output (expect five axis subsections, no `#### Identity`, and both `name` and `displayName` `MISSING`).
+
+**Checkpoint**: quickstart checks 0, 2b, 3 and 4a can now discriminate before and after.
+
+---
+
+## Phase 2: Foundational (blocking prerequisite)
+
+**Purpose**: the spec-first rule. `AGENTS.md` requires the `specs/NNN-*/` artifacts to land as their
+own commit before any implementation commit.
+
+**⚠️ CRITICAL**: no issue commit may be made until T004 is done.
+
+- [X] T004 Commit `specs/011-identity-has-one-scope/` — spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, contracts/ and checklists/ — as `docs(speckit): add 011-identity-has-one-scope spec/plan/tasks`. No file outside that directory is in the commit.
+
+**Checkpoint**: the argument is reviewable before anything it argues for is written.
+
+---
+
+## Phase 3: #58 — identity is unique within one list (US1 P1 + US2 P2) 🎯 MVP
+
+**Goal**: one reading of the scope, stated in one place, with the other two artifacts naming it
+instead of repeating it. Contract: [contracts/identity-scope.md](contracts/identity-scope.md).
+
+**Independent test**: quickstart checks 2a–2d. A renderer author reads the schema's `name`
+description, `README.md` § *A predicate* and `GLOSSARY.md` § *criterionId* in any order and finds
+one answer; `examples/the-run-held-up.yaml` is valid under all three for the first time.
+
+**No gate change.** `scripts/verify.sh` already implements this reading — that is why the corpus
+never failed. Making it fire is Phase 4.
+
+- [X] T005 [US1] Rewrite `README.md:357-367` — the `**\`name\`.**` paragraph — per [contracts/identity-scope.md](contracts/identity-scope.md) § 1: the scope becomes the list and is stated here; the worked example's collision moves into `criteria`; the exemption sentence names `examples/the-run-held-up.yaml`.
+- [X] T006 [P] [US2] Replace the `description` of `$defs/predicate.name` at `schema/opennfr.io/v1/requirementset.schema.json:130` per [contracts/identity-scope.md](contracts/identity-scope.md) § 2. It stops stating the scope and defers to `README.md`, in the shape `$defs/unit` already uses — and per **FR-006a** it also stops saying *"in a report"*, which is the last downstream claim in the schema.
+- [X] T007 [P] [US2] Rewrite `GLOSSARY.md:200-207` § *criterionId* per [contracts/identity-scope.md](contracts/identity-scope.md) § 3: the definition keeps the derivation, the scope becomes a pointer, and a second `*Rejected*` line records the requirement scope and why it was refused.
+- [X] T008 [US1] Verify the commit before making it: `git diff --stat -- examples/` is empty, `bash scripts/verify.sh` is **PASS**, and T001's grep now returns nothing.
+- [X] T009 [US1] Commit as `fix(format): identity is unique within one list (#58)` with a `Closes #58` line. Three files: `README.md`, `GLOSSARY.md`, `schema/opennfr.io/v1/requirementset.schema.json`.
+
+**Checkpoint**: #58 is closed — **SC-001**, **SC-002**, **SC-003**. The repository states one scope in one
+place, the flagship example is correct under every document that mentions it, and the corpus has not
+moved a byte.
+
+---
+
+## Phase 4: #72 — the identity rule is probed in both directions (US3 P3)
+
+**Goal**: the rule `README.md` states is enforced by something that would notice its absence.
+Contract: [contracts/identity-module.md](contracts/identity-module.md).
+
+**Independent test**: [quickstart.md](quickstart.md) § 3 — seven mutations, each applied alone, each must redden the gate. That list is canonical; [contracts/identity-module.md](contracts/identity-module.md) § *The seven mutations this commit makes fail* names the same seven against what catches each. T002 recorded that all seven are green today.
+
+**No document changes** beyond one clause of `AGENTS.md`, which rides here because this commit adds
+the file that clause describes.
+
+- [X] T010 [US3] Create `scripts/identity.py` with `SECTIONS`, `predicate_id(predicate)`, `collisions(requirement, scanned)` and `duplicates(requirement)`, per [contracts/identity-module.md](contracts/identity-module.md) § 1. The module docstring names `README.md` § *A predicate* as where the rule is stated and does **not** restate the scope.
+- [X] T011 [US3] Add `PROBES` (six entries), `FLOOR = 6` and `selftest()` to `scripts/identity.py` per the same contract. Four probes must report a collision, two must report none; the floor message is the file's existing sentence, *"a rule nothing probes is a rule nothing checks"*.
+- [X] T012 [US3] Wire the `SCHEMA` heredoc in `scripts/verify.sh` (lines 118–172): add `sys.path.insert(0, "scripts")`, `import identity`, the `selftest()` gate in the shape `LINKS` uses at `:901-911`, and `identity_lists = []`; then replace the inline rule at `:157-166` with `identity.collisions(r, identity_lists)`, and replace the comment at `:155-156` with a pointer to `scripts/identity.py` per **FR-008** — it is a second copy of the module's docstring once the rule moves, and its last clause, *"uniqueness is checked here"*, stops being true. Mind the boundary: the comment is 155–156, the rule is 157–166.
+- [X] T013 [US3] Add `IDENTITY_LISTS = 5` and its floor before `sys.exit(rc)` in the same `SCHEMA` heredoc of `scripts/verify.sh`, plus the `ok    identity: N probes still hold, M lists read` line (**FR-020**). The section has no aggregate line today.
+- [X] T014 [US3] Replace `scripts/verify.sh:340-350` in the `SELFCHECK` heredoc with the same import, the `identity.duplicates` call over the schema's root examples, a `root_identity_lists` counter and `ROOT_IDENTITY_LISTS = 1`. Keep the existing comment about the root examples answering to what the corpus answers to.
+- [X] T015 [P] [US3] Update `AGENTS.md` § *Structure*: `what it shares (\`mdlinks.py\`)` becomes `what it shares (\`mdlinks.py\`, \`identity.py\`)`. A map correction, not a rule.
+- [X] T016 [US3] Run all seven mutations from [quickstart.md](quickstart.md) § 3, one at a time, reverting between each with `git checkout -- scripts/identity.py scripts/verify.sh`. Every one must exit non-zero, and each must fail for its own reason. Compare against T002.
+- [X] T017 [US3] Commit as `fix(gate): the identity rule is probed in both directions (#72)` with a `Closes #72` line. Three files: `scripts/identity.py` (new), `scripts/verify.sh`, `AGENTS.md`.
+
+**Checkpoint**: #72 is closed — **SC-004**, **SC-005**, **SC-006**. `README.md` § *What the schema does not
+check* — *"The gate checks it; the schema cannot"* — is true in the sense that matters: deleting the
+check now fails.
+
+---
+
+## Phase 5: #82 — identity has no slot in a Gatling assertion (US4 P4)
+
+**Goal**: all nine predicate keys have a reach row, on an axis whose verdict is neither **can** nor
+**cannot**. Contract: [contracts/identity-reach.md](contracts/identity-reach.md).
+
+**Independent test**: quickstart checks 4a–4c. Nine keys, nine rows; the axis rejects nothing, and a
+probe says so.
+
+**The row stops at the assertion.** A target description says what a renderer reads to produce
+assertions. What Gatling does with an assertion afterwards is not described here, and no sentence in
+this phase may drift into describing it.
+
+- [X] T018 [US4] Add `#### Identity` to `README.md` § *Gatling*, between § *Units* and § *Two things Gatling cannot do at all*, per [contracts/identity-reach.md](contracts/identity-reach.md) § 1: two rows, the **not carried** verdict explained beneath, and a `Sourced`/`Checked` line naming `Assertion`, `gatling-shared-model` 0.0.11, **Gatling 3.13.5** and **2026-08-31** — and saying why that is not the header's 3.15.1.
+- [X] T019 [US4] Add the nine-keys paragraph to `README.md` § *How these tables are applied*, after *"The tables partition each axis."* at `:726`, per the same contract § 2. Seven keys decide assertability, two do not, and the gate implements no rejection from the Identity axis.
+- [X] T020 [P] [US4] Add `{**RENDERABLE, "name": "p95-latency"}` to `PREDICATE_RENDERS` in `scripts/verify.sh` (`:788-803`), with the comment explaining that this is the Identity axis's only probe and that it is a rendering one because the axis rejects nothing.
+- [X] T021 [US4] Raise the `PREDICATE_RENDERS` floor from **14** to **15** in `FLOORS` at `scripts/verify.sh:825-826`. Same file as T020, so not parallel with it.
+- [X] T022 [US4] Confirm the probe is load-bearing: add `if "name" in p: why.append("name has no equivalent")` to `predicate_why`, run `bash scripts/verify.sh`, confirm it exits non-zero, revert. T003 recorded that nothing catches this today.
+- [X] T023 [US4] Commit as `docs(format): identity has no slot in a Gatling assertion (#82)` with a `Closes #82` line. Two files: `README.md`, `scripts/verify.sh`.
+
+**Checkpoint**: all three issues closed — **SC-007**, **SC-008**, **SC-009**. Nine keys, nine rows, and a
+partition claim that holds.
+
+---
+
+## Phase 6: Polish, and what this milestone found but does not fix
+
+- [X] T024 Run [quickstart.md](quickstart.md) end to end against the finished branch — this is where **SC-010** (green at every commit, probe counts risen) is demonstrated — steps 0 through 4 and 6. Step 5 needs the Gatling jar and is expected to be unrunnable on a machine without it; that is the point of the step.
+- [X] T025 Confirm the shape of the whole change: `git diff --name-only main | grep -v '^specs/011-'` returns exactly the six files in § *Path Conventions*, and `git diff --stat main -- examples/` is empty (**FR-034**, **FR-009**, **FR-021**).
+- [X] T026 Confirm the three negative requirements the file list cannot reach: `git diff main -- .specify/memory/constitution.md` is empty and its footer still reads **4.0.0** (**FR-037**); `git diff main -- README.md` leaves the § *What the schema does not check* bullet *"That two predicates have distinct identities"* untouched (**FR-010**); and no borrowed OpenTelemetry name and no field name appearing in a published example is added, removed or renamed (**FR-036**) — which the empty `examples/` diff shows for the second half and a read of the schema diff shows for the first.
+- [X] T027 Demonstrate **SC-011**: open the pull request carrying milestone **v0.8.0** with `Closes #58`, `Closes #72` and `Closes #82`, then run `scripts/check-linkage.sh --pr <N>`. Confirm all three issues sit in that milestone. The PR title must be conventional before merge — a squash freezes it into the commit.
+- [X] T028 [P] Open the two issues this milestone found in passing — filed against **v0.8.0** and, on the maintainer's call, brought into scope rather than deferred (spec.md § *What review added*). They are **#91** and **#92**: **(a)** `criterionId` names the identity of a guard as well as a criterion and reads wrong of the first — a rename argued under Principle I; **(b)** `GLOSSARY.md` § *name* justifies its character restriction with *"a report line, a CI annotation, a URL fragment"*, two of which are downstream of anything this format describes, and it is the last place in the repository that argues from one.
+
+---
+
+## Phase 7: #91 — the term covers what it names
+
+**Goal**: `criterionId` becomes `predicateId`. Contract: spec.md FR-038 … FR-041.
+
+**Why it is here and not in v0.9.0**: #58 made the guard a first-class carrier of identity by scoping
+uniqueness to the list, and #72 shipped a probe whose whole subject is a guard's identity. The release
+that promoted the guard is the release that should stop calling its identity a criterion's.
+
+**Independent test**: `grep -rn criterionId` outside `specs/` returns only `GLOSSARY.md`'s *Rejected*
+line, which Principle I requires the entry to carry, and the gate's failure message on a colliding
+guard names a term that is true of a guard.
+
+- [X] T029 [US1] Rename the entry in `GLOSSARY.md`: `### criterionId` becomes `### predicateId`, and the body records what the old term got wrong — it named the identity of a predicate after one of the two lists that hold predicates. Both existing `*Rejected*` lines survive; they protect decisions this rename does not reopen (**FR-038**, **FR-039**).
+- [X] T030 [US1] Move every remaining site together (**FR-040**): both failure messages and the comment in `scripts/verify.sh`, and the `duplicates()` docstring in `scripts/identity.py`. `README.md` does not use the term and must not gain it.
+- [X] T031 [US1] Verify and commit as `refactor(vocabulary): the identity of a predicate is a predicateId (#91)` with `Closes #91`. `grep -rn criterionId` outside `specs/` returns only the *Rejected* line, `bash scripts/verify.sh` is **PASS**, and `git diff --stat main -- examples/ schema/` shows no new change.
+
+**Checkpoint**: #91 closed — **SC-012**.
+
+---
+
+## Phase 8: #92 — the restriction is justified by something the format has
+
+**Goal**: `GLOSSARY.md` § *name* stops arguing from consumers this format does not describe.
+Contract: spec.md FR-042, FR-043.
+
+**Independent test**: read the entry and name, for each reason it gives, the artifact in this
+repository that makes it true. Today two of three name things outside the format, and #82 makes the
+third false for the one target described.
+
+- [X] T032 [US4] Replace the justification in `GLOSSARY.md` § *name* (**FR-042**, **FR-043**): the restriction holds because an identity is compared for **equality** by the gate — a closed character set is what makes two identities that look alike to a reader be alike to the check — and because `$defs/name` is one spelling rule shared by `metadata.name`, a requirement's `name` and a predicate's `name`.
+- [X] T033 [US4] Replace the `*Rejected*` line *"free-form strings — nothing could point at one reliably"* on the same grounds, keeping the alternative it rejects. Principle I says the rejection outlives the term it protects, so the alternative stays and only its reason moves.
+- [X] T034 [US4] Verify and commit as `docs(vocabulary): name is restricted for a reason the format can back (#92)` with `Closes #92`. No reason in the entry names a report, a CI annotation, or anything downstream of the assertions a renderer produces.
+
+**Checkpoint**: #92 closed — **SC-013**. All five issues closed.
+
+---
+
+## Phase 9: the pull request catches up
+
+- [X] T035 Update [galax-io/opennfr#90](https://github.com/galax-io/opennfr/pull/90): add `Closes #91` and `Closes #92` to the body, describe both, and re-run `scripts/check-linkage.sh --pr 90`. Push with `--force-with-lease`, as `AGENTS.md` requires of a pushed PR.
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 (T001-T003)  baselines — must precede Phase 4, which destroys T002's
+      |
+Phase 2 (T004)       spec commit — blocks every issue commit
+      |
+Phase 3 (T005-T009)  #58    ── MVP. No gate change.
+      |
+Phase 4 (T010-T017)  #72    ── probes encode Phase 3's answer
+      |
+Phase 5 (T018-T023)  #82    ── the row describes an identity that means one thing
+      |
+Phase 6 (T024-T028)  PR, linkage, the two issues review brought into scope
+      |
+Phase 7 (T029-T031)  #91   ── the term the milestone made wrong
+      |
+Phase 8 (T032-T034)  #92   ── the reason FR-006a left behind
+      |
+Phase 9 (T035)       the PR catches up
+```
+
+**Why Phase 4 waits on Phase 3**: a content dependency, not a convention. Probe 6 — a `rate` guard
+beside a `rate` criterion reporting no collision — *is* #58's answer written as code. Written before
+the answer was settled, it would encode a scope no document yet states.
+
+**Why Phase 5 waits on Phase 4**: convention rather than content. The Identity row does not depend on
+the probes. It is last because the milestone orders it last, and because #82's row describes an
+identity whose meaning Phase 3 fixed.
+
+**Parallel within Phase 3**: T006 (schema) and T007 (`GLOSSARY.md`) are different files from T005
+(`README.md`) and from each other. All three can be written at once; T008 verifies the set.
+
+**Parallel within Phase 4**: T015 (`AGENTS.md`) touches neither `identity.py` nor `verify.sh` and can
+be done at any point in the phase. T010 → T011 are the same file in sequence; T012 → T013 are the same
+heredoc in sequence; T014 is a different heredoc but the same file, so it follows T013.
+
+**Parallel within Phase 5**: T018 and T019 are both `README.md` and are sequential; T020 is
+`scripts/verify.sh` and is parallel with either; T021 follows T020 in the same file.
+
+---
+
+## Implementation Strategy
+
+**The smallest shippable increment is Phase 3.** It closes #58, ends a contradiction between the two
+most authoritative documents in the repository, and makes the flagship example valid under every
+document that mentions it. It needs no new machinery and touches no gate.
+
+**Phase 4 is the one that changes what the repository can prove.** Everything else in this milestone
+is words; T010–T017 turn a claim into a check. If time runs out, this is the phase not to defer:
+#72 is a rule that has been *stated* since guards arrived and enforced by nothing that would notice.
+
+**The contestable part is Phase 5, not Phases 3 or 4.** The one decision a reviewer might reverse is
+the third verdict — **not carried** beside **can** and **cannot** in a target's description. The
+alternatives and why each was rejected are in plan.md § *Complexity Tracking* and research.md R6. If
+the verdict is rejected in review, Phases 3 and 4 stand unchanged and #82 is re-argued alone.
+
+**Each issue commit must survive being read alone.** T009, T017 and T023 each carry a `Closes` line
+and each must be green on `bash scripts/verify.sh` at that commit, not only at the tip.
+
+---
+
+## Notes
+
+- **`examples/` is never edited.** If any task appears to require a corpus change, the task is wrong.
+  Every published document is already valid under the reading this milestone settles on, and FR-021
+  keeps the corpus out of the coverage business — the `name` arm is exercised by probes.
+- **One external claim.** The Identity row's reason rests on Gatling's `Assertion`, read at 3.13.5
+  from `gatling-shared-model` 0.0.11 on 2026-08-31 (research.md R1). It cannot be checked from this
+  repository, which is why T018 carries the version and the date into the page itself.
+- **Adding a probe means raising the floor beside it.** `scripts/verify.sh:826` states that as a rule.
+  T021 pays it for T020, and T011's `FLOOR = 6` is exact for the same reason.
+- **No constitutional amendment.** `.specify/memory/constitution.md` stays at 4.0.0 and is not opened.

--- a/specs/012-the-metric-names-are-ours/spec.md
+++ b/specs/012-the-metric-names-are-ours/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: The Metric Names Are Ours
+
+**Feature Branch**: `011-identity-has-one-scope`
+
+**Created**: 2026-08-31
+
+**Status**: Draft
+
+**Input**: [#89](https://github.com/galax-io/opennfr/issues/89), milestone **v0.8.0**, `severity:critical`. Filed after the milestone's first three issues had landed and brought into scope on the maintainer's call, so it rides in the same pull request. It is a second spec rather than a section of `011-identity-has-one-scope` because it is a second argument: that one is about what tells two statements apart, this one is about who owns a name.
+
+**Scope note**: `http.client.request.duration` is retired for `loadtest.request.duration`, and `loadtest.group.duration` is minted beside it. This is the first time this repository mints a metric name, and it reverses two decisions `GLOSSARY.md` records — which is why the entry that records them is amended rather than contradicted.
+
+Unlike `011`, this one **does** change the published corpus: four documents carry the retired name.
+
+## Decisions
+
+### Session 2026-08-31
+
+- **Q**: #89 asks for the old name to be *"deprecated with a window and then removed — accepted with a warning while the corpus and any existing documents migrate"*. The gate has two outcomes, `ok` and `FAIL`; a warning is a third, and Principle III forbids reporting success by omission. → **A**: **No window. A clean cut.** The corpus is four documents in this repository, the one external consumer #89 names is *"ready to follow"*, and `AGENTS.md` says nothing is stable yet. A window would buy a deprecation period for documents nobody has, at the price of a third verdict in the gate and an argument for why it is not a silent green.
+
+- **Q**: #89 says the borrowing rule *"needs one qualification"* — semconv having a **string** is not semconv having this **quantity**. That rule is also Principle II of the constitution, word for word. Does the constitution get the qualification? → **A**: **No amendment.** *"Equivalent"* is read as an equivalent **quantity**, which is what the word means and what makes the clause coherent: semconv has no name for *the duration of one recorded operation, whatever produced it, by the generator's own clock*, so Principle II already permits the mint. `README.md` § *Names* states what "equivalent" means; the constitution stays at **4.0.0**.
+
+### What was verified here, and what was taken from the issue
+
+#89 is sourced to Gatling 3.13.5. Every load-bearing claim it makes about the assertion path was **re-read from the jars on this machine** rather than quoted, with `javap` against `gatling-charts` 3.13.5 and `gatling-shared-model` 0.0.11 on **2026-08-31**:
+
+| Claim | Verified |
+|---|---|
+| The assertion path reads `AssertionStatsRepository`, which has exactly four methods | `allRequestPaths`, `findPathByParts`, `requestGeneralStats`, `groupCumulatedResponseTimeGeneralStats` |
+| A group's cumulated response time **is** assertable | `groupCumulatedResponseTimeGeneralStats(List[String], Option[Status])` is on the interface |
+| A group's wall-clock duration is **not** | `groupDurationGeneralStats` exists on `LogFileData` and is **absent** from `AssertionStatsRepository`, so no assertion can reach it |
+| A group statistic admits the same aggregations as a request's | both return `AssertionStatsRepository.Stats(min: Int, max: Int, count: Long, mean: Int, stdDev: Int, percentile: Double => Double, meanRequestsPerSec: Double)` — one type, so one set of aggregations and the same integer-threshold rule |
+
+What was **not** re-verified and is carried from #89 on its own authority, dated to its reading: that `gatling.charting.useGroupDurationMetric` reaches the report generator only and never the assertion path. It is consistent with what was verified — the flag cannot change an assertion that has no access to the quantity it selects — and the reach text says which reading it rests on.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A mixed run stops rendering to something it does not say (Priority: P1)
+
+An author writes `metric: http.client.request.duration` under `selector: {}`. Every row of the Selection and Metrics tables says **can**, and the document is schema-valid. It renders to Gatling's global scope, whose buffer holds every entry recorded through `statsEngine.logResponse` — JMS, JDBC, every third-party protocol plugin. On an HTTP-only run the two quantities coincide. On a mixed run the document says *99th percentile of HTTP client request duration* and the assertion evaluates *99th percentile of the response time of every recorded operation*, and nothing anywhere says so.
+
+After this story the name states the quantity that is actually measured: `loadtest.request.duration`, the duration of one recorded operation by the generator's own clock, protocol left to the operation.
+
+**Why this priority**: it is the `severity:critical` case — a document silently rendering to something it does not say — and every other change here follows from fixing the name.
+
+**Independent Test**: write the mixed-run document with the new name and read it against the Metrics row. The row says what is measured, and the document says the same thing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the retired name, **When** an author writes it, **Then** the gate refuses the document for a published example and the reach table says why.
+2. **Given** `loadtest.request.duration` under `selector: {}`, **When** a reader asks what is measured, **Then** the answer is the same on a mixed run as on an HTTP-only one.
+3. **Given** `README.md` § *Names*, **When** a reader asks why the format mints a name here, **Then** the answer names the vantage — `loadtest.*` is the vantage statement — and does not rest on semconv lacking a string.
+
+---
+
+### User Story 2 - A group scope becomes assertable, and says which quantity (Priority: P2)
+
+`{loadtest.group.name: [G₁, …, Gₙ]}` with no request name is **cannot** today, and the row's reason is that *"no name in § Names is true of"* a group's cumulated response time. That reason was a missing name, not a missing capability: `AssertionStatsRepository.groupCumulatedResponseTimeGeneralStats` is on the interface and has been all along.
+
+After this story the selection renders, paired with `loadtest.group.duration`, and the reach text says which of the two quantities that could answer to "the duration of a group" a Gatling run computes.
+
+**Why this priority**: it is the half of [#52](https://github.com/galax-io/opennfr/issues/52) that could not be closed until a name existed. It is second because it depends on the minting rule Story 1 establishes.
+
+**Independent Test**: the hierarchy-only selector with `loadtest.group.duration` renders; with any other metric it does not; and the reach text names the quantity Gatling computes and the one it does not.
+
+**Acceptance Scenarios**:
+
+1. **Given** `{loadtest.group.name: ["Checkout"]}` with `loadtest.group.duration`, **When** the gate judges it, **Then** it renders.
+2. **Given** the same selection with `loadtest.request.duration`, **When** the gate judges it, **Then** it is refused: a hierarchy-only path resolves to a group, and a group has no request statistics of its own.
+3. **Given** the Identity of the quantity, **When** a reader asks what Gatling computes, **Then** the text says the **sum of the enclosed operations' durations**, not the elapsed time of the traversal, and says the wall-clock quantity is computed but unreachable by any assertion.
+
+---
+
+### Edge Cases
+
+- **`sum` is not a substitute.** The group quantity is a percentile across traversals of a sum across the operations each traversal encloses — two nested aggregations, and `aggregation` states one. It is a distinct measured quantity, so it is a distinct name.
+- **Aliasing.** Pointing the old name at the new one would make `metric: http.client.request.duration` over a Kafka run conformant and false. It is retired, not aliased.
+- **The other three names in § *Names*.** `http.client.request.body.size`, `http.client.response.body.size` and `http.server.request.duration` keep their names. Fault 2 does not reach them: the body sizes are volumes and unrenderable either way, and `http.server.request.duration` names a *different vantage* on purpose — it is the one place the format deliberately says "not the generator's clock".
+- **A rejected alternative reversed.** `GLOSSARY.md` § *metric* declined a name for a group's cumulated response time *"because no scope denotes the requests a path encloses"*. That reason is false and this milestone verified it false. Development Workflow requires the entry to be amended rather than contradicted.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `loadtest.request.duration` MUST be minted: the duration of one recorded operation, measured by the load generator's own clock, with the protocol an attribute of the operation rather than part of the measurement.
+- **FR-002**: `loadtest.group.duration` MUST be minted: the duration of one traversal of a group.
+- **FR-003**: `http.client.request.duration` MUST be retired — removed from § *Names* as a name an author may write, and carried in the reach tables as a row that refuses it with the reason. It MUST NOT be aliased to either new name.
+- **FR-004**: The published corpus MUST migrate in the same commit. Four documents in `examples/` and four embedded examples in the schema carry the retired name.
+- **FR-005**: `README.md` § *Names* MUST state the qualification the mint rests on: semconv having a **string** is not semconv having this **quantity**, and where a semconv name would import a producer this format is not, a `loadtest.*` name is required rather than merely permitted. The paragraph that says **no name is minted here** MUST be replaced, because one is.
+- **FR-006**: `GLOSSARY.md` MUST gain an entry for each minted name before either appears in an example, a schema or an implementation, as Principle I requires, and each MUST record a rejected alternative.
+- **FR-007**: `GLOSSARY.md` § *metric* MUST be **amended**, not contradicted. It records two decisions this change reverses — the mint bar as applied to a group's cumulated response time, and the claim that no scope denotes the requests a path encloses. Development Workflow requires the amendment to be in this PR.
+- **FR-008**: The reach § *Metrics* table MUST carry a row for each minted name and a row retiring `http.client.request.duration`, each with its reason.
+- **FR-009**: The reach § *Selection* row for `{loadtest.group.name: [G₁, …, Gₙ]}` with no request name MUST become **can**, paired with `loadtest.group.duration`.
+- **FR-010**: The pairing MUST be stated as a **joint** constraint and enforced as one. A hierarchy-only path resolves to a group, so it admits `loadtest.group.duration` and nothing else; every other selection admits `loadtest.request.duration` and not the group name. § *How these tables are applied* MUST say that this one pair is judged jointly, because the section otherwise claims each axis decides alone.
+- **FR-011**: The reach text MUST say which quantity a Gatling run computes for `loadtest.group.duration` — the sum of the enclosed operations' durations, not the elapsed time of the traversal — and MUST record that the wall-clock quantity is computed and unreachable by any assertion.
+- **FR-012**: Every claim about Gatling MUST carry the artifact it was read from and the date. Claims re-read here MUST be dated to this reading; the one carried from #89 MUST say so rather than borrowing this reading's authority.
+- **FR-013**: `scripts/verify.sh` MUST implement every row it publishes: the two metric names, the retired one, the new selection, and the joint rule. Each MUST be probed in both directions, with the floors raised beside the probes.
+- **FR-014**: The schema MUST NOT enumerate metric names. It does not today and this change does not start: only its embedded examples move.
+- **FR-015**: `.specify/memory/constitution.md` MUST NOT change. Principle II already permits the mint under the reading recorded in § *Decisions*.
+- **FR-016**: `bash scripts/verify.sh` MUST be green at the commit, and every document in `examples/` MUST keep its validity and gain no new refusal.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: No artifact outside `specs/` and `docs/` offers `http.client.request.duration` as a name an author may write, and the reach tables refuse it with a reason.
+- **SC-002**: `examples/` validates and renders with the new names, and the mixed-run document a reader can now write says the quantity it renders to.
+- **SC-003**: A hierarchy-only selection renders with `loadtest.group.duration` and is refused with any other metric, and both directions are probed.
+- **SC-004**: Every reach claim about a group statistic names the jar it was read from and the date, and the one claim carried from #89 is marked as carried.
+- **SC-005**: `GLOSSARY.md` carries an entry for each minted name with a rejected alternative, and § *metric* no longer records a decision this PR reverses.
+- **SC-006**: `bash scripts/verify.sh` is green, and the probe counts are higher than before by the number of probes added.
+
+## Assumptions
+
+- **The quantity exists outside this repository.** The mint bar in `GLOSSARY.md` § *metric* — *"a name is minted only where something outside this repository already records the quantity under one"* — is cleared by the quantity, not the string: Gatling records a response time per recorded operation and a cumulated time per group, JMeter records elapsed time per sample and per transaction controller, k6 records per-request and per-group timings. One target's feature is not the grounds; three tools recording the same quantity is.
+- **The corpus migrates, and its meaning does not.** Every published document is HTTP-only, so the number each asserts is unchanged. What changes is that the name now states what was always being measured.
+- **`http.server.request.duration` stays.** It is the one name in § *Names* whose whole point is a different vantage, and Fault 2 does not reach it.
+- **One commit.** #89 is one issue, so it is one commit, with the spec commit before it.

--- a/specs/012-the-metric-names-are-ours/tasks.md
+++ b/specs/012-the-metric-names-are-ours/tasks.md
@@ -1,0 +1,68 @@
+---
+
+description: "Tasks for 012-the-metric-names-are-ours"
+---
+
+# Tasks: The Metric Names Are Ours
+
+**Input**: [spec.md](spec.md) and [#89](https://github.com/galax-io/opennfr/issues/89)
+
+**Tests**: no separate test tasks. The probes T009 adds are deliverables, not tests of the feature;
+what validates it is that each new row is exercised in both directions and that the retired name is
+refused. Both are inside T009 and T010.
+
+## Format: `[ID] [P?] Description`
+
+## Path Conventions
+
+```text
+GLOSSARY.md                                      # § metric amended; two entries minted
+README.md                                        # § Names; reach § Metrics, § Selection, § Units,
+                                                 #   § How these tables are applied
+schema/opennfr.io/v1/requirementset.schema.json  # four embedded examples; no enumeration added
+examples/                                        # four documents migrate
+scripts/verify.sh                                # METRIC -> two names, SELECTIONS, the joint rule,
+                                                 #   probes and floors
+```
+
+---
+
+## Phase 1: Vocabulary first
+
+**Purpose**: Principle I — a new term reaches `GLOSSARY.md` before it reaches an example, a schema or
+an implementation. Two names are minted, and the entry that declined one of them is amended.
+
+- [X] T001 Amend `GLOSSARY.md` § *metric* (**FR-007**): it records two decisions this change reverses — the mint bar as applied to a group's cumulated response time, and the claim that *"no scope denotes the requests a path encloses"*, which this milestone verified false. Development Workflow requires the entry to be amended rather than contradicted.
+- [X] T002 Add `GLOSSARY.md` § *loadtest.request.duration* (**FR-001**, **FR-006**): the duration of one recorded operation by the generator's own clock, protocol an attribute of the operation. *Rejected*: `http.client.request.duration`, with Fault 2 as the reason — it is published by other producers, so a requirement document and a production dashboard could carry one string for two measurements.
+- [X] T003 Add `GLOSSARY.md` § *loadtest.group.duration* (**FR-002**, **FR-006**): the duration of one traversal of a group. *Rejected*: `aggregation: sum` over `loadtest.request.duration` — the quantity is two nested aggregations and `aggregation` states one.
+
+**Checkpoint**: both names exist in the vocabulary before anything writes them — **SC-005**.
+
+---
+
+## Phase 2: What an author may write
+
+- [X] T004 `README.md` § *Names* → Metrics table (**FR-001**, **FR-002**, **FR-003**): the two minted names replace `http.client.request.duration`; the three remaining borrowed names stay, and the text says why Fault 2 does not reach them.
+- [X] T005 `README.md` § *Names* — the qualification (**FR-005**): semconv having a **string** is not semconv having this **quantity**, and where a semconv name would import a producer this format is not, a `loadtest.*` name is required rather than permitted. The paragraph saying *"No name is minted here"* goes, because one is.
+- [X] T006 [P] Migrate `examples/` — four documents — and the schema's four embedded examples (**FR-004**, **FR-014**). No enumeration of metric names is added to the schema.
+
+**Checkpoint**: the corpus says what it measures — **SC-002**.
+
+---
+
+## Phase 3: What a tool can run
+
+- [X] T007 `README.md` reach § *Metrics* (**FR-008**): a row for each minted name and a row retiring `http.client.request.duration` with its reason. The group row carries the quantity Gatling computes — the **sum** of the enclosed operations' durations — and records that the wall-clock quantity is computed and unreachable (**FR-011**), with the jar and date it was read from (**FR-012**).
+- [X] T008 `README.md` reach § *Selection* and § *How these tables are applied* (**FR-009**, **FR-010**): the hierarchy-only row becomes **can**, paired with `loadtest.group.duration`, and the section says that this one pair is judged **jointly** — the only place where an axis does not decide alone.
+
+**Checkpoint**: every published row states its reason and its source — **SC-001**, **SC-004**.
+
+---
+
+## Phase 4: The gate implements every row it publishes
+
+- [X] T009 `scripts/verify.sh` (**FR-013**): `METRIC` becomes the two names; `SELECTIONS` gains the hierarchy-only shape; a joint rule refuses a group metric under a request selection and a request metric under a group selection. Probes in both directions for each new row, and the floors beside them raised.
+- [X] T010 Verify: the retired name is refused, the hierarchy-only selection renders only with `loadtest.group.duration`, every new probe fires when its rule is removed, and `bash scripts/verify.sh` is green (**FR-016**, **SC-003**, **SC-006**).
+- [ ] T011 Commit as `feat(format): the metric names are ours (#89)` with `Closes #89`, and add the closing line to [#90](https://github.com/galax-io/opennfr/pull/90).
+
+**Checkpoint**: #89 closed; milestone v0.8.0 has no issue without a closing PR.


### PR DESCRIPTION
Milestone **v0.8.0**. Six issues. Five sit under one question: *what tells two statements in one document apart?*

Identity — the `name` if set, the `aggregation` otherwise — was scoped two incompatible ways, checked by a branch nothing reached, and never described at the target. Each issue is written from the previous one's answer, so they land in the milestone's own order. #91 and #92 were found in passing and brought into scope rather than deferred: each is a defect this milestone's own work created or exposed, and both were filed against v0.8.0 **before** any file changed, which is what Principle I asks of a naming disagreement.

### #58 — one scope, and one place that states it

The schema scoped identity to the **requirement**; `README.md`, the gate and the corpus scoped it to the **list**. `examples/the-run-held-up.yaml` — the document that explains guards — is malformed under the first reading and correct under the second. Two documents each stated both: `README.md` taught the requirement scope in its worked example and the list scope three lines below it, and `GLOSSARY.md` named the requirement in its definition and the list in its rule.

**The list wins.** `rate` over the requests and `rate` over a fraction are different quantities sharing a word, and a predicate's own shape already tells them apart — so the wider scope would force a name onto a collision that is only lexical, which is the noise `GLOSSARY.md`'s own *Rejected* line refuses.

**And the rule gets one home** rather than four corrected copies. `README.md` § *A predicate* states it; the schema's `name` description and `GLOSSARY.md` § *criterionId* name that section instead of repeating it, in the shape `$defs/unit` already uses. Four agreeing copies is the state #58 reports on — nothing makes copies converge, and this one drifted the moment guards arrived.

The schema description also stops saying the key identifies the predicate *"in a report"*. A report is downstream of the assertions a renderer produces, and this format describes neither.

### #72 — the branch fires, and stays fired

Both uniqueness branches could be replaced with `if False:` and the gate still printed **PASS** — recorded before the fix, and reproduced in the PR's own history. All ten corpus predicates carry `name = None`, so does the schema's root example, so no colliding pair existed anywhere and the **`name` arm of the fallback had never been observed at all**.

The rule moves to `scripts/identity.py`, shared by the two heredocs that check it, for the reason `mdlinks.py`'s own comment already gives: two copies drift. Six probes — four that must report a collision, two that must not, because without that second direction a rule hardened into *"every pair collides"* passes every rejection probe. An exact floor of six beside them.

A probe cannot catch a deleted **call**, since probes reach the module directly. Each site therefore counts the lists it read and floors the count, which is what Principle III asks of a check that scanned nothing.

**Seven mutations now redden the gate, each for its own reason. All seven were green before.**

### #82 — the identity axis gets a row

The reach tables claim to partition every axis; two of the nine predicate keys had no row, so a renderer meeting a `name` met no instruction at all.

`Assertion` is `(path, target, condition)` and no field of it holds a label. The predicate renders; the key does not travel with it. That is not **cannot** — the assertion runs — so the axis takes a third verdict, **not carried**, which says what becomes of the key rather than whether the statement runs. `displayName` gets its own row and its own reason: it is inert, so nothing is lost.

The axis rejects nothing, and nothing could show that: no corpus document and no probe carried a `name`, so a rejection added on the key would have been caught by nothing. `PREDICATE_RENDERS` gains one and its floor goes **14 → 15**.

**Sourced** to `gatling-shared-model` 0.0.11, the release Gatling **3.13.5** pins, read with `javap` on **2026-08-31**. The section header is sourced to 3.15.1; the row names the version it was *actually* read at rather than borrowing that one, and says why. This is the one claim in the milestone that cannot be checked inside this repository.

### #91 — the term covers what it names

`criterionId` named the identity of a predicate after one of the two lists that hold predicates. This milestone made that load-bearing rather than untidy: #58 scoped uniqueness to the **list**, which is exactly what makes a guard an equal carrier of identity, and #72 shipped a probe whose whole subject is a guard's identity. The gate said it out loud, in the message a contributor reads when their build goes red:

```
FAIL  examples/the-run-held-up.yaml: whole-run/guards: duplicate criterionId 'rate'
```

It is now `predicateId`. Four sites move together — the `GLOSSARY.md` entry, two failure messages and one comment in `scripts/verify.sh`, one docstring in `scripts/identity.py`. `README.md` never used the term. The entry records what the old term got wrong, as Principle I requires of a rename, and keeps both rejections it already carried. No compatibility-sensitive surface moves: it is a derived value with a name, never a field.

### #92 — the restriction is justified by something the format has

`GLOSSARY.md` § *name* justified its character restriction with *"something downstream — a report line, a CI annotation, a URL fragment — has to be able to point at it"*. Two of those are downstream of the assertions a renderer produces, and this format describes neither. The third is no better: **#82 in this same PR** makes it false for the one target described — the identity is **not carried** into a Gatling assertion, so nothing downstream of a run points at a `name`, because the `name` does not get there. Nothing inside the format points at one either; there is no cross-reference construct.

The restriction is real; its stated reason was not — which is the shape of #75 one document over, a false reason in a normative document. Two reasons replace it, both checkable here: an identity is compared for **equality** by `scripts/verify.sh`, so a closed character set is what makes two identities that look alike to a reader be alike to the check; and `$defs/name` is one spelling rule shared by `metadata.name`, a requirement's `name` and a predicate's `name`.

### #89 — the metric names are ours

`http.client.request.duration` welded three independent things into one string — the vantage, the protocol, the granularity — and a load generator fixes only the first. `selector: {}` renders to Gatling's **global** scope, whose buffer holds every entry recorded through `statsEngine.logResponse`: JMS, JDBC, every third-party plugin. On a mixed run the document said *99th percentile of HTTP client request duration* and the assertion evaluated the 99th percentile of **every recorded operation**, silently.

And the name belongs to someone else — published by production instrumentation and by any OpenTelemetry HTTP client, where `client` means the calling service. A requirement document and a production dashboard could carry one string for two measurements: the substitution this format exists to forbid, committed by the naming rule meant to forbid it.

Two names are minted: **`loadtest.request.duration`** (one recorded operation, by the generator's clock, protocol an attribute of the operation) and **`loadtest.group.duration`** (one traversal of a group). The old name is **retired, not aliased** — aliasing would make it mean "any recorded operation", so reading it over a Kafka run would be conformant and false. No deprecation window: the gate has `ok` and `FAIL` and Principle III is hostile to a third, the corpus is four files here, and the one external consumer is ready to follow. Every published document is HTTP-only, so no number changes — only the name now states what was always measured.

**The hierarchy-only selection flips `cannot` → `can`.** It refused because *"no name in § Names is true of"* a group's cumulated response time — a missing name, not a missing capability. `AssertionStatsRepository` has carried `groupCumulatedResponseTimeGeneralStats` all along, and `groupDurationGeneralStats` is **absent** from the interface, so the wall-clock quantity is computed and unreachable by any assertion. Both statistics return one `Stats` type, which is why a group admits the same aggregations, units and integer-threshold rule as a request. Read with `javap` from `gatling-charts` 3.13.5 and `gatling-shared-model` 0.0.11 on 2026-08-31 — #89's claims were re-verified here, not quoted.

**One joint rule, and the section says it is the only one.** A hierarchy with no request name admits `loadtest.group.duration` and nothing else; every other selection admits everything but it. Two `can` rows that do not compose is precisely what a renderer cannot discover from the tables alone.

`GLOSSARY.md` § *metric* is **amended** rather than contradicted, as Development Workflow requires: it recorded both declines this reverses, and its second reason — that no scope denotes the requests a path encloses — was simply wrong.

A mutation adding the retired name back to `METRICS` **survived every probe**, because its `cannot` row is the only published rule that is an *absence*. It now has a probe of its own, and the predicate-rejection floor rises with it.

### What review changed, and where it landed

A max-effort review of this branch found that **three of the rules the milestone shipped could be deleted with the gate still green**, and that several pages claimed more than had been checked. Every fix is folded into the commit whose defect it corrects, so the history is still the spec commit plus one commit per issue.

**The counted floors guarded the wrong call** (#72). `identity_lists` was fed by a separate `lists_in()`, so dropping the `duplicates()` loop at either site left both floors satisfied while the gate printed `ok identity: 6 probes still hold, 5 lists read` and the uniqueness rule was enforced nowhere. `collisions()` is now a generator that appends one entry per list compared, so the count is a by-product of *consuming* the check and an unconsumed check appends nothing.

**The pairing rule had no guard at all, and `GROUP_METRIC`'s value was anchored by nothing** (#89) — renaming it stayed green while the gate rejected the name README publishes. The corpus and the pairing probes now share one `render_why` composite, and the gate checks both metric names against README's reach section.

**A predicate carrying `metric` beside `bad`/`good` had its metric silently discarded by the shape** (#89), which let a group metric ride a fraction into a group scope asserting `failedRequests`. That is the #57 class and is now refused for every metric. The group statistic is a property of the metric rather than a rewrite of another name, and has a probe that reads it.

**Two corrections claim less rather than more.** `README.md` no longer says a `loadtest.*` name is *"required rather than merely permitted"* — that is a reading of *equivalent*, not a second rule, and nothing is added to Principle II. And the claim that **JMeter and k6** record these quantities is **withdrawn rather than reworded**: it was never checked or dated, Principle IV does not allow one on memory, and the minting bar for `loadtest.group.duration` therefore rests on one target so far — which the Compatibility Constraints call necessary and **not sufficient**. That is written down as open on the page, and wants its own issue before v0.8.0 is tagged.

### What did not change

`examples/` is byte-identical **for #58, #72, #82, #91 and #92** — the corpus is not where coverage gets installed. #89 is the one issue here that touches it, and it touches only the metric name: every published document keeps its selector, its thresholds and its verdict. `.specify/memory/constitution.md` stays at 4.0.0 — no amendment is needed or made. No compatibility-sensitive surface moves: the schema's key set is identical and only a description string differs.

Nine files change: `README.md`, `GLOSSARY.md`, `schema/opennfr.io/v1/requirementset.schema.json`, `scripts/verify.sh`, a new `scripts/identity.py`, and one clause of `AGENTS.md` § *Structure*, which names what the gate shares and would otherwise name half of it.

`.specify/memory/constitution.md` stays at **4.0.0**: #89 asked whether Principle II needs a qualification, and it does not — *"equivalent"* reads as an equivalent **quantity**, and semconv has no name for the duration of any recorded operation by the generator's own clock, so the clause already permits the mint.

`bash scripts/verify.sh` is green at **every** commit, not only the tip.

### Left for their own issues

Two things this milestone found and deliberately does not fix: `criterionId` names the identity of a guard as well as a criterion and reads wrong of the first; and `GLOSSARY.md` § *name* justifies its character restriction with *"a report line, a CI annotation, a URL fragment"*, two of which are downstream of anything this format describes.

Closes #58
Closes #72
Closes #82
Closes #91
Closes #92
Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
