### PR TITLE
fix(ci): the release notes surface a vocabulary change, and in the stated order

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -2,14 +2,17 @@
 # AGENTS.md names git-cliff as the release-notes tool; this is its config.
 #
 # The commit groups below are ordered for a design repo: what the format now says
-# comes before how the notes are organised. Once there is an implementation,
-# revisit the ordering — "feat" will start meaning code rather than vocabulary.
+# comes before how the notes are organised. The order is the `<!-- N -->` prefix on
+# each group and NOT the order of the parsers — Tera's group_by sorts by key, so for
+# eight releases these notes came out alphabetical while this comment claimed
+# otherwise. Once there is an implementation, revisit it: "feat" will start meaning
+# code rather than vocabulary.
 
 [changelog]
 header = ""
 body = """
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 - {{ commit.message | split(pat="\n") | first | trim | upper_first }}
 {%- endfor %}
@@ -34,20 +37,27 @@ protect_breaking_commits = true
 sort_commits = "oldest"
 
 commit_parsers = [
+  # Vocabulary first, whatever type carries it. A term is the one thing every
+  # document is written against, so a rename or a redefinition outranks the
+  # change that motivated it — which is what the note below this list asks for
+  # and what nothing here used to do. Without this line `refactor(vocabulary)`
+  # falls through to Housekeeping and `docs(vocabulary)` to Notes; v0.8.0
+  # shipped a renamed term filed under housekeeping for exactly that reason.
+  { message = "^[a-z]+\\((vocabulary|glossary)\\)!?:", group = "<!-- 1 -->Vocabulary" },
   # A design repo's headline change is a change to what the format says.
-  { message = "^feat", group = "Format changes" },
-  { message = "^docs\\(adr\\)", group = "Decisions revisited" },
-  { message = "^docs\\(speckit\\)", group = "Specs" },
-  { message = "^docs", group = "Notes" },
-  { message = "^fix", group = "Corrections" },
-  { message = "^refactor", group = "Housekeeping" },
+  { message = "^feat", group = "<!-- 2 -->Format changes" },
+  { message = "^docs\\(adr\\)", group = "<!-- 5 -->Decisions revisited" },
+  { message = "^docs\\(speckit\\)", group = "<!-- 6 -->Specs" },
+  { message = "^docs", group = "<!-- 4 -->Notes" },
+  { message = "^fix", group = "<!-- 3 -->Corrections" },
+  { message = "^refactor", group = "<!-- 7 -->Housekeeping" },
   { message = "^chore\\(release\\)", skip = true },
-  { message = "^chore", group = "Housekeeping" },
-  { message = "^ci", group = "Housekeeping" },
-  { body = ".*security", group = "Security" },
+  { message = "^chore", group = "<!-- 7 -->Housekeeping" },
+  { message = "^ci", group = "<!-- 7 -->Housekeeping" },
+  { body = ".*security", group = "<!-- 0 -->Security" },
   # Catch-all. Without it, a commit that is not conventional gets no group and
   # silently vanishes from the notes — which is how you ship an empty release.
-  { message = ".*", group = "Other" },
+  { message = ".*", group = "<!-- 8 -->Other" },
 ]
 
 # Vocabulary changes are breaking by nature — a renamed term invalidates every


### PR DESCRIPTION
`cliff.toml` states two things about the notes it produces, and neither was true.

**A vocabulary change had nowhere to go.** The config's own note says such changes are breaking by nature and must not hide in a group — and no parser matched them. v0.8.0 filed the renamed term `criterionId` → `predicateId` under **Housekeeping** and a glossary redefinition under **Notes**. A parser for the `vocabulary` and `glossary` scopes now sits ahead of the generic rules, under any type, in its own group.

**The order was alphabetical.** The header claimed the groups were "ordered for a design repo"; the template groups by key and Tera sorts keys, so every release since v0.1.0 rendered alphabetically. The order is now the `<!-- N -->` prefix on each group, stripped in the template.

Regenerating from the corrected config also fixes two things that predate it: **v0.2.0 and v0.3.0 carry broken diff links** (`https://github.com///compare/…`, empty owner and repo), and v0.8.0 loses the Housekeeping group it should never have had.

No tag is deleted and no version reused — only the notes attached to them change. **v0.1.0's hand-written preamble is preserved**; git-cliff does not generate it.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)