### PR TITLE
fix(format): which numbers a predicate may carry

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -227,7 +227,19 @@ drawn from a closed enumeration. A mandatory unit settles "is 0.1 a fraction or 
 which OpenSLO answers with two fields and this format answers with one.
 
 *Rejected*: full UCUM — a grammar parser for seventeen units is the string-DSL mistake in a
-different hat. `threshold: "500ms"` — that is string parsing.
+different hat. `threshold: "500ms"` — that is string parsing. A **precision bound on `threshold`**
+(`multipleOf`, or a stated significant-digit limit) — proposed as the way to settle whether a
+converted threshold is a whole number, and refused on two independent grounds. It narrows the
+schema to one target's reach, which § *aggregation* already refused in these words when #57
+proposed it for `count` and `rate`; and it does not work, because JSON Schema 2020-12 says only
+that "division by this keyword's value results in an integer" and prescribes no arithmetic for it,
+so an implementation is free to do that division in binary floating point — and the one this
+repository validates with does. `multipleOf: 0.001` rejects `1.001`, `1.003` and `1.005` under
+`jsonschema` **4.26.0**, **checked 2026-09-01**: the very values the bound was proposed to admit. What settles the question instead is an arithmetic, stated
+in `README.md` § *What any tool can actually run*: the conversion is exact decimal arithmetic on
+the value the threshold denotes.
+What would reverse it: a JSON Schema numeric constraint defined over decimal values rather than
+binary floats, and a reason to bound the format that does not come from one target's target type.
 
 ### displayName
 

--- a/README.md
+++ b/README.md
@@ -756,28 +756,33 @@ for another. A percentile in `%` is not a Gatling assertion.
 
 | Statistic | Accepts | Native | Target |
 |---|---|---|---|
-| `responseTime.*` | `ms`, `s` | milliseconds | **`Int`** |
-| `groupCumulatedResponseTime.*` | `ms`, `s` | milliseconds | **`Int`** |
+| `responseTime.*` | `ns`, `us`, `ms`, `s`, `min`, `h` | milliseconds | **`Int`** |
+| `groupCumulatedResponseTime.*` | `ns`, `us`, `ms`, `s`, `min`, `h` | milliseconds | **`Int`** |
 | `failedRequests.percent` | `%`, `1` | percent, 0..100 | `Double` |
 | `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Long`** |
 | `requestsPerSec` | `{request}/s` | per second | `Double` |
-| — | `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
+| — | `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
 
 The last row is **derived**: it is the enumeration in § *Units* above minus every unit a statistic
 here reaches. Add a unit to the format and it belongs in that enumeration; whether it appears here
-follows, and is not a second decision.
+follows, and is not a second decision. Seventeen units, ten reached, seven left — and the reason
+the last row gives is true of all seven: no assertable statistic carries bytes, and nothing counts
+iterations or virtual users.
+
+**The four finer durations are not an exception to the whole-number rule; they are newly subject to
+it.** `responseTime.*` is a duration statistic whose native unit is milliseconds, and the same
+exact arithmetic that converts `s` converts the other four: `2000000 ns` is 2 ms, `1500000 us` is
+1500 ms, `2 min` is 120000 ms, `1 h` is 3600000 ms — no rounding, nothing approximated. Where the
+conversion is not whole the rule below refuses it, and refuses it for that reason rather than for
+the unit: `1500 ns` is 3/2000 ms and `1 us` is 1/1000 ms, both unrenderable. Until v0.9.0 all four
+were refused as unreachable, which was true of the seven above them and never of these.
 
 **`Target` is the type of the DSL entry point that reaches the statistic, not a property of the
 statistic itself** — a distinction the column did not draw and one of its cells got wrong.
 `AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` return
 `AssertionWithPathAndTarget[Int]`; `AssertionWithPathAndCountMetric.count` returns
 `AssertionWithPathAndTarget[`**`Long`**`]`, not `Int`; `.percent` and `AssertionWithPath.requestsPerSec`
-return `[Double]`. The type is consumed at the boundary — `lt(threshold: T)` calls
-`numeric.toDouble(threshold)` — and the `Assertion` produced carries a `double` in every
-`Condition`, so a renderer that constructs the assertion model itself never passes through the
-typed builder. **The rule below is not relaxed for it.** Reach is a property of the target, not of
-how a renderer happens to be built, and a table that said otherwise would describe implementations
-rather than Gatling.
+return `[Double]`.
 
 **`groupCumulatedResponseTime.*` has no entry point of its own, and its row is sourced through the
 one that does.** `AssertionWithPath` carries exactly `responseTime`, `allRequests`,
@@ -794,6 +799,7 @@ than fussy. The type is consumed at the boundary — `lt(threshold: T)` calls
 typed builder. **The rule below is not relaxed for it.** Reach is a property of the target, not of
 how a renderer happens to be built, and a table that said otherwise would describe implementations
 rather than Gatling.
+
 **Sourced** to `AssertionBuilders.scala` from `gatling-core` **3.13.5**, to
 `io.gatling.javaapi.core.Assertion$WithPathAndTimeMetric` from `gatling-core-java` **3.13.5**
 (`max()` returns `WithPathAndTarget<Integer>`, so the Java DSL is Int-typed too), and to
@@ -811,11 +817,11 @@ significant digits, which is far more precision than a threshold carries. **Reta
 document's source text is not required**, and must not be: JSON and YAML parsers discard it.
 
 **Where the target is integral, the threshold converted to the native unit must be a whole
-number, and must be one the target holds.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
-fine; `aggregation: count, threshold: 20.5` is unrenderable for the same reason — the rule is about
-the target holding no fraction, and `Int` and `Long` both qualify. Rounding is not an option: it
-moves the bar the author wrote, so the document states one limit and the run enforces another, and
-the report names neither.
+number, and must be one the target holds.** `threshold: 0.5, unit: ms` is unrenderable;
+`threshold: 0.5, unit: s` is 500 ms and is fine; `aggregation: count, threshold: 20.5` is
+unrenderable for the same reason — the rule is about the target holding no fraction, and `Int` and
+`Long` both qualify. Rounding is not an option: it moves the bar the author wrote, so the document
+states one limit and the run enforces another, and the report names neither.
 
 **The range is part of it and not a separate rule.** A converted threshold can be a whole number
 and still be one no target carries: `threshold: 2149200, unit: s` is exactly 2 149 200 000 ms, and
@@ -824,6 +830,7 @@ milliseconds against `Int`, counts against `Long`. It is stated here rather than
 to discover at the point it overflows — and the four finer duration units make it ordinary rather
 than exotic, since `597 h` and `35820 min` are the same quantity spelled in units a soak run
 actually uses.
+
 #### Identity
 
 A predicate's identity — its `name`, or the `aggregation` standing in where no `name` is set — is

--- a/README.md
+++ b/README.md
@@ -757,9 +757,9 @@ for another. A percentile in `%` is not a Gatling assertion.
 | Statistic | Accepts | Native | Target |
 |---|---|---|---|
 | `responseTime.*` | `ms`, `s` | milliseconds | **`Int`** |
-| `groupCumulatedResponseTime.*` | `ms`, `s` | milliseconds | **`Int`** | 
+| `groupCumulatedResponseTime.*` | `ms`, `s` | milliseconds | **`Int`** |
 | `failedRequests.percent` | `%`, `1` | percent, 0..100 | `Double` |
-| `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Int`** |
+| `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Long`** |
 | `requestsPerSec` | `{request}/s` | per second | `Double` |
 | — | `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
 
@@ -767,11 +767,63 @@ The last row is **derived**: it is the enumeration in § *Units* above minus eve
 here reaches. Add a unit to the format and it belongs in that enumeration; whether it appears here
 follows, and is not a second decision.
 
-**Where the target is an `Int`, the threshold converted to the native unit must be a whole
-number.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
-fine. Rounding is not an option: it moves the bar the author wrote, so the document states one
-limit and the run enforces another, and the report names neither.
+**`Target` is the type of the DSL entry point that reaches the statistic, not a property of the
+statistic itself** — a distinction the column did not draw and one of its cells got wrong.
+`AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` return
+`AssertionWithPathAndTarget[Int]`; `AssertionWithPathAndCountMetric.count` returns
+`AssertionWithPathAndTarget[`**`Long`**`]`, not `Int`; `.percent` and `AssertionWithPath.requestsPerSec`
+return `[Double]`. The type is consumed at the boundary — `lt(threshold: T)` calls
+`numeric.toDouble(threshold)` — and the `Assertion` produced carries a `double` in every
+`Condition`, so a renderer that constructs the assertion model itself never passes through the
+typed builder. **The rule below is not relaxed for it.** Reach is a property of the target, not of
+how a renderer happens to be built, and a table that said otherwise would describe implementations
+rather than Gatling.
 
+**`groupCumulatedResponseTime.*` has no entry point of its own, and its row is sourced through the
+one that does.** `AssertionWithPath` carries exactly `responseTime`, `allRequests`,
+`failedRequests`, `successfulRequests` and `requestsPerSec`, and `TimeMetric` has exactly one
+variant, `ResponseTime` — so nothing in the builder names the group statistic. What selects it is
+the **path**: `AssertionValidator` resolves a path that matches a recorded group to
+`StatsPath.Group` and reads `groupCumulatedResponseTimeGeneralStats`, where a request path reads
+`requestGeneralStats`. The row's `Int` is therefore `responseTime`'s, reached by
+`AssertionWithPathAndTimeMetric` and redirected by resolution — which is also why § *Selection*'s
+precondition that a rendered path must not name both a request and a group is load-bearing rather
+than fussy. The type is consumed at the boundary — `lt(threshold: T)` calls
+`numeric.toDouble(threshold)` — and the `Assertion` produced carries a `double` in every
+`Condition`, so a renderer that constructs the assertion model itself never passes through the
+typed builder. **The rule below is not relaxed for it.** Reach is a property of the target, not of
+how a renderer happens to be built, and a table that said otherwise would describe implementations
+rather than Gatling.
+**Sourced** to `AssertionBuilders.scala` from `gatling-core` **3.13.5**, to
+`io.gatling.javaapi.core.Assertion$WithPathAndTimeMetric` from `gatling-core-java` **3.13.5**
+(`max()` returns `WithPathAndTarget<Integer>`, so the Java DSL is Int-typed too), and to
+`Condition$Lt` / `Condition$Between` from `gatling-shared-model_2.13` **0.0.11** — the release
+Gatling 3.13.5 pins. **Checked 2026-09-01.** That is a different version from the **3.15.1** this
+section's header carries, and it is named rather than rounded to match it.
+
+**The conversion is exact decimal arithmetic on the value the threshold denotes**, never binary
+floating-point multiplication. `threshold: 1.001, unit: s` is 1001 ms and renders; a renderer that
+multiplies the parsed double computes 1000.9999999999999 and refuses, and the two disagree on every
+sub-millisecond budget written in seconds. A renderer that has already parsed the threshold into a
+binary float conforms by recovering the shortest decimal that round-trips that float and computing
+exactly from there — that decimal is the literal's value for any threshold of at most fifteen
+significant digits, which is far more precision than a threshold carries. **Retaining the
+document's source text is not required**, and must not be: JSON and YAML parsers discard it.
+
+**Where the target is integral, the threshold converted to the native unit must be a whole
+number, and must be one the target holds.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
+fine; `aggregation: count, threshold: 20.5` is unrenderable for the same reason — the rule is about
+the target holding no fraction, and `Int` and `Long` both qualify. Rounding is not an option: it
+moves the bar the author wrote, so the document states one limit and the run enforces another, and
+the report names neither.
+
+**The range is part of it and not a separate rule.** A converted threshold can be a whole number
+and still be one no target carries: `threshold: 2149200, unit: s` is exactly 2 149 200 000 ms, and
+the `Int` above tops out at 2 147 483 647, so it is unrenderable. The bound follows the row:
+milliseconds against `Int`, counts against `Long`. It is stated here rather than left to a renderer
+to discover at the point it overflows — and the four finer duration units make it ordinary rather
+than exotic, since `597 h` and `35820 min` are the same quantity spelled in units a soak run
+actually uses.
 #### Identity
 
 A predicate's identity — its `name`, or the `aggregation` standing in where no `name` is set — is

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -579,6 +579,48 @@ try:
 except ImportError as e:
     print(f"  FAIL  {e.name} not installed (pip install pyyaml)"); sys.exit(1)
 
+# PyYAML hands back a double, and a double cannot carry a decimal literal of more than 15
+# significant digits: `1.0000000000000001` arrives as `1.0`. The rule this section implements is
+# about the value the literal DENOTES -- README > Gatling > Units -- so the literal is what has to
+# reach it. Without this the gate converts that threshold to a whole 1000 ms and renders a document
+# the rule it claims to implement refuses, which is #73's two-answers-in-one-run defect one field
+# over. `threshold` is a bare `number` with no precision bound and deliberately stays one (#59).
+class ExactFloat(float):
+    def __new__(cls, literal):
+        self = super().__new__(cls, literal)
+        self.literal = literal
+        return self
+
+class ExactLoader(yaml.SafeLoader):
+    pass
+
+def _exact_float(loader, node):
+    try:
+        return ExactFloat(node.value.replace("_", ""))
+    except ValueError:
+        # `.inf`, `.nan` and YAML 1.1 sexagesimals: PyYAML resolves them as floats and float()
+        # does not. The JSON-mapping section rejects them already; here they keep their old
+        # handling rather than crashing the scan.
+        return yaml.SafeLoader.construct_yaml_float(loader, node)
+
+ExactLoader.add_constructor("tag:yaml.org,2002:float", _exact_float)
+
+def threshold_literal(t):
+    # The decimal the document carries. `str(float)` is the shortest decimal that round-trips,
+    # which IS the literal at 15 significant digits or fewer and is NOT it beyond that.
+    return t.literal if isinstance(t, ExactFloat) else str(t)
+
+# Named once, and read by both the corpus scan below and the check under it. No published document
+# carries a threshold of more than four significant digits, so a probe cannot reach this wiring:
+# swap the loader and every probe above still passes while real documents are judged on the double
+# again. The check is what notices, and it lives beside the thing it checks.
+LOADER = ExactLoader
+if threshold_literal(list(yaml.load_all("t: 1.0000000000000001\n", LOADER))[0]["t"]) \
+        != "1.0000000000000001":
+    print("  FAIL  the loader no longer carries a threshold's decimal literal — a document past "
+          "15 significant digits would be judged on the double it parsed to")
+    sys.exit(1)
+
 # The two keys that spell a request's recorded position. Written once: they appear in the key
 # sets, in the value rules and in the flattener below, and four literals of one attribute name
 # are four chances to fix three of them.
@@ -624,9 +666,17 @@ BAD = {"error.type": "*"}
 # there is no negation, so `neq` has no equivalent.
 OPS = {"lt": "lt", "lte": "lte", "gt": "gt", "gte": "gte", "eq": "is"}
 
-# The partition. (shape, aggregation) -> what Gatling asserts, in which units, and
-# whether the target is an Int — a fractional value against an Int target is
-# unrenderable rather than roundable, and rounding would move the bar silently.
+# The largest value each integral target holds. The rule is a RANGE and not only a divisibility:
+# a converted threshold can be a whole number and still be one no target can carry, and `h`/`min`
+# make that ordinary to write -- a soak bound of a few hundred hours overflows Int (#74).
+INT, LONG = 2**31 - 1, 2**63 - 1
+
+# The partition. (shape, aggregation) -> what Gatling asserts, in which units, and the largest
+# value its target holds, or None where the target is a Double — a fractional value against an
+# integral target is unrenderable rather than roundable, and rounding would move the bar silently.
+# All six duration units, every factor exact, so no conversion rounds at the point it is computed.
+# `ns`/`us`/`min`/`h` were refused as unreachable until v0.9.0 -- true of the seven units still in
+# the last Units row, never of these four, which responseTime reaches by this same arithmetic (#74).
 TIME = {"ms": Fraction(1), "s": Fraction(1000)}          # -> native milliseconds
 SHARE = {"%": Fraction(1), "1": Fraction(100)}           # -> native percent
 COUNT = {"{request}": Fraction(1)}
@@ -650,19 +700,19 @@ NATIVE = {METRIC: "responseTime", GROUP_METRIC: "groupCumulatedResponseTime"}
 
 TABLE = {
     "metric": {
-        "PERCENTILE": ("{}.percentile", TIME, True),
-        "max":        ("{}.max",        TIME, True),
-        "min":        ("{}.min",        TIME, True),
-        "avg":        ("{}.mean",       TIME, True),
-        "stddev":     ("{}.stdDev",     TIME, True),
+        "PERCENTILE": ("{}.percentile", TIME, INT),
+        "max":        ("{}.max",        TIME, INT),
+        "min":        ("{}.min",        TIME, INT),
+        "avg":        ("{}.mean",       TIME, INT),
+        "stddev":     ("{}.stdDev",     TIME, INT),
     },
     "fraction": {
-        "rate":  ("failedRequests.percent", SHARE, False),
-        "count": ("failedRequests.count",   COUNT, True),
+        "rate":  ("failedRequests.percent", SHARE, None),
+        "count": ("failedRequests.count",   COUNT, LONG),
     },
     "requests": {
-        "count": ("allRequests.count", COUNT, True),
-        "rate":  ("requestsPerSec",    PERSEC, False),
+        "count": ("allRequests.count", COUNT, LONG),
+        "rate":  ("requestsPerSec",    PERSEC, None),
     },
 }
 
@@ -738,22 +788,31 @@ def predicate_why(p):
         why.append(f"op {p.get('op')} has no equivalent")
 
     if row:
-        native, units, integral = row
+        native, units, bound = row
         # A no-op on the fraction and requests rows, which carry no placeholder.
         native = native.format(NATIVE.get(p.get("metric", METRIC), METRIC))
         factor = units.get(p.get("unit"))
         if factor is None:
             why.append(f"unit {p.get('unit')} is not a unit of {native}")
-        elif integral and "threshold" not in p:
+        elif bound and "threshold" not in p:
             # The one key the old inline block read without .get(). A predicate missing it is
             # schema-invalid, but this section reads examples/ and never the schema, so it has to
             # say so rather than abort the scan and leave the rest of the corpus unread.
             why.append(f"threshold is absent, and {native} takes one")
-        elif integral:
-            value = Fraction(str(p["threshold"])) * factor
+        elif bound:
+            # Exact decimal arithmetic on the value the threshold denotes -- README > Gatling >
+            # Units states the rule, and these two lines are that rule rather than an accident.
+            # A plain `p["threshold"] * factor` would compute 1000.9999999999999 for `1.001 s` and
+            # refuse a document the rule admits (#59); `threshold_literal` is why a literal past
+            # 15 significant digits is not silently rounded into one the rule admits either.
+            literal = threshold_literal(p["threshold"])
+            value = Fraction(literal) * factor
             if value.denominator != 1:
-                why.append(f"threshold {p['threshold']} {p['unit']} is {value} for {native}, "
+                why.append(f"threshold {literal} {p['unit']} is {value} for {native}, "
                            f"whose target is an integer")
+            elif not -bound - 1 <= value <= bound:
+                why.append(f"threshold {literal} {p['unit']} is {value} for {native}, "
+                           f"which is outside the range its target holds")
     return why
 
 def shape_of(p, why):
@@ -913,6 +972,33 @@ PREDICATE_PROBES = [
      "unit % is not a unit of responseTime.percentile"),
     ({**RENDERABLE, "threshold": 0.1},
      "threshold 0.1 ms is 1/10 for responseTime.percentile, whose target is an integer"),
+    # Whole, and still outside what the target carries. One probe per bound: INT and LONG are two
+    # constants, and a single probe would leave the other deletable with this section green.
+    ({**RENDERABLE, "threshold": 2149200, "unit": "s"},
+     "threshold 2149200 s is 2149200000 for responseTime.percentile, "
+     "which is outside the range its target holds"),
+    ({"aggregation": "count", "op": "lte", "threshold": 1e19, "unit": "{request}"},
+     "threshold 1e+19 {request} is 10000000000000000000 for allRequests.count, "
+     "which is outside the range its target holds"),
+    # The literal a double cannot carry. Written as an ExactFloat because that is what ExactLoader
+    # hands the corpus; passed as a plain float it would arrive here as 1.0 and render, which is
+    # the defect. Its exact value is not a whole number of milliseconds, so the rule refuses it.
+    ({**RENDERABLE, "threshold": ExactFloat("1.0000000000000001"), "unit": "s"},
+     "threshold 1.0000000000000001 s is 10000000000000001/10000000000000 for "
+     "responseTime.percentile, whose target is an integer"),
+    # The whole-number rule reaches the count rows too, and until #59 nothing said so and nothing
+    # checked it: both carried `True` in TABLE and either could be flipped to `False` with this
+    # section still green. The message is the one the rule already gave -- `Long` is an integer,
+    # so correcting the page's `Int` to `Long` changed no string here.
+    #
+    # TWO probes and not one: the count rows live in different shapes -- `allRequests.count` under
+    # `requests`, `failedRequests.count` under `fraction` -- so one probe reaches one row and the
+    # other stays exactly as unguarded as it was. Written as one probe first, and the revert set
+    # caught it.
+    ({"aggregation": "count", "op": "lte", "threshold": 20.5, "unit": "{request}"},
+     "threshold 20.5 {request} is 41/2 for allRequests.count, whose target is an integer"),
+    ({"bad": BAD, "aggregation": "count", "op": "lte", "threshold": 20.5, "unit": "{request}"},
+     "threshold 20.5 {request} is 41/2 for failedRequests.count, whose target is an integer"),
     ({k: v for k, v in RENDERABLE.items() if k != "threshold"},
      "threshold is absent, and responseTime.percentile takes one"),
     ({"good": {"error.type": "*"}, "aggregation": "rate", "op": "lte", "threshold": 5, "unit": "%"},
@@ -946,6 +1032,12 @@ PREDICATE_RENDERS = [
     {**RENDERABLE, "aggregation": "avg"},
     {**RENDERABLE, "aggregation": "stddev"},
     {**RENDERABLE, "aggregation": "p99.9", "unit": "s", "threshold": 1},
+    # The one document the two arithmetics disagree about, and the only probe that fails if the
+    # exact conversion above becomes a double multiplication. Two keys and no more: `threshold`
+    # and `unit` move together because the subject is the conversion, and nothing else moves.
+    {**RENDERABLE, "threshold": 1.001, "unit": "s"},
+    # The largest value the target holds. Without it `<= bound` could become `< bound` green.
+    {**RENDERABLE, "threshold": 2147483647, "unit": "ms"},
     {**RENDERABLE, "op": "lt"},
     {**RENDERABLE, "op": "gt"},
     {**RENDERABLE, "op": "gte"},
@@ -989,7 +1081,7 @@ for _name in (METRIC, GROUP_METRIC):
 # probe is the sole catcher of one published `can` row being deleted, which no rejection probe and
 # no corpus document can show.
 FLOORS = [("rejection", SELECTION_PROBES, 9), ("rendering", SELECTION_RENDERS, 6),
-          ("predicate rejection", PREDICATE_PROBES, 16), ("predicate rendering", PREDICATE_RENDERS, 16),
+          ("predicate rejection", PREDICATE_PROBES, 21), ("predicate rendering", PREDICATE_RENDERS, 18),
           ("pairing rejection", PAIRING_PROBES, 4), ("pairing rendering", PAIRING_RENDERS, 4)]
 for _label, _probes, _floor in FLOORS:
     if len(_probes) < _floor:
@@ -1034,7 +1126,7 @@ if not files:
     sys.exit(1)
 for f in files:
     with open(f, encoding="utf-8") as fh:
-        docs = list(yaml.safe_load_all(fh))
+        docs = list(yaml.load_all(fh, LOADER))
     for doc in docs:
         if not isinstance(doc, dict):
             continue

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -677,7 +677,8 @@ INT, LONG = 2**31 - 1, 2**63 - 1
 # All six duration units, every factor exact, so no conversion rounds at the point it is computed.
 # `ns`/`us`/`min`/`h` were refused as unreachable until v0.9.0 -- true of the seven units still in
 # the last Units row, never of these four, which responseTime reaches by this same arithmetic (#74).
-TIME = {"ms": Fraction(1), "s": Fraction(1000)}          # -> native milliseconds
+TIME = {"ns": Fraction(1, 1000000), "us": Fraction(1, 1000), "ms": Fraction(1),
+        "s":  Fraction(1000),       "min": Fraction(60000),  "h":  Fraction(3600000)}  # -> native ms
 SHARE = {"%": Fraction(1), "1": Fraction(100)}           # -> native percent
 COUNT = {"{request}": Fraction(1)}
 PERSEC = {"{request}/s": Fraction(1)}
@@ -972,6 +973,11 @@ PREDICATE_PROBES = [
      "unit % is not a unit of responseTime.percentile"),
     ({**RENDERABLE, "threshold": 0.1},
      "threshold 0.1 ms is 1/10 for responseTime.percentile, whose target is an integer"),
+    # A sub-millisecond value in a unit #74 makes reachable. The expected reason is the whole-number
+    # rule's and NOT `unit ns is not a unit of ...`: the four units are reachable first and governed
+    # second, and a probe asserting the old refusal would pass on a table that never gained them.
+    ({**RENDERABLE, "threshold": 1500, "unit": "ns"},
+     "threshold 1500 ns is 3/2000 for responseTime.percentile, whose target is an integer"),
     # Whole, and still outside what the target carries. One probe per bound: INT and LONG are two
     # constants, and a single probe would leave the other deletable with this section green.
     ({**RENDERABLE, "threshold": 2149200, "unit": "s"},
@@ -1036,8 +1042,14 @@ PREDICATE_RENDERS = [
     # exact conversion above becomes a double multiplication. Two keys and no more: `threshold`
     # and `unit` move together because the subject is the conversion, and nothing else moves.
     {**RENDERABLE, "threshold": 1.001, "unit": "s"},
+    # One per unit #74 makes reachable, and one per unit deliberately: a single probe would leave
+    # three factors deletable green. Each value converts to a whole number of milliseconds exactly.
     # The largest value the target holds. Without it `<= bound` could become `< bound` green.
     {**RENDERABLE, "threshold": 2147483647, "unit": "ms"},
+    {**RENDERABLE, "threshold": 2000000, "unit": "ns"},
+    {**RENDERABLE, "threshold": 1500000, "unit": "us"},
+    {**RENDERABLE, "threshold": 2,       "unit": "min"},
+    {**RENDERABLE, "threshold": 1,       "unit": "h"},
     {**RENDERABLE, "op": "lt"},
     {**RENDERABLE, "op": "gt"},
     {**RENDERABLE, "op": "gte"},
@@ -1081,7 +1093,7 @@ for _name in (METRIC, GROUP_METRIC):
 # probe is the sole catcher of one published `can` row being deleted, which no rejection probe and
 # no corpus document can show.
 FLOORS = [("rejection", SELECTION_PROBES, 9), ("rendering", SELECTION_RENDERS, 6),
-          ("predicate rejection", PREDICATE_PROBES, 21), ("predicate rendering", PREDICATE_RENDERS, 18),
+          ("predicate rejection", PREDICATE_PROBES, 22), ("predicate rendering", PREDICATE_RENDERS, 22),
           ("pairing rejection", PAIRING_PROBES, 4), ("pairing rendering", PAIRING_RENDERS, 4)]
 for _label, _probes, _floor in FLOORS:
     if len(_probes) < _floor:

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -570,7 +570,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   bad "python3 not found — the Gatling reach gate cannot run"
 else
   python3 - <<'GATLING' || fail=1
-import glob, sys
+import glob, re, sys
 from fractions import Fraction
 sys.path.insert(0, "scripts")
 import identity
@@ -631,7 +631,16 @@ TIME = {"ms": Fraction(1), "s": Fraction(1000)}          # -> native millisecond
 SHARE = {"%": Fraction(1), "1": Fraction(100)}           # -> native percent
 COUNT = {"{request}": Fraction(1)}
 PERSEC = {"{request}/s": Fraction(1)}
-def percentile(a): return a.startswith("p") and a[1:].replace(".", "", 1).isdigit()
+# The row this implements, verbatim: README > Gatling > Aggregations quotes it from the schema's
+# $defs/aggregation, and the three copies are one string so a reader can compare them by eye. The
+# anchors are redundant under fullmatch and kept for exactly that.
+#
+# fullmatch and NOT match: Python's `$` also matches before a trailing newline, and ECMA-262's --
+# the dialect a JSON Schema `pattern` is written in -- does not. Under `match` this would admit
+# "p95\n", which the row and the schema both reject: #73's own defect, one input smaller, put back
+# by the commit that closes it. The three percentile probes in PREDICATE_PROBES are what notice.
+PERCENTILE = r"^p\d{1,2}(\.\d+)?$"
+def percentile(a): return re.fullmatch(PERCENTILE, a) is not None
 
 # The statistic each addressable metric resolves to. One `Stats` type serves both, so the units
 # and the integer target are shared and only the name differs — but the name belongs to the METRIC,
@@ -870,6 +879,17 @@ PREDICATE_PROBES = [
      "aggregation rate over a metric has no equivalent"),
     ({**RENDERABLE, "aggregation": "sum"},
      "aggregation sum over a metric has no equivalent"),
+    # Three shapes the helper this replaced called assertable and the row rejects (#73). They are
+    # schema-invalid too, so no document reaches them — what they guard is the gate agreeing with
+    # the row it implements, which is a property no corpus document can show. Each catches one
+    # regression and no other: `p999` a widened integer part (or the old isdigit() helper coming
+    # back), `p.5` an integer part made optional, and "p95\n" `fullmatch` swapped for `match`.
+    ({**RENDERABLE, "aggregation": "p999"},
+     "aggregation p999 over a metric has no equivalent"),
+    ({**RENDERABLE, "aggregation": "p.5"},
+     "aggregation p.5 over a metric has no equivalent"),
+    ({**RENDERABLE, "aggregation": "p95\n"},
+     "aggregation p95\n over a metric has no equivalent"),
     ({**RENDERABLE, "metric": "http.client.response.body.size"},
      "metric http.client.response.body.size is not addressable"),
     # The retired name (#89). Its `cannot` row is the only published row whose rule is an
@@ -969,7 +989,7 @@ for _name in (METRIC, GROUP_METRIC):
 # probe is the sole catcher of one published `can` row being deleted, which no rejection probe and
 # no corpus document can show.
 FLOORS = [("rejection", SELECTION_PROBES, 9), ("rendering", SELECTION_RENDERS, 6),
-          ("predicate rejection", PREDICATE_PROBES, 13), ("predicate rendering", PREDICATE_RENDERS, 16),
+          ("predicate rejection", PREDICATE_PROBES, 16), ("predicate rendering", PREDICATE_RENDERS, 16),
           ("pairing rejection", PAIRING_PROBES, 4), ("pairing rendering", PAIRING_RENDERS, 4)]
 for _label, _probes, _floor in FLOORS:
     if len(_probes) < _floor:

--- a/specs/013-numbers-a-predicate-carries/checklists/requirements.md
+++ b/specs/013-numbers-a-predicate-carries/checklists/requirements.md
@@ -1,0 +1,97 @@
+# Specification Quality Checklist: Which Numbers a Predicate May Carry
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+
+### Iteration 3 — 2026-09-01 — all items pass
+
+The `Long`/`Int` finding moved from *Out of Scope* into #59 on the maintainer's call, and checking
+it against the spec's own scope rules turned up that it was never separable:
+
+- FR-017 restates what § *Units*' `Target` column **means**; the count cell is wrong under the new
+  meaning as much as the old, so a correct FR-017 cannot leave it standing.
+- The whole-number rule is worded *"where the target is an `Int`"*. Correcting the cell alone would
+  drop counts out of the rule and make `20.5 {request}` renderable — so FR-017e rewords the rule to
+  the property it was always testing.
+- Neither count row's integral flag is reached by any probe: both can be flipped and the gate stays
+  **green**. FR-017f adds the probe and raises the floor.
+
+Three FRs (FR-017d/e/f), three acceptance scenarios, one edge case and two success criteria
+(SC-009, SC-010). *Out of Scope* loses its first bullet. Scope is still bounded: no document
+changes renderability, and `examples/` is still untouched.
+
+### Iteration 2 — 2026-09-01 — all items pass
+
+Both markers resolved by the maintainer; both went to the recommendation.
+
+- **FR-017** → narrow the attribution, change no rule. FR-017 became FR-017/a/b/c: the `Int` is
+  named as the DSL entry points' type, the read is dated and versioned, the whole-number rule is
+  held unchanged, and the reason it was not relaxed is recorded so the argument is not reopened.
+- **FR-022** → extend the two duration statistics' `Accepts` cells, one row per statistic. The
+  issue's separate-row wording is refused in the requirement itself, with the reason.
+
+Both decisions are in *Decisions* § *Session 2026-09-01* as Q&A, so the spec carries the argument
+and not only the outcome.
+
+### Iteration 1 — 2026-09-01
+
+Two [NEEDS CLARIFICATION] markers stood, both raised to the maintainer rather than guessed:
+
+- **FR-017** — the fact is settled (re-read locally at Gatling 3.13.5 / shared-model 0.0.11 on
+  2026-09-01); what the format does about it is not. No reasonable default: (a) changes no
+  document's validity, (b) widens what is renderable and makes reach depend on how a renderer is
+  built, (c) leaves a claim this milestone has just shown imprecise standing in a table it is
+  editing.
+- **FR-022** — whether the Units table extends the two duration statistics' `Accepts` cells or
+  gains a separate row as #74's wording proposes. No reasonable default: the issue's words point
+  one way, § *Units*' own "units are per statistic" framing points the other.
+
+On the "non-technical stakeholders" item: the stakeholder for a format specification is a renderer
+author, and the spec is written to that reader throughout. Version numbers, file paths and type
+names appear as **evidence for claims about artifacts that already exist**, which Principle IV
+requires be dated and attributed — not as instructions for how to build anything. No requirement
+below names how a change is to be implemented.
+
+Three claims in the spec were reproduced rather than quoted from the issues, and two corrected
+what the issues say:
+
+- The percentile helper admits **five** shapes the row rejects, not four — `p1.` is a fifth.
+- `multipleOf: 0.001` **rejects** `1.001`, `1.003` and `1.005` under `jsonschema` 4.26.0, so #59's
+  second proposed close reproduces the defect it was proposed to fix.
+- The six duration conversions and the two sub-millisecond refusals were each computed.
+
+And one assumption in the first draft was wrong and is corrected: it said no Gatling jar was
+present to re-read. The jars are in the local Coursier cache, #59's closing claim was verified from
+them, and the same read turned up a `Long`/`Int` mismatch in § *Units* that no issue mentions —
+recorded under *Out of Scope*, because it is nobody's issue yet and AGENTS.md forbids it riding
+along.

--- a/specs/013-numbers-a-predicate-carries/contracts/duration-units.md
+++ b/specs/013-numbers-a-predicate-carries/contracts/duration-units.md
@@ -1,0 +1,120 @@
+# Contract: responseTime reaches ns, us, min and h (#74)
+
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md) | **Commit 4 of 4**
+
+Closes [#74](https://github.com/galax-io/opennfr/issues/74). Satisfies FR-018 … FR-025.
+
+**Files**: `README.md` § *Units* (under § *Gatling*) and `scripts/verify.sh`.
+
+This is the only commit in the milestone that changes which documents may be published.
+
+---
+
+## What is wrong today
+
+The last row of the Units table gives one reason for eleven units:
+
+> | — | `ns`, `us`, `min`, `h`, `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
+
+The reason is true of seven. It is false of the four durations: `responseTime.*` is a duration
+statistic whose native unit is milliseconds, and the same arithmetic that already converts `s`
+converts all four exactly ([research.md](../research.md) R4).
+
+## The change — `README.md` § *Units*
+
+**1. The two duration rows' `Accepts` cells** grow from `ms`, `s` to the six duration units:
+
+| Statistic | Accepts | Native | Target |
+|---|---|---|---|
+| `responseTime.*` | `ns`, `us`, `ms`, `s`, `min`, `h` | milliseconds | `Int` |
+| `groupCumulatedResponseTime.*` | `ns`, `us`, `ms`, `s`, `min`, `h` | milliseconds | `Int` |
+
+Both, and by one edit: they share a factor table because they share one `Stats` type, which
+§ *Metrics* already sources and dates.
+
+**2. The last row** loses the four and keeps its reason, which is now true of everything in it:
+
+| | Accepts | | |
+|---|---|---|---|
+| — | `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` | — | not reachable through any assertable statistic |
+
+**3. The derived-row sentence stands unchanged** and is re-checked rather than re-worded: the
+enumeration in § *Units* is 17, the statistics above reach 10 distinct units, 17 − 10 = **7**, and
+the seven are exactly those listed (R7).
+
+**4. The whole-number rule is named as what still governs them** — it is not an exception for
+these four but the rule they now answer to: `1500000 us` is 1500 ms and renders; `1500 ns` is
+3/2000 ms and is refused, by that rule and with its reason.
+
+**No separate row for the four durations**, which is what #74's wording proposes. § *Units* opens
+by stating that units are per statistic, and a statistic in two rows contradicts the sentence the
+table is organised around. Recorded in [spec.md](../spec.md) § *Decisions*.
+
+## The change — `scripts/verify.sh`
+
+**1. Four factors** join `TIME`, which both duration statistics already share:
+
+```python
+TIME = {"ns": Fraction(1, 1000000), "us": Fraction(1, 1000), "ms": Fraction(1),
+        "s":  Fraction(1000),       "min": Fraction(60000),  "h":  Fraction(3600000)}
+```
+
+Every factor is exact; no conversion rounds.
+
+**2. Four rendering probes** in `PREDICATE_RENDERS`, one per new unit, so deleting any single
+factor fails the gate:
+
+```python
+{**RENDERABLE, "threshold": 2000000, "unit": "ns"},
+{**RENDERABLE, "threshold": 1500000, "unit": "us"},
+{**RENDERABLE, "threshold": 2,       "unit": "min"},
+{**RENDERABLE, "threshold": 1,       "unit": "h"},
+```
+
+**3. One rejection probe** in `PREDICATE_PROBES` — a sub-millisecond value in a newly reachable
+unit, refused by the whole-number rule and not by "not a unit of":
+
+```python
+({**RENDERABLE, "threshold": 1500, "unit": "ns"},
+ "threshold 1500 ns is 3/2000 for responseTime.percentile, whose target is an integer"),
+```
+
+**4. Floors**: rejection `20` → `22`, rendering `18` → `22`.
+
+## The conversions, verified
+
+| written | native (ms), exact | verdict |
+|---|---|---|
+| `2000000 ns` | 2 | renders |
+| `1500000 us` | 1500 | renders |
+| `2 min` | 120000 | renders |
+| `1 h` | 3600000 | renders |
+| `1500 ns` | 3/2000 | refused — whole-number rule |
+| `1 us` | 1/1000 | refused — whole-number rule |
+
+## What must NOT change
+
+- **No message string**, and in particular the sub-millisecond refusal must come from the
+  whole-number branch, not from `unit … is not a unit of …`. The four units are reachable first
+  and governed second; that ordering is the whole of #74.
+- **The unit enumeration.** All seventeen are already in `$defs/unit`; this changes which of them
+  a table calls reachable, not what the format carries. The schema is not edited.
+- **`examples/` stays byte-identical.** These four units are newly *publishable*; publishing an
+  example in one is a separate decision and no issue asks for it.
+
+## Acceptance
+
+```bash
+bash scripts/verify.sh
+```
+
+`22 predicate probes still rejected, 22 still rendered`, whole gate **PASS**.
+
+| revert | expected failure |
+|---|---|
+| any one of the four factors deleted from `TIME` | that unit's rendering probe |
+| the whole-number check skipped for the new units | the `1500 ns` rejection probe |
+| any probe deleted | the floor |
+
+And by reading: every unit in `$defs/unit` is either in a statistic's `Accepts` cell or in the last
+row — seventeen units, none in both, none in neither.

--- a/specs/013-numbers-a-predicate-carries/contracts/percentile-pattern.md
+++ b/specs/013-numbers-a-predicate-carries/contracts/percentile-pattern.md
@@ -1,0 +1,102 @@
+# Contract: the percentile test is the row it implements (#73)
+
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md) | **Commit 2 of 4**
+
+Closes [#73](https://github.com/galax-io/opennfr/issues/73). Satisfies FR-001 … FR-006.
+
+**Files**: `scripts/verify.sh` only. `README.md` § *Aggregations* is the **source** of this rule
+and its text is final — this commit changes no prose.
+
+---
+
+## What is wrong today
+
+`scripts/verify.sh:634`:
+
+```python
+def percentile(a): return a.startswith("p") and a[1:].replace(".", "", 1).isdigit()
+```
+
+Against the row's `^p\d{1,2}(\.\d+)?$`, which § *Aggregations* quotes from the schema, this admits
+five shapes the row and the schema both reject:
+
+| aggregation | helper | row / schema |
+|---|---|---|
+| `p95` `p99.9` `p1` `p10` `p0.1` `p99.99` | accepts | accepts |
+| `p100` `p999` `p1234` `p.5` `p1.` | **accepts** | rejects |
+| `p` | rejects | rejects |
+
+On any of the five, one run of the gate calls the predicate assertable in its reach section and
+the document invalid in its schema section.
+
+## The change
+
+**1. `import re`** joins the Gatling heredoc's imports, which today are `glob`, `sys`,
+`Fraction`, `identity` and `yaml`.
+
+**2. The helper becomes the row's pattern**, held as a named constant and applied with
+`re.fullmatch`:
+
+```python
+# The row this implements, verbatim: README > Gatling > Aggregations quotes it from
+# $defs/aggregation, and the three copies are one string so a reader can compare them by eye.
+# fullmatch and not match: Python's `$` also matches before a trailing newline and ECMA-262's --
+# the dialect a JSON Schema `pattern` is written in -- does not, so `match` would admit "p95\n",
+# which is the row's own defect one input smaller (#73).
+PERCENTILE = r"^p\d{1,2}(\.\d+)?$"
+def percentile(a): return re.fullmatch(PERCENTILE, a) is not None
+```
+
+The `^` and `$` are redundant under `fullmatch` and are kept: their job is that the constant, the
+row and `$defs/aggregation` are character-identical (FR-004).
+
+**3. Three rejection probes** join `PREDICATE_PROBES`, each the sole catcher of one regression:
+
+```python
+({**RENDERABLE, "aggregation": "p999"},
+ "aggregation p999 over a metric has no equivalent"),
+({**RENDERABLE, "aggregation": "p.5"},
+ "aggregation p.5 over a metric has no equivalent"),
+({**RENDERABLE, "aggregation": "p95\n"},
+ "aggregation p95\n over a metric has no equivalent"),
+```
+
+| probe | catches |
+|---|---|
+| `p999` | `\d{1,2}` widened, or the `isdigit()` helper returning |
+| `p.5` | the integer part made optional |
+| `"p95\n"` | `re.fullmatch` swapped for `re.match` |
+
+**4. The rejection floor** rises `13` → `16` in `FLOORS`.
+
+## What must NOT change
+
+- **No new message.** All three reasons come from the existing aggregation-row lookup: once
+  `percentile()` returns false, the key falls through `TABLE["metric"].get(...)` to `None` and the
+  existing branch fires. A message written specially for out-of-range percentiles would be a
+  second rule (FR-003). Verified by simulation — [research.md](../research.md) R5.
+- **`p100` gains no row.** § *Aggregations* already says why: the quantity it names is `max`.
+- **The schema is not read and not written.** § *How these tables are applied* states this section
+  never reads the schema, and the heredoc's own header comment repeats the reason.
+- **`README.md` is not edited by this commit**, and `examples/` is not edited by any of them.
+
+## Acceptance
+
+```bash
+bash scripts/verify.sh
+```
+
+`== Examples are assertable by Gatling` reports `16 predicate probes still rejected` and
+`16 still rendered`, and the whole gate is **PASS**.
+
+Then, each on its own, and each must turn the gate **red**:
+
+| revert | expected failure |
+|---|---|
+| `re.fullmatch` → `re.match` | probe `p95\n` |
+| `\d{1,2}` → `\d+` | probe `p999` |
+| `\d{1,2}` → `\d*` | probe `p.5` |
+| the whole constant → the old `isdigit()` helper | probes `p999` and `p.5` |
+| any probe deleted | the floor, before any probe runs |
+
+And the six accepted percentiles still render: `p95`, `p99.9`, `p1`, `p10`, `p0.1`, `p99.99`.

--- a/specs/013-numbers-a-predicate-carries/contracts/threshold-arithmetic.md
+++ b/specs/013-numbers-a-predicate-carries/contracts/threshold-arithmetic.md
@@ -1,0 +1,176 @@
+# Contract: the conversion is exact decimal arithmetic (#59)
+
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md) | **Commit 3 of 4**
+
+Closes [#59](https://github.com/galax-io/opennfr/issues/59). Satisfies FR-007 … FR-017f.
+
+**Files**: `README.md` § *Units* (under § *Gatling*), `GLOSSARY.md` § *threshold and unit*, and
+`scripts/verify.sh`. The schema is read and **not** written.
+
+---
+
+## What is wrong today
+
+Three things, in one paragraph of one table.
+
+**1. The whole-number rule has no arithmetic model.** It forbids rounding on the ground that
+rounding moves the bar, and then leaves undecided the question of whether a value *is* whole:
+
+| document | exact decimal | IEEE-754 double |
+|---|---|---|
+| `1.001 s` | `1001` → renders | `1000.9999999999999` → refused |
+| `1.003 s` | `1003` → renders | `1002.9999999999999` → refused |
+| `1.005 s` | `1005` → renders | `1004.9999999999999` → refused |
+
+Neither renderer is wrong under the published text.
+
+**2. The `Target` column attributes the `Int` to the target.** It is the type of the DSL entry
+point; the `Assertion` a renderer may construct itself carries a `double`
+([research.md](../research.md) R3, re-read 2026-09-01 at 3.13.5 / 0.0.11).
+
+**3. One cell in that column is wrong.** `AssertionWithPathAndCountMetric.count` returns
+`AssertionWithPathAndTarget[Long]`; the table says `Int`.
+
+## The change — `README.md` § *Units*
+
+**1. The arithmetic, stated** — a new paragraph immediately before the whole-number rule:
+
+> **The conversion is exact decimal arithmetic on the value the threshold denotes**, never binary
+> floating-point multiplication: `threshold: 1.001, unit: s` is 1001 ms and renders, where a
+> double would compute 1000.9999999999999 and refuse. A renderer that has already parsed the
+> threshold into a binary float conforms by recovering the shortest decimal that round-trips that
+> float and computing exactly from there — that decimal is the literal's value for any threshold
+> of at most fifteen significant digits. Keeping the document's source text is **not** required;
+> JSON and YAML parsers discard it.
+
+**2. The `Target` column** becomes the DSL entry point's type, and says so. One cell changes:
+
+| Statistic | Target, before | Target, after |
+|---|---|---|
+| `responseTime.*`, `groupCumulatedResponseTime.*` | `Int` | `Int` |
+| `failedRequests.percent` | `Double` | `Double` |
+| `allRequests.count`, `failedRequests.count` | `Int` | **`Long`** |
+| `requestsPerSec` | `Double` | `Double` |
+
+with a sourcing line naming `AssertionBuilders.scala` at `gatling-core` **3.13.5**,
+`gatling-core-java` **3.13.5** and `gatling-shared-model_2.13` **0.0.11**, **checked 2026-09-01** —
+its own versions and its own date, not § *Gatling*'s 3.15.1 header.
+
+**3. The whole-number rule** stops naming a Scala type:
+
+> **Where the target is integral, the threshold converted to the native unit must be a whole
+> number.** `threshold: 0.5, unit: ms` is unrenderable; `threshold: 0.5, unit: s` is 500 ms and is
+> fine; `aggregation: count, threshold: 20.5` is unrenderable for the same reason. Rounding is not
+> an option: it moves the bar the author wrote, so the document states one limit and the run
+> enforces another, and the report names neither.
+
+**4. A recorded non-relaxation**, so the next reader meets the argument rather than reopening it:
+the `Int` and the `Long` are the types of the two DSL entry points, a renderer constructing the
+assertion model itself does not pass through them, and the rule is **not** relaxed for it —
+reach is a property of the target, not of how a renderer is built.
+
+## The change — `GLOSSARY.md` § *threshold and unit*
+
+The entry's existing *Rejected* line gains one sentence, naming both grounds (FR-012):
+
+> A **precision bound on `threshold`** — `multipleOf`, or a stated significant-digit limit. It
+> narrows the schema to one target's reach, which § *aggregation* already refused in these words
+> when #57 proposed it for `count` and `rate`; and it does not work, because `multipleOf` is
+> itself evaluated in binary floating point — `multipleOf: 0.001` rejects `1.001`, `1.003` and
+> `1.005` under `jsonschema` 4.26.0, the very values the bound was proposed to admit.
+
+**Why here and not in § *Units*.** An earlier draft of this contract put it in the reach section.
+That is a **target description** — Principle VI defines one as what a renderer reads to turn a
+requirement document into that target's assertions — and why the format declined to constrain its
+own schema is not something a renderer reads. `GLOSSARY.md` is where this repository records a
+rejected alternative, § *threshold and unit* is the entry that owns the field, and its *Rejected*
+line already carries the two neighbouring decisions: full UCUM, and `threshold: "500ms"`. A
+contributor proposing a bound is editing `$defs/threshold` and reading the term that defines it.
+
+**No entry is added, renamed or redefined**, which is what [spec.md](../spec.md) FR-027 requires:
+*"Where a decision above bears on an existing entry, it is recorded at the entry's own Rejected
+line rather than as a new term."* The spec provided for this from the start; this contract had
+narrowed it.
+
+## The change — `scripts/verify.sh`
+
+**1. A comment on the round-trip**, so replacing it reads as a change to the rule:
+
+```python
+# Exact decimal arithmetic on the value the threshold denotes -- README > Gatling > Units states
+# it, and this is not an accident of Python. str() of a float is its shortest round-tripping
+# decimal, which is the literal's value for any threshold of at most 15 significant digits; a
+# plain `p["threshold"] * factor` would refuse 1.001 s, which the rule admits.
+value = Fraction(str(p["threshold"])) * factor
+```
+
+**2. One rendering probe** in `PREDICATE_RENDERS` — the disagreement itself:
+
+```python
+{**RENDERABLE, "threshold": 1.001, "unit": "s"},
+```
+
+Two keys and no more. `threshold` and `unit` move together because the subject is the conversion —
+`1.001 ms` is not whole and would test the wrong thing — and nothing else moves, because
+`scripts/verify.sh:863` states the convention this table is written to: a probe is *"a mutation of
+one renderable predicate so a probe differs from a passing one in exactly the thing it tests."*
+An aggregation override here would test nothing.
+
+**3. Two rejection probes** in `PREDICATE_PROBES` — the count rows' integral flag, which no probe
+reaches today:
+
+```python
+({"aggregation": "count", "op": "lte", "threshold": 20.5, "unit": "{request}"},
+ "threshold 20.5 {request} is 41/2 for allRequests.count, whose target is an integer"),
+({"bad": BAD, "aggregation": "count", "op": "lte", "threshold": 20.5, "unit": "{request}"},
+ "threshold 20.5 {request} is 41/2 for failedRequests.count, whose target is an integer"),
+```
+
+**One per count row, and this contract said one probe until implementation.** The two rows sit in
+different shapes — `allRequests.count` under `requests`, `failedRequests.count` under `fraction` —
+so a single probe reaches one row and leaves the other exactly as unguarded as it was. The revert
+set below is what caught it.
+
+**4. Floors**: rejection `16` → `20`, rendering `16` → `18`.
+
+## What must NOT change
+
+- **No message string.** The count refusal's existing wording — *"whose target is an integer"* —
+  stays true and correct under `Long`. The gate reasons over an `integral` flag and never over the
+  word `Int`, which is why the gate was right and only the page was wrong.
+- **No document changes renderability.** `20.5 {request}` is unrenderable before and after;
+  `1.001 s` renders before and after. The rule's bite is identical (FR-017b).
+- **The schema gains no precision bound** (FR-011), and the reason it does not lands in
+  `GLOSSARY.md` rather than here (FR-012) — see the section above.
+- **`GLOSSARY.md` gains no entry and loses none.** One sentence joins an existing *Rejected* line;
+  no term changes, so Development Workflow's same-PR obligation is not triggered by a rename. The
+  entry's existing rejection of `threshold: "500ms"` stays and is not contradicted: this rule is
+  about the value a number denotes, not about admitting a decimal string.
+- **The `0.1 ms` rejection probe and its message survive byte-identical** (FR-015). T017 rewords
+  the whole-number rule and the tempting companion edit is to reword the gate's message to match;
+  it must not be made. The floors do not protect this probe — a deletion plus two additions still
+  clears them — so it is checked directly.
+
+## Acceptance
+
+```bash
+bash scripts/verify.sh
+```
+
+`20 predicate probes still rejected, 18 still rendered`, whole gate **PASS**.
+
+| revert | expected failure |
+|---|---|
+| `Fraction(str(...))` → `p["threshold"] * factor` | the `1.001 s` rendering probe |
+| the `0.1 ms` probe's message reworded to match T017 | nothing — which is why FR-015 is checked by diff, not by the gate |
+| `allRequests.count`'s `True` → `False` in `TABLE` | the plain `20.5 {request}` probe |
+| `failedRequests.count`'s `True` → `False` in `TABLE` | the `bad: BAD` `20.5 {request}` probe |
+| any probe deleted | the floor |
+
+And by diff: `git diff main -- scripts/verify.sh` shows the `0.1 ms` probe and its message
+untouched (FR-015), and `git diff main -- GLOSSARY.md` shows exactly one added sentence inside an
+existing *Rejected* line — no heading added, none removed (FR-027).
+
+And by reading: § *Units* answers "how is the conversion computed?" without opening
+`scripts/verify.sh`; every cell of the `Target` column matches `AssertionBuilders.scala`; the
+whole-number rule names no Scala type; and § *Units* carries no statement about the schema.

--- a/specs/013-numbers-a-predicate-carries/data-model.md
+++ b/specs/013-numbers-a-predicate-carries/data-model.md
@@ -1,0 +1,173 @@
+# Phase 1 — Data Model: Which Numbers a Predicate May Carry
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Date**: 2026-09-01
+
+Nothing here is a data structure in a program. These are the entities the milestone's rules are
+written about, each with where it lives, what decides it, and what it may hold after the change.
+
+---
+
+## 1. The percentile pattern
+
+**What it is**: the decision that an aggregation names a percentile.
+
+| | |
+|---|---|
+| **Stated in** | `schema/…/requirementset.schema.json` → `$defs/aggregation.anyOf[1].pattern` |
+| **Restated in** | `README.md` § *Aggregations*, first row, quoting the schema |
+| **Implemented in** | `scripts/verify.sh`, the Gatling heredoc |
+| **Value** | `^p\d{1,2}(\.\d+)?$` — one string, three places, character-identical |
+
+**Admits**: `p0` … `p99`, optionally with a decimal fraction of any length. `p95`, `p99.9`,
+`p0.1`, `p99.99`, `p1`, `p10`.
+
+**Refuses**: an integer part of three or more digits (`p100`, `p999`, `p1234`), a missing integer
+part (`p.5`), a trailing bare dot (`p1.`), a bare `p`, and — under `re.fullmatch`, not under
+`re.match` — a trailing newline (`"p95\n"`). See [research.md](research.md) R1.
+
+**Invariant after this milestone**: the three copies are one string. The row is the argued
+artifact; the schema decides validity; the gate implements the row. Drift between the gate and
+the row is caught by three probes. Drift of all three *together* — if the schema's pattern
+widened — is caught by nothing, and is in [spec.md](spec.md) § *Out of Scope*.
+
+**Does not change**: the pattern's value, the schema, or § *Aggregations*' text.
+
+---
+
+## 2. The conversion
+
+**What it is**: a `threshold` and a `unit` reduced to a statistic's native unit.
+
+| | |
+|---|---|
+| **Inputs** | `threshold` (a JSON `number`, no stated precision) and `unit` (closed enumeration, 17 values) |
+| **Factor** | per statistic — `TIME`, `SHARE`, `COUNT`, `PERSEC` in the gate; the `Accepts` and `Native` columns of § *Units* |
+| **Output** | one exact rational in the statistic's native unit |
+| **Arithmetic** | **exact decimal on the value `threshold` denotes** — new, and the whole of #59 |
+
+**The arithmetic, stated**: the conversion is computed exactly over the decimal value the
+threshold denotes, never over the binary double nearest to it. A renderer that has already parsed
+into a double conforms by recovering the shortest decimal that round-trips that double and
+computing from there; that decimal is the literal's value for any literal of at most fifteen
+significant digits, which is more precision than a threshold carries.
+
+**Why this and not "the literal as written"**: JSON and YAML parsers discard source text, and a
+format may not require a parser nobody has (FR-010). Why not shortest-round-trip *as* the rule:
+Java's `Double.toString` did not always produce the shortest decimal before JDK 19, so the answer
+would depend on the JDK. The rule is about the value; the recovery is one route to it.
+
+**Where the two arithmetics disagree** — the reason the rule cannot stay unstated:
+
+| document | exact decimal | IEEE-754 double |
+|---|---|---|
+| `1.001 s` | `1001` → renders | `1000.9999999999999` → refused |
+| `1.003 s` | `1003` → renders | `1002.9999999999999` → refused |
+| `1.005 s` | `1005` → renders | `1004.9999999999999` → refused |
+
+---
+
+## 3. The whole-number rule
+
+**What it is**: the constraint that a converted value must be whole where the target cannot hold
+a fraction. It forbids rounding, because rounding moves the bar the author wrote.
+
+| | before | after |
+|---|---|---|
+| **Condition** | "Where the target is an `Int`" | "Where the target is **integral**" |
+| **Governs** | the two duration statistics; the count rows only by the accident that they were also labelled `Int` | the two duration statistics **and** both count rows, explicitly |
+| **Implemented by** | the gate's `integral` flag — already correct, already covering both count rows | unchanged |
+
+**Why the wording must change with the cell**: § *Units* labels `allRequests.count` and
+`failedRequests.count` as `Int`; the DSL returns `Long` ([research.md](research.md) R3).
+Correcting the cell while the rule still says `Int` drops counts out of the rule and makes
+`threshold: 20.5, unit: {request}` renderable. The gate never read the word — it reads a boolean —
+so the gate was right and the page was wrong.
+
+**Refuses, after the change, exactly as before**: `0.5 ms` (1/2), `0.1 ms` (1/10),
+`20.5 {request}` (41/2), and newly reachable sub-millisecond values `1500 ns` (3/2000) and
+`1 us` (1/1000).
+
+---
+
+## 4. The Units reach table
+
+**What it is**: one row per statistic, plus one derived row for what nothing reaches.
+
+**After this milestone**:
+
+| Statistic | Accepts | Native | Target |
+|---|---|---|---|
+| `responseTime.*` | `ns` `us` `ms` `s` `min` `h` | milliseconds | `Int` — the DSL entry point's type |
+| `groupCumulatedResponseTime.*` | `ns` `us` `ms` `s` `min` `h` | milliseconds | `Int` — the same |
+| `failedRequests.percent` | `%` `1` | percent, 0..100 | `Double` |
+| `allRequests.count`, `failedRequests.count` | `{request}` | count | **`Long`** |
+| `requestsPerSec` | `{request}/s` | per second | `Double` |
+| — | `By` `KiBy` `MiBy` `GiBy` `{iteration}` `{iteration}/s` `{vu}` | — | not reachable through any assertable statistic |
+
+**Invariants**:
+
+- **One row per statistic.** Why the four durations join the two `Accepts` cells rather than
+  taking a row of their own, which is what #74's wording proposes: § *Units* opens by stating
+  units are per statistic, and a statistic in two rows contradicts it. Recorded in
+  [spec.md](spec.md) § *Decisions*.
+- **The last row is derived**: the enumeration in § *Units* minus every unit a statistic reaches.
+  17 − 10 = 7, and the seven are exactly the ones listed ([research.md](research.md) R7). Adding
+  a unit to the format stays one decision, not two.
+- **The `Target` column is the DSL entry point's type**, and says so. Five rows, five types, each
+  checkable against `AssertionBuilders.scala` at the version the cell is dated to.
+
+---
+
+## 5. A probe
+
+**What it is**: a predicate this contract says renders, or says does not, paired with the reason
+the gate must give. The gate's only means of showing a rule still fires — the corpus cannot,
+because it holds only documents that render.
+
+| | |
+|---|---|
+| **Rejection probe** | `(predicate, expected_message)` in `PREDICATE_PROBES`; fails if the message is absent |
+| **Rendering probe** | `predicate` in `PREDICATE_RENDERS`; fails if any reason is produced |
+| **Exercises** | `predicate_why` — the same function the corpus is judged by, never a copy |
+
+**Fifteen added**, each the sole catcher of one regression; the table is in
+[research.md](research.md) R6. It said ten until implementation showed the two count rows sit in
+different shapes and need a probe each, and eleven until code review found the rule was a range as
+well as a divisibility and that the stated arithmetic was unreachable past fifteen significant
+digits. **No new message string**: every refusal comes from a code path
+that already exists (R5).
+
+---
+
+## 6. A floor
+
+**What it is**: the exact probe count a class must meet. A pruned probe table reports no failures
+and reads exactly like a sound one, so each floor is exact and adding a probe means raising it.
+
+| class | today | after #73 | after #59 | after #74 |
+|---|---|---|---|---|
+| predicate rejection | 13 | **16** | **20** | **22** |
+| predicate rendering | 16 | 16 | **18** | **22** |
+
+The four selection and pairing floors — 9, 6, 4, 4 — are untouched.
+
+---
+
+## 7. The DSL entry point *(read, not written)*
+
+**What it is**: the Gatling constructor a rendered predicate would pass through, and the source of
+the `Target` column. Read **2026-09-01** at `gatling-core` / `gatling-core-java` **3.13.5** and
+`gatling-shared-model_2.13` **0.0.11**.
+
+| entry point | target type | reaches |
+|---|---|---|
+| `AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` | `Int` | `responseTime.*`, `groupCumulatedResponseTime.*` |
+| `AssertionWithPathAndCountMetric.count` | **`Long`** | `allRequests.count`, `failedRequests.count` |
+| `AssertionWithPathAndCountMetric.percent` | `Double` | `failedRequests.percent` |
+| `AssertionWithPath.requestsPerSec` | `Double` | `requestsPerSec` |
+
+The type is consumed at the boundary — `lt(threshold: T)` calls `numeric.toDouble(threshold)` —
+and the `Assertion` it produces carries a `double` in every `Condition`. So a renderer constructing
+the model itself never passes through the typed builder. § *Units* records that and **does not**
+relax the rule for it: reach is a property of the target, not of how a renderer is built
+([spec.md](spec.md) § *Decisions*).

--- a/specs/013-numbers-a-predicate-carries/plan.md
+++ b/specs/013-numbers-a-predicate-carries/plan.md
@@ -1,0 +1,152 @@
+# Implementation Plan: Which Numbers a Predicate May Carry
+
+**Branch**: `013-numbers-a-predicate-carries` | **Date**: 2026-09-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/013-numbers-a-predicate-carries/spec.md`
+
+## Summary
+
+Milestone **v0.9.0**, three issues, one question under all of them: *which numbers may a predicate carry, and which artifact decides?* Three artifacts answer today and they answer differently.
+
+The milestone stays inside what a renderer does — turning a requirement document into a target's assertions. Nothing here describes a report, a verdict, or anything a consumer builds after the run.
+
+- **#73**: the gate's percentile test is `a.startswith("p") and a[1:].replace(".", "", 1).isdigit()`, which admits **five** shapes the row's `^p\d{1,2}(\.\d+)?$` and the schema both reject — `p100`, `p999`, `p1234`, `p.5` and `p1.`, the last of which no issue names. On those, one run of the gate calls a predicate assertable in its reach section and the document invalid in its schema section. The helper becomes the row's pattern, matched with `re.fullmatch` and not `re.match` ([research.md](research.md) R1), plus three rejection probes.
+- **#59**: the whole-number rule forbids rounding but never says which arithmetic decides whether a value is whole, and exact decimal disagrees with a double on `1.001 s`, `1.003 s` and `1.005 s`. The contract gains the arithmetic and a conformance route for a renderer that already parsed into a double (R2). The schema does **not** gain a precision bound: `GLOSSARY.md` § *aggregation* already rejected narrowing the schema to a target's reach, and `multipleOf: 0.001` **rejects `1.001`** under the repository's own validator, reproducing the defect one layer down.
+- **#59, closing section**: the `Int` the rule rests on is the type of two DSL entry points, not of the target — re-read here at 3.13.5 / 0.0.11 (R3). The attribution is corrected, no rule is relaxed, and one cell in the same column is wrong: `count` returns `AssertionWithPathAndTarget[`**`Long`**`]`. That correction is not separable — the rule is worded *"where the target is an `Int`"*, so fixing the cell alone would drop counts out of the rule and make `20.5 {request}` renderable.
+- **#74**: the Units table gives one reason for eleven units and it is true of seven. `responseTime.*` reaches `ns`, `us`, `min` and `h` exactly, by the same arithmetic that already converts `s`. Four factors are added, the two duration statistics' `Accepts` cells grow, and the unreachable row shrinks to the seven for which its reason holds.
+
+**The work is three files.** `README.md` (§ *Aggregations* untouched but named as the source; § *Units* — the `Accepts` cells, the `Target` column, the whole-number rule, and a new sentence stating the arithmetic), `GLOSSARY.md` (one sentence joining § *threshold and unit*'s existing *Rejected* line, recording why a precision bound on `threshold` was refused) and `scripts/verify.sh` (`import re`, the percentile constant and test, four `TIME` factors, the `Int`/`Long` bounds, a literal-preserving loader, fifteen probes, four raised floors). The schema is read and not written.
+
+**`examples/` does not change**, and R8 shows why rather than asserting it: across all ten published predicates the aggregations are `p50`/`p95`/`p99`/`max`/`count`/`rate`, the units are `ms`/`s`/`%`/`{request}`/`{request}/s`, and every threshold is a whole number in a whole unit. Every change here either refuses something no document says or admits something no document says.
+
+The plan's four load-bearing decisions:
+
+- **`re.fullmatch`, and the pattern carried verbatim with its anchors.** Python's `$` also matches before a trailing newline; ECMA-262's — the dialect JSON Schema `pattern` is defined in — does not. `re.match` with the row's pattern would accept `"p95\n"` and leave a strictly smaller copy of #73 installed by the commit that closes it (R1). The anchors are redundant under `fullmatch` and kept anyway, so a reader can hold the gate's constant beside the row and beside `$defs/aggregation` and see three identical strings.
+- **The rule is about the value, and the double route is a conformance note.** "The literal as written" would oblige a renderer to keep source text that JSON and YAML parsers discard (FR-010). Shortest-round-trip recovery is named as *a route to* the value, not as the rule: Java's `Double.toString` did not always produce the shortest decimal before JDK 19, so a Scala renderer's answer would otherwise depend on its JDK.
+- **The gate was right; the page was wrong.** The gate reasons over an `integral` flag and never over the word `Int`, so its existing refusal message — *"whose target is an integer"* — stays true and correct under `Long`. FR-017e makes the page say what the gate already does, and no message string changes anywhere in this milestone (R5).
+- **Fifteen probes, each the sole catcher of one regression.** That is the standard the section's own comment already sets. Without probe 3 (`"p95\n"`) the `fullmatch`→`match` swap passes green; without probe 5 either count row's integral flag can be flipped and the gate stays green today.
+
+## Technical Context
+
+**Language/Version**: none for the format. The gate is POSIX `bash` driving `python3` heredocs. This feature adds one standard-library import, `re`, to the Gatling heredoc, which today imports `glob`, `sys`, `Fraction`, `identity` and `yaml`.
+
+**Primary Dependencies**: unchanged. `jsonschema` and `pyyaml` are already required and nothing joins them.
+
+**Storage**: N/A.
+
+**Testing**: `bash scripts/verify.sh` is the only gate, and this feature adds to one of its sections — *Examples are assertable by Gatling*. There is no test runner and nothing to compile.
+
+**Target Platform**: N/A — the artifacts are a JSON Schema, three markdown documents and a shell gate.
+
+**Project Type**: format specification with a validating gate.
+
+**Performance Goals**: N/A. The gate reads four YAML documents and one schema.
+
+**Constraints**: `examples/` is byte-identical before and after. No compatibility-sensitive surface is touched: no borrowed OpenTelemetry name changes, and no field name appearing in a published example is added, removed or renamed. The schema is not edited. `git rm -r docs && bash scripts/verify.sh` stays green.
+
+**Scale/Scope**: three files, fifteen probes, four floors. Four schema-valid documents become publishable that were not; none stops being publishable.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 research and re-evaluated after Phase 1 design. Both passes recorded.*
+
+See `.specify/memory/constitution.md` (v4.0.0).
+
+- [x] **I. Vocabulary Before Features** — no term is introduced and none is renamed. `threshold`, `unit`, `aggregation` and every unit spelling are unchanged. `GLOSSARY.md` gains **no entry and loses none**; § *threshold and unit*'s existing *Rejected* line gains one sentence, which is the shape this principle asks for — *"the rejection outlives the term it protects"* — and is what [spec.md](spec.md) FR-027's second sentence provides for. The line already refuses full UCUM and `threshold: "500ms"`, the latter being the shape a "keep the source text" reading of #59 would have pushed toward; the refused precision bound joins them. All three issues were argued before any file changed.
+- [x] **II. Borrow Names, Never Invent Them** — no metric or attribute name is touched. The four units entering the reach tables are already in the format's closed enumeration and are UCUM spellings; nothing is minted. No alias, no derived or composite quantity.
+- [x] **III. No Silent Green** — the principle this milestone is most exposed to, and #73 and FR-017f are both instances of it. Every rule changed gains a probe that fails when it is reverted (R6), and each of the four floors is raised in the commit that adds its probes. Two rules that are unprobed **today** stop being so: the percentile pattern, and both count rows' integral flag, either of which can currently be flipped with the gate staying green.
+- [x] **IV. Honest Status** — every external claim carries its artifact, its version and its date. R3 was re-read here at `gatling-core` / `gatling-core-java` **3.13.5** and `gatling-shared-model_2.13` **0.0.11** on **2026-09-01**, and § *Units* will name those rather than borrowing § *Gatling*'s 3.15.1 header — the same treatment v0.8.0's Identity row received. FR-017d exists because a published table stated a type nobody had checked.
+- [x] **V. Structure Over Grammar** — no field is added and no value set changes. The percentile pattern is a schema `pattern` today and stays one; the gate carries a copy of it as a constant, which is an implementation of a row, not a second grammar. `threshold` stays a bare `number` — FR-011 declines the one change that would have put a decoding rule in the schema.
+- [x] **VI. The Requirement Is Target-Blind** — no requirement document names a target and `examples/` does not change. Every prose edit that is a **target fact** lands in `README.md` § *What any tool can actually run*, the **one** description Gatling has; no second copy is created. The one edit that is *not* a target fact — why the format declined to bound `threshold` in its own schema — lands in `GLOSSARY.md` instead, because a renderer reads nothing from it and a description is defined as what a renderer reads. An earlier draft of the contract had put it in § *Units*; `/speckit-analyze` caught it. The gate implements that description and carries no second copy of its rows — every new refusal comes from a code path that already existed, and no message string is added (R5). Adding these four reachable units changes no format, no schema and no requirement document.
+- [x] **VII** — *withdrawn in 3.0.0. No gate.*
+- [x] **VIII. Ideas Are Parked, Not Merged** — nothing under `docs/` is touched, no construct is proposed or parked, and no document outside `docs/` gains a link into it. `git rm -r docs && bash scripts/verify.sh` is unaffected.
+- [x] **Compatibility** — no borrowed OpenTelemetry name is touched. No field name in a published example is added, removed or renamed. **The published corpus widens rather than narrows**: four units the format already carried become publishable, and the "at least one surveyed target can assert it exactly" bar is cleared by the arithmetic in R4 — `1500000 us` is 1500 ms with no rounding, which is exactly what "assert it exactly" asks. Nothing enters the format at all, so the second clause — that a construct must not enter solely to reach one target's feature — has nothing to bind.
+
+**Post-Phase-1 re-check**: unchanged. Three things the design passes made explicit, none a violation.
+
+1. **R1 changed how #73 is implemented, not what it decides.** The spec's FR-001 asks that the gate admit exactly what the row admits; a naive `re.match` would have missed that by one input. The requirement did not move — the implementation that satisfies it did, and [contracts/percentile-pattern.md](contracts/percentile-pattern.md) fixes the call so a later "simplification" is a visible change.
+2. **The `Long` correction stays inside #59 and does not become its own commit.** It is downstream of FR-017's sentence, not adjacent to it: the column's *meaning* changes, and one cell is wrong under the new meaning. Splitting it out would produce a commit whose only content is a cell that the previous commit had just made false.
+3. **Code review found the rule was under-stated twice, and both are now in the gate.** The
+   whole-number rule is a **range** as well as a divisibility — `597 h` is exactly 2 149 200 000 ms
+   and the `Int` the table now names stops at 2 147 483 647 — so `TABLE` carries a bound per row
+   rather than a boolean. And the arithmetic § *Units* states is about the value the literal
+   denotes, which `Fraction(str(float))` cannot recover past fifteen significant digits: the gate
+   rendered `1.0000000000000001 s` as a whole 1000 ms while the rule refused it. `ExactLoader`
+   keeps the literal, and `LOADER`'s own check guards the wiring, which no probe can reach because
+   no published document carries a threshold that long.
+4. **The count rows needed two probes, not one, and implementation is where that surfaced.**
+   FR-017f and this plan said "a rejection probe for a fractional threshold on a count row",
+   singular. The two count rows sit in **different shapes** — `allRequests.count` under `requests`,
+   `failedRequests.count` under `fraction` — so a single probe reaches one and leaves the other as
+   unguarded as T002's baseline found it. The T025 revert set caught it before the commit: with one
+   probe, flipping `failedRequests.count`'s integral flag left the gate green. Two probes now, and
+   the rejection floors are 18 and 19 rather than 17 and 18. Recorded here rather than silently
+   corrected, because the probe count is the milestone's own claim about what it checks.
+5. **`GLOSSARY.md` gains one sentence, and the plan was wrong to say otherwise.** This entry said the file was untouched. `/speckit-analyze` found that it put FR-012's recorded rejection — why a precision bound on `threshold` was refused — inside § *Units*, which is a target description, and Principle VI defines one as what a renderer reads to turn a document into assertions. A rejected schema change is not that. The rejection moves to § *threshold and unit*'s *Rejected* line, beside the two neighbouring decisions about the same field. **The spec never narrowed this**: FR-027 already read *"where a decision above bears on an existing entry, it is recorded at the entry's own Rejected line"*, and § *Dependencies* already said `GLOSSARY.md` was "extended only if FR-027's second sentence applies". The plan and the contract narrowed what the spec allowed; the spec needs no change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-numbers-a-predicate-carries/
+├── spec.md
+├── plan.md                         # this file
+├── research.md                     # Phase 0 — eight questions; R1 changed an implementation
+├── data-model.md                   # Phase 1 — the pattern, the conversion, the row, the probe
+├── quickstart.md                   # Phase 1 — how to check the milestone landed
+├── contracts/
+│   ├── percentile-pattern.md       # the constant, the call, the three probes          (#73)
+│   ├── threshold-arithmetic.md     # the arithmetic sentence, the Target column, Long  (#59)
+│   └── duration-units.md           # the factors, the two Accepts cells, the last row  (#74)
+└── checklists/
+    └── requirements.md
+```
+
+### Repository (what this feature edits)
+
+```text
+README.md                                       # § Units (under § Gatling) — the two Accepts cells,
+                                                #   the Target column incl. Long, the whole-number
+                                                #   rule reworded, one new sentence on the arithmetic
+scripts/verify.sh                               # import re; PERCENTILE + fullmatch; four TIME
+                                                #   factors; bounds; loader; fifteen probes; four floors
+
+# read, and deliberately not written
+schema/opennfr.io/v1/requirementset.schema.json # $defs/aggregation's pattern is the source of the
+                                                #   constant; $defs/threshold gains no bound (FR-011)
+# ^ and the reason it gains none is recorded in GLOSSARY.md above, not in a target description
+GLOSSARY.md                                     # § threshold and unit — one sentence joins the
+                                                #   existing *Rejected* line: why a precision bound
+                                                #   on `threshold` was refused (FR-012)
+README.md § Aggregations                        # the percentile row is the source; its text is final
+
+# untouched, and checked to be untouched (quickstart step 1)
+examples/                                       # byte-identical; every document keeps its verdict
+docs/                                           # no idea added, moved or edited
+.specify/memory/constitution.md                 # stays at 4.0.0; no amendment is needed
+specs/                                          # except this feature's own directory
+```
+
+**Structure Decision**: the repository has no source tree. The format is `schema/`, explained by `README.md`, its terms in `GLOSSARY.md`, its corpus in `examples/`, and its gate in `scripts/`. This feature edits three of those five and reads the other two; `examples/` is deliberately untouched, and the schema is deliberately not written.
+
+## Implementation Order
+
+Four commits, one per issue in the milestone's own order, preceded by the spec commit. Each is green on its own, and each raises the floors it earns.
+
+1. **`docs(speckit): add 013-numbers-a-predicate-carries spec/plan/tasks`** — this directory.
+2. **`fix(gate): the percentile test is the row it implements (#73)`** — `scripts/verify.sh`: `import re`, the `PERCENTILE` constant, `re.fullmatch`, three rejection probes, rejection floor 13 → 16. No `README.md` change: § *Aggregations* is already correct and is the source. Contract: [contracts/percentile-pattern.md](contracts/percentile-pattern.md).
+3. **`fix(format): the conversion is exact decimal arithmetic (#59)`** — `README.md` § *Units*: the arithmetic sentence, the `Target` column with `Long`, the whole-number rule conditioned on an integral target. `GLOSSARY.md` § *threshold and unit*: one sentence on the refused precision bound. `scripts/verify.sh`: the round-trip's comment, one rendering probe (`1.001 s`), four rejection probes (`20.5 {request}` once per count row, the 17-digit literal, the `Long` bound) and two rendering, floors 16 → 20 and 16 → 18. Contract: [contracts/threshold-arithmetic.md](contracts/threshold-arithmetic.md).
+4. **`fix(format): responseTime reaches ns, us, min and h (#74)`** — `README.md` § *Units*: the two `Accepts` cells, the last row down to seven. `scripts/verify.sh`: four `TIME` factors, four rendering probes, one rejection probe, floors 20 → 22 and 18 → 22. Contract: [contracts/duration-units.md](contracts/duration-units.md).
+
+#73 is first because it is one line of rule and touches nothing the other two touch. #59 is second because #74 adds four conversions that #59's sentence governs, and adding them first would multiply the ambiguity by four. #74 is last and is the only commit that changes which documents may be published.
+
+## Complexity Tracking
+
+> Three costs are paid deliberately. None is a Constitution Check violation; each is recorded because a reviewer should meet it here rather than find it in a diff.
+
+| Cost | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| A third copy of the percentile pattern, as a constant in the gate | The row and the schema already hold it; the gate must too, because § *How these tables are applied* states this section "never reads the schema" and the heredoc says so in a comment. The copy is what makes the gate an implementation of the row rather than a second rule. | **Reading `$defs/aggregation` at runtime** gives one copy and crosses the line the section draws — and the direction matters less than the sentence, which a reader would then have to reconcile against the code. **Leaving the helper and widening the row** inverts #73: the row is the argued artifact and the helper is the accident. The residual — schema, row and gate could drift *as a group* — is in spec § *Out of Scope* with the note that it needs its own issue. |
+| Three probes for #73 where FR-002 asks for one | Each catches a distinct regression: a widened integer part, an optional integer part, and `fullmatch` swapped for `match` (R1). At one probe, two of the three pass green. | **One probe** meets the letter of FR-002 and leaves the two most likely edits — "simplify the regex", "match is shorter" — undetected. The section's own comment already sets this standard: *"Each probe here is the sole catcher of its own class."* |
+| A cell correction (`Int` → `Long`) riding inside #59 rather than taking its own issue | It is downstream of FR-017, not adjacent to it. FR-017 restates what the `Target` column **means**; under the new meaning the count cell is wrong, and correcting it alone would drop counts out of a rule worded *"where the target is an `Int`"*, making `20.5 {request}` renderable. | **Its own issue and commit** would land a commit whose only content is a cell the immediately preceding commit had just made false — and would leave the milestone shipping a rule that exempts counts. AGENTS.md's "does not ride along" governs work that is *not* one of the milestone's issues; this is what doing one of them correctly entails. Recorded in spec § *Decisions* as the maintainer's call. |

--- a/specs/013-numbers-a-predicate-carries/quickstart.md
+++ b/specs/013-numbers-a-predicate-carries/quickstart.md
@@ -1,0 +1,153 @@
+# Quickstart: checking that v0.9.0 landed
+
+**Feature**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md) | **Date**: 2026-09-01
+
+Nine steps. Each is a command or a read, each has an expected result, and together they check
+every functional requirement without reading a diff. Run from the repository root.
+
+**Prerequisites**: `python3` with `jsonschema` and `pyyaml` — the gate's existing dependencies.
+Nothing is added. Steps 8 and 9 additionally need a JDK's `javap` and the Gatling jars in the
+local Coursier cache; skip them and say so if the jars are absent, rather than passing them
+silently.
+
+---
+
+## 1. The corpus did not change
+
+```bash
+git diff --stat main -- examples/
+```
+
+**Expect**: empty output. FR-026 and SC-011. This is checked rather than read: byte-identical is
+not an impression.
+
+## 2. The gate is green and the floors moved
+
+```bash
+bash scripts/verify.sh
+```
+
+**Expect**: `PASS`, and the reach line reading
+
+```
+ok    10 predicates assertable by Gatling, 9 selection probes still rejected, 6 still rendered,
+      22 predicate probes still rejected, 22 still rendered, 4 pairing probes still rejected,
+      4 still rendered
+```
+
+**13 → 22** and **16 → 22** are the fifteen probes this milestone adds. The four selection and pairing
+counts are unchanged, which is how you know nothing else moved.
+
+## 3. Three artifacts say one thing about percentiles
+
+```bash
+python3 - <<'CHECK'
+import json, re
+schema = json.load(open("schema/opennfr.io/v1/requirementset.schema.json"))
+sp = [b["pattern"] for b in schema["$defs"]["aggregation"]["anyOf"] if "pattern" in b][0]
+readme = set(re.findall(r"`(\^p\\d\{1,2\}\(\\\.\\d\+\)\?\$)`",
+                        open("README.md", encoding="utf-8").read()))
+gate = set(re.findall(r'PERCENTILE\s*=\s*r"([^"]+)"',
+                      open("scripts/verify.sh", encoding="utf-8").read()))
+print("  schema:", sp)
+print("  README:", readme or "NOT FOUND")
+print("  gate  :", gate or "NOT FOUND")
+print("  all three identical:", bool(gate) and bool(readme) and {sp} == readme == gate)
+CHECK
+```
+
+**Expect**: `all three identical: True`. FR-001 and FR-004. Run it before #73 lands and the gate
+line reads `NOT FOUND` — which is the point: the named constant is what makes the three comparable
+at all, and the `isdigit()` helper it replaces was never a pattern anyone could hold beside the
+row. The gate's site must also name the row it implements, in a comment.
+
+## 4. Every out-of-range percentile is refused, and the six in range render
+
+```bash
+python3 - <<'PY'
+import re
+P = r"^p\d{1,2}(\.\d+)?$"
+for a in ["p95","p99.9","p1","p10","p0.1","p99.99","p100","p999","p1234","p.5","p1.","p","p95\n"]:
+    print(f"  {a!r:10} {'renders' if re.fullmatch(P,a) else 'refused'}")
+PY
+```
+
+**Expect**: the first six render, the last seven are refused. FR-005. If `p95\n` renders, the gate
+is using `re.match` — [research.md](research.md) R1.
+
+## 5. The arithmetic is answerable from the page alone
+
+Open `README.md` § *Units* under § *Gatling* and, **without opening `scripts/verify.sh`**, answer:
+
+- How is a threshold converted to the native unit? → *exact decimal arithmetic on the value the
+  threshold denotes.*
+- I have already parsed it into a double. What do I do? → *recover the shortest decimal that
+  round-trips it, then compute exactly; that is the literal's value up to fifteen significant
+  digits.*
+- Must I keep the document's source text? → *no.*
+
+Then open `GLOSSARY.md` § *threshold and unit* and confirm its *Rejected* line names the refused
+precision bound on `threshold` and both grounds — that it narrows the schema to one target's reach,
+and that `multipleOf` is itself evaluated in binary floating point. Confirm § *Units* says **nothing**
+about the schema: a target description is what a renderer reads, and a renderer reads nothing from
+a rejected schema change.
+
+FR-007 … FR-010, FR-012, FR-027, SC-003, SC-004.
+
+## 6. The two arithmetics are reconciled on the values that split them
+
+```bash
+python3 - <<'PY'
+from fractions import Fraction
+for lit in ["1.001","1.003","1.005","0.5"]:
+    print(f"  {lit} s -> exact {Fraction(lit)*1000}   double {float(lit)*1000.0}")
+PY
+```
+
+**Expect**: exact gives `1001`, `1003`, `1005`, `500` — all whole, all rendering. The double column
+shows why the rule could not stay unstated. The gate must render all four.
+
+## 7. Every unit is placed exactly once
+
+```bash
+python3 - <<'PY'
+import json
+units = set(json.load(open("schema/opennfr.io/v1/requirementset.schema.json"))["$defs"]["unit"]["enum"])
+reached = {"ns","us","ms","s","min","h","%","1","{request}","{request}/s"}
+print("  total", len(units), "| reached", len(reached), "| unreachable", len(units-reached))
+print("  unreachable:", sorted(units - reached))
+PY
+```
+
+**Expect**: `total 17 | reached 10 | unreachable 7`, and the seven are `By`, `GiBy`, `KiBy`,
+`MiBy`, `{iteration}`, `{iteration}/s`, `{vu}`. Read § *Units*' last row and confirm it holds
+exactly those. FR-020, FR-021, SC-005.
+
+## 8. The `Target` column matches the DSL
+
+```bash
+SRC=$(find ~/Library/Caches/Coursier ~/.cache/coursier -name 'gatling-core-3.13.5-sources.jar' 2>/dev/null | head -1)
+unzip -p "$SRC" 'io/gatling/core/assertion/AssertionBuilders.scala' | grep -n 'AssertionWithPathAndTarget\[' | head -20
+```
+
+**Expect**: `[Int]` for `min`/`max`/`mean`/`stdDev`/`percentile`, **`[Long]` for `count`**,
+`[Double]` for `percent` and `requestsPerSec`. Compare against § *Units*' `Target` column: five
+rows, five types, no mismatch. FR-017d, SC-009.
+
+## 9. The rule survives every revert that should kill it
+
+Apply each on its own, run `bash scripts/verify.sh`, expect **red**, then revert:
+
+| edit | expected failure |
+|---|---|
+| `re.fullmatch` → `re.match` | probe `p95\n` |
+| `\d{1,2}` → `\d+` in the pattern | probe `p999` |
+| `Fraction(str(...))` → `p["threshold"] * factor` | the `1.001 s` rendering probe |
+| either count row's `True` → `False` in `TABLE` | that row's own `20.5 {request}` rejection probe — one per shape |
+| any one of the four new `TIME` factors deleted | that unit's rendering probe |
+| the range check removed, or its bound off by one | `597 h`, or the `2147483647 ms` rendering probe |
+| `threshold_literal` back to `str(...)`, or `LOADER` swapped | the 17-digit probe, or `LOADER`'s own check |
+| any single probe deleted | the floor beside it |
+
+SC-007 and SC-010. The fourth row is the one that fails **today**: before this milestone, flipping
+either count row's integral flag leaves the gate green.

--- a/specs/013-numbers-a-predicate-carries/research.md
+++ b/specs/013-numbers-a-predicate-carries/research.md
@@ -1,0 +1,270 @@
+# Phase 0 — Research: Which Numbers a Predicate May Carry
+
+**Feature**: [spec.md](spec.md) | **Date**: 2026-09-01 | **Read at**: `906f8d2`
+
+Eight questions. Two changed a requirement's implementation, and one of those would have
+reintroduced a smaller copy of the defect #73 is about.
+
+---
+
+## R1 — The corrected percentile test must use `re.fullmatch`, not `re.match`
+
+**Question**: the helper becomes the row's pattern. Which Python call applies it?
+
+**Finding**: `re.match` is wrong, and wrong in the same direction as the bug being fixed.
+
+Python's `$` matches at the end of the string **or immediately before a trailing newline**.
+ECMA-262's `$` — the dialect JSON Schema `pattern` is defined in, and therefore the dialect the
+row's pattern is written in — matches only at the very end. So with the row's pattern carried
+verbatim:
+
+| input | `re.match` | `re.fullmatch` | what the schema does |
+|---|---|---|---|
+| `p95`, `p99.9`, `p1`, `p10`, `p0.1`, `p99.99` | accepts | accepts | accepts |
+| `p100`, `p999`, `p1234`, `p.5`, `p1.`, `p` | rejects | rejects | rejects |
+| `"p95\n"` | **accepts** | rejects | rejects |
+
+`re.match` would leave the gate admitting one shape the row and the schema reject — a strictly
+smaller instance of #73, installed by the commit that closes it.
+
+**Decision**: `re.fullmatch(PERCENTILE, a) is not None`, with `PERCENTILE` holding the row's
+pattern **character-for-character including its `^` and `$`**. The anchors are redundant under
+`fullmatch` and are kept anyway: the value of this constant is that a reader can hold it beside
+the row and beside `$defs/aggregation` and see three identical strings. Stripping the anchors to
+tidy it would make the three no longer comparable by eye, which is the whole mechanism.
+
+**Alternatives rejected**: `re.match` with the pattern (above). `re.fullmatch` with the anchors
+stripped — same behaviour, loses the by-eye comparison. Reading the pattern out of the schema at
+runtime — `README.md` § *How these tables are applied* states this section "never reads the
+schema", and the gate says so in a comment above its own heredoc.
+
+**Consequence**: `import re` is added to the Gatling heredoc, which today imports only
+`glob`, `sys`, `Fraction`, `identity` and `yaml`.
+
+---
+
+## R2 — The arithmetic rule can be stated without obliging anyone to keep the source text
+
+**Question**: FR-008 says exact decimal arithmetic on the value `threshold` denotes. A renderer
+that parsed into a double has lost the decimal. Is the rule implementable, or does it oblige a
+renderer to read raw document text — which FR-010 forbids?
+
+**Finding**: implementable, and the escape is a guarantee rather than a convention. Converting the
+double back to its **shortest round-tripping decimal** and computing exactly from there recovers
+the literal's value for any literal of at most fifteen significant digits.
+
+Spot-checked over 20 000 random 15-significant-digit literals with exponents in `1e-6 … 1e3`:
+`Fraction(str(float(lit))) != Fraction(lit)` in **0** cases. And on the values the rule is about:
+
+| literal | parsed | shortest decimal | exact value recovered |
+|---|---|---|---|
+| `1.001` | `1.001` | `1.001` | `1001/1000` — yes |
+| `1.0010` | `1.001` | `1.001` | same value — yes |
+| `0.5` | `0.5` | `0.5` | `1/2` — yes |
+| `1.23456789012345` | — | same | yes |
+
+**Decision**: state the rule as *exact decimal arithmetic on the value the threshold denotes*, and
+add one sentence naming the recovery route and the precision it holds to. The gate's
+`Fraction(str(p["threshold"]))` **is** that route; FR-013's comment says so.
+
+**Alternatives rejected**: "on the literal as written" — obliges a renderer to retain source text,
+which JSON and YAML parsers discard (FR-010). Naming shortest-round-trip as *the* rule rather than
+as a conformance route — Java's `Double.toString` did not always produce the shortest decimal
+before JDK 19, so a Scala renderer's answer would depend on its JDK; the rule is about the value,
+and the route is one way to reach it.
+
+**Checked and not a problem**: `yaml.safe_load("5e2")` returns the **string** `'5e2'`, because
+YAML 1.1 requires a `.` before an exponent. Such a document is rejected by the schema's
+`"type": "number"` before any of this applies, in a different section of the same gate. Noted so
+the next reader does not rediscover it as a defect of this rule.
+
+---
+
+## R3 — Every DSL entry point's target type, re-read here
+
+**Question**: #59's closing section reports the `Int` is the builder's, not the target's. True at
+the versions this repository names, and what are the other four?
+
+**Finding**: true, and one published cell is wrong. Read **2026-09-01** from the local Coursier
+cache — `gatling-core` and `gatling-core-java` **3.13.5**, `gatling-shared-model_2.13` **0.0.11**,
+the release Gatling 3.13.5 pins.
+
+`AssertionBuilders.scala`, read from the sources jar:
+
+| entry point | returns |
+|---|---|
+| `AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` | `AssertionWithPathAndTarget[Int]` |
+| `AssertionWithPathAndCountMetric.count` | `AssertionWithPathAndTarget[`**`Long`**`]` |
+| `AssertionWithPathAndCountMetric.percent` | `AssertionWithPathAndTarget[Double]` |
+| `AssertionWithPath.requestsPerSec` | `AssertionWithPathAndTarget[Double]` |
+
+And the type is consumed at the boundary — `AssertionWithPathAndTarget[T: Numeric]`:
+
+```scala
+def lt(threshold: T): Assertion = next(Condition.Lt(numeric.toDouble(threshold)))
+```
+
+`javap` on the model confirms the other side: `Condition$Lt.value()` and `Condition$Lte.value()`
+are `public double`, and `Condition$Between` carries two. `javap` on
+`io.gatling.javaapi.core.Assertion$WithPathAndTimeMetric` shows the Java DSL is Int-typed too —
+`max()` returns `WithPathAndTarget<Integer>`, where `T extends Number`.
+
+**Decision**: the `Int` is the type of the two DSL entry points, both of them, and the count cell
+must read `Long` (FR-017d). The whole-number rule stops being conditioned on the word `Int`
+(FR-017e) — otherwise correcting the cell drops counts out of the rule.
+
+**Alternatives rejected**: relaxing the rule for a renderer that emits the model directly — makes
+reach a property of how a renderer is built; argued in [spec.md](spec.md) § *Decisions*. Carrying
+#59's reading with attribution instead of re-reading — the jars are here, and Principle IV prefers
+a dated read.
+
+---
+
+## R4 — The four factors, exactly
+
+**Question**: what does `TIME` become, and does any conversion need rounding?
+
+**Finding**: none does. Every factor is exact in `Fraction`:
+
+```python
+TIME = {"ns": Fraction(1, 1000000), "us": Fraction(1, 1000), "ms": Fraction(1),
+        "s":  Fraction(1000),       "min": Fraction(60000),  "h":  Fraction(3600000)}
+```
+
+Simulated against the corrected `predicate_why`:
+
+| predicate | converted | verdict |
+|---|---|---|
+| `2000000 ns` | 2 ms | renders |
+| `1500000 us` | 1500 ms | renders |
+| `2 min` | 120000 ms | renders |
+| `1 h` | 3600000 ms | renders |
+| `1500 ns` | 3/2000 ms | `threshold 1500 ns is 3/2000 for responseTime.percentile, whose target is an integer` |
+| `1 us` | 1/1000 ms | same form |
+
+**Decision**: the four factors go in `TIME`, which both duration statistics already share, so
+`groupCumulatedResponseTime.*` gains them without a second table.
+
+---
+
+## R5 — Every new refusal comes from an existing code path
+
+**Question**: do the new probes need new messages? FR-003 forbids a message written specially for
+out-of-range percentiles.
+
+**Finding**: no new message is needed anywhere. Simulated:
+
+| probe | message, from which existing path |
+|---|---|
+| `aggregation: p999` | `aggregation p999 over a metric has no equivalent` — the row lookup, because `percentile()` now returns false and the key falls through |
+| `aggregation: p100` | same form |
+| `threshold: 1500, unit: ns` | the whole-number branch |
+| `aggregation: count, threshold: 20.5, unit: {request}` | the whole-number branch — `threshold 20.5 {request} is 41/2 for allRequests.count, whose target is an integer` |
+
+The last line is worth stating plainly: the gate's existing wording — *"whose target is an
+integer"* — stays true and correct under `Long`. The gate reasoned over an `integral` flag and
+never over the word `Int`, so **the gate was right and only the page was wrong**. FR-017e makes
+the page say what the gate already does.
+
+**Decision**: no message changes. FR-003, FR-015 and FR-024 are satisfied by touching no strings.
+
+---
+
+## R6 — Which probes, and what the floors become
+
+**Question**: the floors are exact and adding a probe means raising the number beside it. Which
+probes, and to what?
+
+**Finding**: nine probes, each the sole catcher of one regression — the standard the section's own
+comment sets.
+
+| # | probe | direction | sole catcher of |
+|---|---|---|---|
+| 1 | `aggregation: p999` | rejection | the pattern's `\d{1,2}` widening, or the old `isdigit()` helper returning |
+| 2 | `aggregation: p.5` | rejection | the integer part being made optional |
+| 3 | `aggregation: "p95\n"` | rejection | `re.fullmatch` becoming `re.match` (R1) |
+| 4 | `threshold: 1.001, unit: s` | rendering | the exact arithmetic becoming a double multiplication |
+| 5 | `aggregation: count, threshold: 20.5` | rejection | `allRequests.count`'s integral flag being flipped |
+| 5b | the same with `bad: {error.type: "*"}` | rejection | `failedRequests.count`'s integral flag being flipped |
+| 5c | `threshold: ExactFloat("1.0000000000000001"), unit: s` | rejection | the literal being read off the double again |
+| 5d | `threshold: 1e19, unit: {request}` | rejection | the `Long` bound being dropped |
+| 5e | `threshold: 2147483647, unit: ms` | rendering | the `Int` bound going off by one |
+| 5f | `threshold: 597, unit: h` | rejection | the range being checked before the conversion rather than after |
+| 6–9 | `2000000 ns`, `1500000 us`, `2 min`, `1 h` | rendering | each of the four new factors being deleted |
+| 10 | `threshold: 1500, unit: ns` | rejection | the whole-number rule stopping at `ms`/`s` |
+
+Floors, per commit — each is exact, and each commit is green on its own:
+
+| after | predicate rejection | predicate rendering |
+|---|---|---|
+| today | 13 | 16 |
+| #73 | **16** | 16 |
+| #59 | **20** | **18** |
+| #74 | **22** | **22** |
+
+**Decision**: fifteen probes, floors raised in the commit that adds them.
+
+**Corrected twice.** First during implementation, then by code review; both corrections are in
+the direction of a rule this milestone claimed and did not check.
+
+Review added four. The whole-number rule is a **range** and not only a divisibility — a converted
+threshold can be whole and still be one no target holds, and `h`/`min` make that ordinary to write
+(`597 h` is 2 149 200 000 ms against an `Int` that stops at 2 147 483 647). And the arithmetic
+`README.md` now states is about the value the literal denotes, which `Fraction(str(float))` cannot
+recover past fifteen significant digits: `1.0000000000000001 s` arrived as `1.0` and rendered as a
+whole 1000 ms, which is the rule refusing a document the gate blessed. Probes 5c–5f close both, and
+`LOADER`'s own check closes the wiring no probe can reach.
+
+**Corrected during implementation.** This table said ten, with one probe for "either count row".
+The two count rows live in **different shapes** — `allRequests.count` under `requests`,
+`failedRequests.count` under `fraction` — so one probe reaches one row and leaves the other exactly
+as unguarded as it was. T025's revert set caught it: `failedRequests.count`'s flag flipped green
+with the single probe in place. Probe 5b is the fix, and the rejection floors move to 18 and 19.
+
+**Alternative rejected**: one probe for #73 instead of three. FR-002 asks for "at least one", and
+one would leave two distinct regressions — a widened integer part and a swapped match call — each
+one edit away from passing green.
+
+---
+
+## R7 — The unreachable row is still derived
+
+**Question**: FR-021 requires the last row stay the enumeration minus what a statistic reaches.
+Does the arithmetic still work after four units move?
+
+**Finding**: yes. Seventeen units in `$defs/unit`. Reached after this milestone:
+
+| statistic | units |
+|---|---|
+| `responseTime.*`, `groupCumulatedResponseTime.*` | `ns` `us` `ms` `s` `min` `h` |
+| `failedRequests.percent` | `%` `1` |
+| `allRequests.count`, `failedRequests.count` | `{request}` |
+| `requestsPerSec` | `{request}/s` |
+
+Ten distinct. 17 − 10 = **7**: `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}`
+— exactly FR-020's list, and the existing reason holds for all seven (no statistic carries bytes;
+nothing counts iterations or virtual users).
+
+---
+
+## R8 — `examples/` needs no change, and that is checkable rather than assumed
+
+**Question**: FR-026 and SC-011 require the corpus byte-identical. Is any published predicate
+affected?
+
+**Finding**: no. Enumerated from the four documents rather than assumed — the corpus is ten
+predicates, and across all of them:
+
+| axis | every value the corpus uses |
+|---|---|
+| `aggregation` | `p50`, `p95`, `p99`, `max`, `count`, `rate` |
+| `unit` | `ms`, `s`, `%`, `{request}`, `{request}/s` |
+| `threshold` | `3`, `5`, `20`, `200`, `500`, `1000` |
+
+No out-of-range percentile, so #73 refuses nothing published. Every threshold is a whole number
+written in a whole unit, so the two arithmetics agree on all six and #59 changes no verdict. No
+duration unit outside `ms` and `s`, so #74 admits something no document yet says. Every change in
+this milestone either refuses something no document says, or admits something no document says.
+
+**Decision**: `examples/` is untouched, and quickstart step 1 checks it with `git diff --stat`
+rather than by reading.

--- a/specs/013-numbers-a-predicate-carries/spec.md
+++ b/specs/013-numbers-a-predicate-carries/spec.md
@@ -1,0 +1,311 @@
+# Feature Specification: Which Numbers a Predicate May Carry
+
+**Feature Branch**: `013-numbers-a-predicate-carries`
+
+**Created**: 2026-09-01
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/opennfr/milestone/11" — milestone **v0.9.0**, three open issues: #73, #59 and #74, in that order. A fourth, #94, was in this milestone and landed on `main` at `906f8d2` before this specification was written; it is not in scope here.
+
+**Scope note**: One question runs through all three: *which numbers may a predicate carry, and which artifact decides?* Three axes answer it today and they answer differently. The gate calls `p100` and `p999` assertable where the row and the schema reject both (#73). The whole-number threshold rule is stated without an arithmetic model, so two conforming renderers disagree about `1.001 s` (#59). And the Units table calls `ns`, `us`, `min` and `h` unreachable in a row that groups them with seven units that genuinely are (#74). A renderer written from one artifact refuses what a renderer written from another accepts.
+
+Nothing here is about a report, a verdict, or anything a consumer displays. A renderer turns a requirement document into a target's assertions, and this milestone stays inside that.
+
+**No term is added and no term is renamed**, so Principle I asks nothing of this milestone beyond leaving `GLOSSARY.md` alone. `examples/` does not change: every published document is already renderable under every answer below, and stays so. Two files change: `README.md` and `scripts/verify.sh`. The schema does not, and *Decisions* records the two independent reasons it does not.
+
+**The format is not narrowed and not widened by #73 and #59.** `p999` is already schema-invalid; `1.001 s` is already schema-valid. Both issues are about artifacts disagreeing over documents whose validity is already settled. #74 alone changes which schema-valid documents may be published: four units move from **cannot** to **can**.
+
+#73 comes first because it is the cheapest and touches one line of rule. #59 comes next because it decides how a conversion is computed before more conversions exist. #74 comes last because it adds the conversions that decision governs.
+
+## Decisions
+
+### Session 2026-09-01
+
+- **Q**: #59 offers two closes — state the arithmetic model in the contract, or bound `threshold`'s precision in the schema. Which? → **A**: **State the model; the schema does not change.** Two independent reasons, and either alone would settle it. `GLOSSARY.md` § *aggregation* already rejected narrowing the schema to a target's reach, in those words, when #57 proposed it for `count` and `rate`; a precision bound on `threshold` exists only because one target's target type is an `Int`, which is the same move. And the bound does not work: `multipleOf: 0.001` **rejects** `1.001`, `1.003` and `1.005` under `jsonschema` 4.26.0, because `multipleOf` is itself evaluated in binary floating point. The schema option reproduces the exact defect it was proposed to fix, one layer down.
+
+- **Q**: "Exact decimal arithmetic on the literal **as written**" would oblige a renderer to read raw document text, which JSON and YAML parsers discard. Is that the rule? → **A**: **No — the rule is about the value the literal denotes, not the characters.** A renderer must compute with the decimal value `threshold` denotes rather than with the binary double nearest to it. A renderer that has already parsed into a double conforms by recovering the shortest decimal that round-trips that double and computing exactly from there, which is exactly the literal's value for any literal of at most fifteen significant digits — the classic round-trip guarantee, and far more precision than a threshold carries. This is what makes the gate's `Fraction(str(...))` correct rather than accidental, and it is statable in one sentence without obliging anyone to keep the source text.
+
+- **Q**: #73 says the helper becomes the row's pattern. Where does the pattern then live — one copy read from the schema at runtime, or a literal in the gate that the row names? → **A**: **A literal in the gate, with the row named as its source, plus the rejection probe.** The milestone says so, and the alternative contradicts a published property: `README.md` § *How these tables are applied* states that the gate "enforces the restriction on `examples/` and never reads the schema". The residual — the schema could widen and leave both the row and the gate stale — is recorded under *Out of Scope* rather than solved here.
+
+- **Q**: #59's closing section is confirmed — the `Int` is the DSL builders' type parameter, consumed by `numeric.toDouble` at the boundary, and the `Assertion` a renderer may construct itself carries a `double`. What does § *Units* do about it? → **A**: **Narrow the attribution; change no rule.** The table stops calling the `Int` a property of the target and says it is the type of the two DSL entry points that reach it, sourced to the re-read. The whole-number rule bites exactly as it does today. The alternative — saying the rule binds a DSL renderer and not a model-emitting one — would make **reach depend on how a renderer is built** rather than on what Gatling can assert, and these tables are about the target. That is a change to what the section is, not to what it says.
+
+- **Q**: #74 says "splitting the row in two", which would give the four durations a row of their own. Is that the shape? → **A**: **No — the two duration statistics' `Accepts` cells grow, and the unreachable row shrinks.** § *Units* opens by stating that units are per statistic, and a statistic appearing in two rows contradicts the sentence the table is organised around. The effect is the one #74 asks for — four units move, seven stay — and the unreachable row stays derived, which the issue's shape would also have preserved but at the cost of the table's own invariant.
+
+- **Q**: The re-read also showed § *Units* calls the count target an `Int` where the DSL says `Long`. No issue mentions it. Own issue, or here? → **A**: **Here, inside #59, on the maintainer's call — and it turns out not to be separate work at all.** FR-017 restates what the `Target` column *means*; the count cell is wrong under the new meaning as much as the old, so a correct FR-017 cannot leave it. Beyond the cell, the whole-number rule is written as "where the target is an `Int`", so correcting the cell alone would silently exempt counts from the rule — and nothing probes the count rows' integrality, so neither today's error nor that regression is visible to the gate. One cell, one rule and one probe, all downstream of the sentence #59 asks us to write. AGENTS.md's "does not ride along" governs work that is *not* one of the milestone's issues; this is what doing one of them correctly entails.
+
+## What the milestone counts, and what is actually true
+
+Read at `906f8d2`. Every number below was reproduced rather than quoted.
+
+### #73 — the helper admits five shapes the row rejects, not four
+
+`scripts/verify.sh:634` is `def percentile(a): return a.startswith("p") and a[1:].replace(".", "", 1).isdigit()`. Against the row's `^p\d{1,2}(\.\d+)?$`:
+
+| aggregation | helper | row and schema |
+|---|---|---|
+| `p95`, `p99.9`, `p1`, `p10`, `p0.1`, `p99.99` | accepts | accepts |
+| `p100` | **accepts** | rejects |
+| `p999` | **accepts** | rejects |
+| `p1234` | **accepts** | rejects |
+| `p.5` | **accepts** | rejects |
+| `p1.` | **accepts** | rejects |
+| `p` | rejects | rejects |
+
+The issue names four. `p1.` is a fifth: `"1.".replace(".", "", 1)` is `"1"`, and `"1".isdigit()` is true. It is listed because a fix written to the issue's four could still admit it, and because it is the one a careless anchor-less pattern would also miss.
+
+### #59 — the two arithmetics, and the escape that does not work
+
+| document | exact decimal | IEEE-754 double |
+|---|---|---|
+| `threshold: 1.001, unit: s` | `1001` → renders | `1000.9999999999999` → refused |
+| `threshold: 1.003, unit: s` | `1003` → renders | `1002.9999999999999` → refused |
+| `threshold: 1.005, unit: s` | `1005` → renders | `1004.9999999999999` → refused |
+| `threshold: 0.5, unit: s` | `500` → renders | `500.0` → renders |
+| `threshold: 0.5, unit: ms` | `1/2` → refused | `0.5` → refused |
+
+And the schema escape, tested rather than assumed:
+
+| constraint | `1.001` | `1.003` | `1.005` | `0.5` | `500` |
+|---|---|---|---|---|---|
+| `multipleOf: 0.001`, `jsonschema` 4.26.0, Draft 2020-12 | **rejected** | **rejected** | **rejected** | accepted | accepted |
+
+### #59, closing section — the `Int` target is the builder's, and it was re-read here
+
+#59 reports that the `Int` the whole-number rule rests on is a property of Gatling's builder entry
+point rather than of the assertion it produces. **Re-read locally 2026-09-01** from the Coursier
+cache — `gatling-core` and `gatling-core-java` **3.13.5**, `gatling-shared-model_2.13` **0.0.11**,
+the release 3.13.5 pins — rather than carried, because the jars are present:
+
+| read | says |
+|---|---|
+| `AssertionBuilders.scala`, `gatling-core` 3.13.5 sources | `AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` return `AssertionWithPathAndTarget[Int]` |
+| the same file | `AssertionWithPathAndTarget[T: Numeric].lt/lte/gt/gte/is` call `numeric.toDouble(threshold)` and build `Condition.Lt(Double)` — the `Int` is consumed at the boundary |
+| `javap` on `Condition$Lt`, `Condition$Lte` | `public double value()` |
+| `javap` on `Condition$Between` | `public double lowerBound()`, `public double upperBound()` |
+| `javap` on `Assertion$WithPathAndTimeMetric`, `gatling-core-java` 3.13.5 | `max()` returns `WithPathAndTarget<Integer>` — the Java DSL is Int-typed too |
+
+So the constraint is real for anyone going through either DSL, and absent for anyone constructing
+`Assertion(path, target, Condition.Lt(0.5))` directly, which is what a renderer emitting
+`Iterable[Assertion]` does. The issue's reading holds. What the format does about it is Q1.
+
+The same read turned up something no issue mentions, and it is **not** separable from FR-017.
+Every DSL entry point, read from the same file:
+
+| entry point | target type |
+|---|---|
+| `AssertionWithPathAndTimeMetric.{min,max,mean,stdDev,percentile}` | `Int` |
+| `AssertionWithPathAndCountMetric.count` | **`Long`** |
+| `AssertionWithPathAndCountMetric.percent` | `Double` |
+| `AssertionWithPath.requestsPerSec` | `Double` |
+
+§ *Units* calls the target of `allRequests.count` and `failedRequests.count` an **`Int`**. One cell,
+wrong under the reading it has today and wrong under the reading FR-017 gives it — the column is
+about to be restated as *the type of the DSL entry point*, and for count that type is `Long`.
+Correcting the column and leaving that cell would make FR-017's own new sentence false in the same
+table it is written into.
+
+And the correction cannot be made alone, which is the part that matters. The whole-number rule is
+worded **"Where the target is an `Int`"**. Change the cell to `Long` without touching the rule and
+counts fall out of the rule's scope: `threshold: 20.5, unit: {request}` becomes renderable, and the
+gate — which is right, and reasons over an `integral` flag rather than over the word `Int` —
+would then disagree with the page. So the rule has to stop being about one Scala type and start
+being about the property it was always testing.
+
+Third, nothing probes it. `PREDICATE_PROBES` carries two fractional-threshold probes, `0.1 ms` and
+`0.05` in `1`, and neither reaches a count row. Both count rows carry `integral=True` in the gate's
+table, and flipping either to `False` leaves the gate **green** — a rule nothing checks, which is
+Principle III's own failure class sitting under the paragraph this milestone is rewriting.
+
+### #74 — the four durations, and the rule that still governs them
+
+| written | native (ms), exact | whole? |
+|---|---|---|
+| `2000000 ns` | `2` | yes — renders |
+| `1500000 us` | `1500` | yes — renders |
+| `2 min` | `120000` | yes — renders |
+| `1 h` | `3600000` | yes — renders |
+| `1500 ns` | `3/2000` | no — refused by the whole-number rule, with the right reason |
+| `1 us` | `1/1000` | no — refused by the whole-number rule, with the right reason |
+
+The last two are why this is not an exception to the whole-number rule: the four units need to stop being refused *before* that rule gets to run, and then be refused by it where it applies.
+
+## User Scenarios & Testing *(mandatory)*
+
+The reader throughout is the author of the first OpenNFR renderer, turning a requirement document into a target's assertions. The three stories are three things that reader cannot learn from the repository without getting a different answer depending on which artifact they open.
+
+### User Story 1 - One rule decides what a percentile is (#73, Priority: P1)
+
+A renderer author reads the Aggregations row, sees `^p\d{1,2}(\.\d+)?$`, and reimplements it. They then check their reading against `scripts/verify.sh`, which § *Gatling* calls "the only implementation" of these tables — and find a strictly wider test. On `p999` the gate's reach section reports assertable while its schema section reports the document invalid: two sections of one run give opposite answers about one predicate.
+
+After this story the helper is the row, the row is the helper, and a probe fails the gate if they part again.
+
+**Why this priority**: cheapest of the three, and the only one that leaves the repository actively contradicting itself within a single run. It is also the one that damages the artifact a second implementer checks their reading against.
+
+**Independent Test**: run the row's pattern and the gate's percentile test over `p95`, `p99.9`, `p0.1`, `p99.99`, `p100`, `p999`, `p1234`, `p.5`, `p1.` and `p`. The two agree on all ten. Then delete the fix and the gate goes red rather than quiet.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected gate, **When** a predicate carries `aggregation: p999`, **Then** the reach section refuses it, and the reason is the one the row's own lookup gives — that the aggregation over that shape has no equivalent — not a message written specially for percentiles.
+2. **Given** the corrected gate, **When** a predicate carries `p100`, `p1234`, `p.5` or `p1.`, **Then** each is refused for the same reason.
+3. **Given** the corrected gate, **When** a predicate carries `p95`, `p99.9`, `p1`, `p10`, `p0.1` or `p99.99`, **Then** it renders, and every published document still renders.
+4. **Given** the helper reverted to its `isdigit()` form, **When** the gate runs, **Then** it FAILs and names the probe that caught it.
+5. **Given** a reader at the gate's percentile test, **When** they ask where the pattern came from, **Then** the site names the reach row it implements.
+
+---
+
+### User Story 2 - The conversion has one arithmetic (#59, Priority: P2)
+
+The same author reaches the whole-number rule. It forbids rounding, on the ground that rounding "moves the bar the author wrote". They implement it the obvious way — parse the YAML number, multiply by the factor, test for a whole number — and their renderer refuses `1.001 s`, which the reference gate accepts. Neither is wrong under the published text: `threshold` is a bare number with no stated precision, the conversion is stated as a factor, and "whole number" is stated with no arithmetic model at all. So a rule whose entire purpose is that being wrong here moves the bar silently is itself the place two conforming renderers disagree.
+
+After this story the contract says which arithmetic, says what a renderer that has already parsed into a double must do, and the gate's round-trip is the rule rather than an implementation detail nobody else knows to reproduce.
+
+**Why this priority**: second because #74 adds four conversions, and adding conversions before the arithmetic governing them is settled multiplies the disagreement by four. It is the milestone's only `severity:high` issue.
+
+**Independent Test**: implement the whole-number rule twice from the corrected text alone — once with exact decimal arithmetic, once starting from a parsed double and following the conformance sentence. Both accept `1.001 s`, `1.003 s`, `1.005 s` and `0.5 s`; both refuse `0.5 ms`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected § *Units*, **When** a renderer author asks how a threshold is converted, **Then** the text names exact decimal arithmetic on the value the literal denotes, and says binary floating-point multiplication is not it.
+2. **Given** a renderer that parses `threshold` into a binary double, **When** its author reads the same text, **Then** they can conform without keeping the document's source text, and the text says how.
+3. **Given** the gate, **When** a reader reaches the `Fraction(str(...))` round-trip, **Then** a comment names the rule it implements, so a future edit to a plain float multiplication is visibly a change to the rule.
+4. **Given** the corrected gate, **When** a predicate carries `threshold: 1.001, unit: s`, **Then** it renders — and the probe that says so fails if the arithmetic is changed to a double.
+5. **Given** the corrected gate, **When** a predicate carries `threshold: 0.5, unit: ms`, **Then** it is refused, and the reason still names the value, the statistic and the integer target.
+6. **Given** the schema, **When** a reader looks for a precision constraint on `threshold`, **Then** there is none, and the reason a bound was rejected is on the record.
+7. **Given** the corrected § *Units*, **When** a reader reads the `Target` column, **Then** every cell is the type the corresponding DSL entry point returns — `Long` for the two count rows — and the column says which of the two it is describing.
+8. **Given** the corrected whole-number rule, **When** a predicate carries `aggregation: count, threshold: 20.5, unit: {request}`, **Then** it is refused, exactly as it is refused today, and the rule that refuses it no longer names a Scala type the count rows do not have.
+9. **Given** either count row's integral flag flipped in the gate, **When** the gate runs, **Then** it FAILs — which it does not do today.
+
+---
+
+### User Story 3 - The Units row says only what is true (#74, Priority: P3)
+
+The author now wants a sub-millisecond budget for a fast internal service, and the outer bound of a soak run in hours. Both units are in the format's closed enumeration. The reach section refuses both, in a row that gives one reason for eleven units — and the reason is true of seven. `responseTime.*` is a duration statistic whose native unit is milliseconds; `1500000 us` is exactly 1500 ms and `1 h` is exactly 3600000 ms, by the same arithmetic that already converts `s`.
+
+After this story the four durations are reachable, subject to the whole-number rule that governs every other duration, and the unreachable row holds the seven units for which its reason holds.
+
+**Why this priority**: last because it is the only one of the three that changes which documents may be published, and it is written from #59's answer. Its refusals are wrong rather than merely under-described, but nothing in the corpus depends on them.
+
+**Independent Test**: write the four documents in the table above and the two sub-millisecond ones, and run each through the gate. The first four render, the last two are refused by the whole-number rule and by nothing else.
+
+**Acceptance Scenarios**:
+
+1. **Given** the corrected § *Units*, **When** a reader asks which units a duration statistic accepts, **Then** the answer is the six duration units, for both `responseTime.*` and `groupCumulatedResponseTime.*`.
+2. **Given** the corrected § *Units*, **When** a reader reads the unreachable row, **Then** it holds exactly the seven units no statistic reaches, and its reason is true of all seven.
+3. **Given** the corrected § *Units*, **When** a reader checks the unreachable row against the enumeration in § *Units* above, **Then** it is still the enumeration minus every unit a statistic reaches — the row is still derived, and adding a unit to the format is still one decision and not two.
+4. **Given** the corrected gate, **When** a predicate carries `1500000 us`, `2 min`, `1 h` or `2000000 ns` on a duration statistic, **Then** it renders.
+5. **Given** the corrected gate, **When** a predicate carries `1500 ns` or `1 us`, **Then** it is refused because the converted value is not whole, and the message names the converted value and the statistic — not "not a unit of".
+6. **Given** any one of the four new factors deleted, **When** the gate runs, **Then** it FAILs, because each has a rendering probe of its own.
+
+### Edge Cases
+
+- **A percentile the pattern admits but no target computes.** `p0.1` and `p99.99` are inside the row and inside the schema. Nothing changes for them: they render, as they do today.
+- **`p100`.** Refused, and § *Aggregations* already says why it needs no row of its own — the quantity it names is `max`. This milestone does not add one.
+- **A threshold with more than fifteen significant digits.** Outside the round-trip guarantee the conformance sentence rests on. No threshold carries one, and the rule is stated about the value the literal denotes, so such a literal is governed by the same rule; only the double-parsing recovery route stops being guaranteed. Recorded, not legislated.
+- **`threshold` in scientific notation.** `5e2` denotes 500 and converts like `500`. The rule is about the value, not the spelling, so no case is added.
+- **Non-finite thresholds.** Already refused before this section is reached: the gate rejects YAML that cannot map onto JSON, non-finite numbers included.
+- **A new duration unit added to the format later.** The unreachable row stays derived, so whether it appears there follows from whether a statistic reaches it, and the gate's factor table is where that is said.
+- **A count threshold above what an `Int` holds.** `Long` admits it and `Int` does not, but nothing in the format, the gate or the assertion model bounds a threshold's magnitude — and the model carries a `double` regardless. So the cell's correction changes which type is named and nothing else; no magnitude rule is added, and none is implied.
+- **A unit reachable for one statistic and not another.** Unchanged and still load-bearing: `%` is a unit of `failedRequests.percent` and not of `responseTime.percentile`, and the probe that says so stays.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**#73 — the percentile test is the row**
+
+- **FR-001**: The gate's percentile test MUST admit exactly the aggregations `^p\d{1,2}(\.\d+)?$` admits, and no others.
+- **FR-002**: The gate MUST carry at least one rejection probe for an aggregation the previous helper admitted and the row rejects, asserting the reason the gate gives.
+- **FR-003**: That reason MUST be produced by the existing aggregation-row lookup — the message that names the aggregation and the shape — and MUST NOT be a message written specially for out-of-range percentiles. A second message would be a second rule.
+- **FR-004**: The site carrying the pattern MUST name the reach row it implements, so a reader can see the two are one rule and not two that happen to agree.
+- **FR-005**: `p95`, `p99.9`, `p1`, `p10`, `p0.1` and `p99.99` MUST continue to render, and the existing `p99.9` rendering probe MUST survive.
+- **FR-006**: The predicate rejection floor MUST rise by the number of probes added, so a later deletion of one is a red gate rather than a quiet one.
+
+**#59 — the conversion has an arithmetic model**
+
+- **FR-007**: `README.md` § *Units* (under § *Gatling*) MUST state the arithmetic by which a threshold is converted to a statistic's native unit, adjacent to the whole-number rule it governs.
+- **FR-008**: That statement MUST be exact decimal arithmetic on the value `threshold` denotes, and MUST say that binary floating-point multiplication is not it.
+- **FR-009**: It MUST tell a renderer that has already parsed `threshold` into a binary double how to conform without retaining the document's source text, and MUST state the precision bound that route rests on.
+- **FR-010**: The statement MUST NOT oblige a renderer to read raw document text, because JSON and YAML parsers discard it and the format may not require a parser nobody has.
+- **FR-011**: `schema/opennfr.io/v1/requirementset.schema.json` MUST NOT gain a precision constraint on `threshold`.
+- **FR-012**: The reason a schema bound was rejected MUST be recorded where a future contributor proposing one will meet it, and MUST name both grounds: that it narrows the schema to one target's reach, and that `multipleOf` is itself evaluated in binary floating point and rejects the very values it was proposed to admit.
+- **FR-013**: The gate's exact-arithmetic round-trip MUST carry a comment naming the rule it implements, so replacing it with a float multiplication reads as a change to the rule.
+- **FR-014**: The gate MUST carry a rendering probe for a threshold on which exact and double arithmetic disagree — `1.001 s` — so the rule's whole subject is exercised rather than assumed.
+- **FR-015**: The existing rejection probe for `0.1 ms` and its message MUST survive unchanged in meaning: a fractional native value is still unrenderable and still not rounded.
+- **FR-016**: The predicate rendering floor MUST rise by the number of rendering probes added.
+- **FR-017**: § *Units* MUST stop attributing the integer constraint to the statistic's target, and MUST say instead that it is the type of the two DSL entry points that reach that statistic.
+- **FR-017a**: That statement MUST name what was read and carry the versions and the date — `gatling-core` and `gatling-core-java` 3.13.5, `gatling-shared-model_2.13` 0.0.11, 2026-09-01 — as § *Gatling*'s other sourced claims do.
+- **FR-017b**: It MUST record that a renderer constructing the assertion model itself does not pass through those entry points, and MUST NOT thereby relax the rule: the whole-number rule binds every renderer after this milestone exactly as it binds them before it, and no document changes renderability on account of FR-017.
+- **FR-017c**: The reason the rule was not relaxed MUST be on the record — that reach is a property of the target and not of how a renderer is built — so the next reader of this paragraph meets the argument rather than reopening it.
+- **FR-017d**: The `Target` cell for `allRequests.count` and `failedRequests.count` MUST read `Long`, which is what `AssertionWithPathAndCountMetric.count` returns. Every other cell in that column MUST be checked against the same read and left correct: `Int` for the two duration statistics, `Double` for `failedRequests.percent` and `requestsPerSec`.
+- **FR-017e**: The whole-number rule MUST stop being conditioned on the word `Int` and MUST be conditioned on the target being integral, so that it governs the count rows exactly as it governs the duration rows. No document may change renderability because of FR-017d: a fractional count threshold is unrenderable before this milestone and unrenderable after it.
+- **FR-017f**: The gate MUST carry a rejection probe for a fractional threshold on a count row, and the predicate rejection floor MUST rise for it. Today both count rows carry an integral flag that no probe reaches, so either could be flipped and the gate would stay green.
+
+**#74 — the Units row says what is true**
+
+- **FR-018**: `ns`, `us`, `min` and `h` MUST be reachable through `responseTime.*` and `groupCumulatedResponseTime.*`, subject to the whole-number rule and to nothing else.
+- **FR-019**: The gate's duration factor table MUST carry all six duration units with exact factors, so no conversion is approximate at the point it is computed.
+- **FR-020**: The unreachable Units row MUST hold exactly `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s` and `{vu}`, and its stated reason MUST be true of all seven.
+- **FR-021**: The unreachable row MUST remain derived — the enumeration in § *Units* minus every unit a statistic reaches — so adding a unit to the format stays one decision.
+- **FR-022**: The `Accepts` cells of the `responseTime.*` and `groupCumulatedResponseTime.*` rows MUST become the six duration units, and the table MUST keep exactly one row per statistic. A separate row for the four newly reachable durations MUST NOT be added: § *Units* opens by stating that units are per statistic, and a statistic in two rows contradicts the sentence the table is organised around.
+- **FR-023**: Each of the four newly reachable units MUST have a rendering probe of its own, so deleting any one factor fails the gate.
+- **FR-024**: The gate MUST carry a rejection probe for a sub-millisecond value written in a newly reachable unit, and its reason MUST be the whole-number rule's — naming the converted value, the statistic and its integer target — and not "not a unit of".
+- **FR-025**: The predicate rendering and rejection floors MUST rise by the number of probes added.
+
+**Across all three**
+
+- **FR-026**: `examples/` MUST NOT change. Every published document renders before and after.
+- **FR-027**: No term is added, renamed or redefined, so `GLOSSARY.md` MUST NOT gain or lose an entry. Where a decision above bears on an existing entry, it is recorded at the entry's own *Rejected* line rather than as a new term.
+- **FR-028**: Each of the three issues MUST land as one semantic commit carrying its own `Closes` link, in the order #73, #59, #74, behind the spec commit.
+- **FR-029**: `bash scripts/verify.sh` MUST pass after each of the three commits, not only after the last.
+
+### Key Entities
+
+- **The percentile test**: the gate's decision that an aggregation is a percentile. One rule, currently stated twice — as a pattern in the row and the schema, and as a string test in the gate — and the two disagree.
+- **The conversion**: threshold and unit reduced to a statistic's native unit. It has a factor, a result, and — until this milestone — no stated arithmetic.
+- **The whole-number rule**: the constraint that a converted value against an integer target must be whole. Depends entirely on the conversion's arithmetic, which is why #59 precedes #74.
+- **The Units reach table**: one row per statistic, plus one derived row for what nothing reaches. Its last row currently gives one reason for two different facts.
+- **A probe**: a predicate the contract says renders, or says does not, paired with the reason. The gate's only means of showing that a rule still fires — the corpus cannot, because it holds only documents that render.
+- **A floor**: the exact probe count each class must meet. Adding a probe means raising it, which is the intended cost of a new rule.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader can determine which aggregations are percentiles from any one of the schema, the reach row or the gate, and the three answers are identical across all ten aggregations in the divergence table above.
+- **SC-002**: No single run of `scripts/verify.sh` reports one predicate as both assertable and invalid.
+- **SC-003**: Two people implementing the whole-number rule from the corrected text alone — one with exact decimal arithmetic, one from a parsed double — accept and refuse the same documents, on all five rows of the arithmetic table above.
+- **SC-004**: The corrected text answers "how is the conversion computed?" without the reader consulting `scripts/verify.sh`, and without them needing the document's source text.
+- **SC-005**: Every unit in the format's closed enumeration is either reached by a named statistic or listed in the unreachable row with a reason true of it — seventeen units, no unit in both places and none in neither.
+- **SC-006**: The four documents in the #74 table are publishable, and the two sub-millisecond ones are refused with the whole-number rule's reason.
+- **SC-007**: Reverting any single rule this milestone changes — the percentile pattern, any one duration factor, or the exact arithmetic — turns the gate red, and the failure names the probe that caught it.
+- **SC-008**: A contributor proposing a precision bound on `threshold` meets the recorded reason it was rejected before they change the schema.
+- **SC-009**: Every cell of § *Units*' `Target` column matches what the correspondingly named DSL entry point returns, at the version the section is dated to — five rows, five types, checkable by one reader with one file open.
+- **SC-010**: Flipping either count row's integral flag turns the gate red. It does not today.
+- **SC-011**: `examples/` is byte-identical before and after the milestone.
+
+## Assumptions
+
+- **The milestone's order is the order.** #73, then #59, then #74, as the milestone states and for the reason it gives: #74 adds conversions that #59's answer governs.
+- **The arithmetic model is stated, not enforced by the schema.** Settled on two independent grounds, both recorded in *Decisions*: narrowing the schema to a target's reach is already rejected in `GLOSSARY.md` § *aggregation*, and `multipleOf` reproduces the defect it would be added to fix.
+- **Gatling's assertion types were re-read for this milestone, not carried.** The jars are in the local Coursier cache, so #59's closing claim was checked here on 2026-09-01 at `gatling-core` / `gatling-core-java` 3.13.5 and `gatling-shared-model_2.13` 0.0.11, and any text this milestone writes about them carries that version and that date. This is what Principle IV asks; carrying the issue's reading would have been the fallback, not the plan.
+- **`http.client.request.duration` stays retired.** It is absent from the gate's addressable metrics and refused by the row that names it, and nothing here revisits that.
+- **The reach section continues not to read the schema.** Recorded in *Decisions* Q3; it is why the percentile pattern is a literal in the gate rather than one read from the schema at runtime.
+- **`p100` gains no row.** § *Aggregations* already explains why, and this milestone makes the gate agree with that explanation rather than changing it.
+- **The gate's `str()` round-trip is retained, not replaced.** It already implements the rule FR-008 states; what it lacks is the sentence saying so.
+
+## Dependencies
+
+- **`README.md` § *Units* (under § *Gatling*)** — the reach table and the whole-number rule; changed by #59 and #74.
+- **`README.md` § *Aggregations*** — the percentile row whose pattern #73 makes the gate agree with; read, not changed.
+- **`scripts/verify.sh` § *Examples are assertable by Gatling*** — the only implementation of both tables; changed by all three.
+- **`schema/opennfr.io/v1/requirementset.schema.json`** — `$defs/aggregation`'s pattern and `threshold`'s type; read by #73 and #59, changed by neither under the recommended answer to Q1.
+- **`GLOSSARY.md` § *aggregation* and § *threshold and unit*** — carry the rejections #59's answer rests on; read, and extended only if FR-027's second sentence applies.
+
+## Out of Scope
+
+- **The schema, the row and the gate could still drift as a group.** If `$defs/aggregation`'s pattern widened, the reach row quoting it and the gate implementing it would both be stale, and the probe added by #73 would not notice. Solving that means the gate checking the row's text against the schema's pattern, which crosses the line § *How these tables are applied* draws. Recorded here so it is a known gap rather than an assumed one; it needs its own issue.
+- **`p100` as a row, or as an alias for `max`.** An alias is forbidden outright by Principle II, and the row is already argued against in § *Aggregations*.
+- **Widening the format's unit enumeration.** All seventeen units are already in the schema. #74 is about which of them a table calls reachable.
+- **Anything a renderer would do with a refused document.** The format says a predicate has no equivalent; what a consumer reports is not in this repository's scope.
+- **#94.** In this milestone, already on `main` at `906f8d2`, and not revisited.

--- a/specs/013-numbers-a-predicate-carries/tasks.md
+++ b/specs/013-numbers-a-predicate-carries/tasks.md
@@ -1,0 +1,265 @@
+---
+
+description: "Tasks for 013-numbers-a-predicate-carries"
+---
+
+# Tasks: Which Numbers a Predicate May Carry
+
+**Input**: Design documents from `specs/013-numbers-a-predicate-carries/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: no separate test tasks. All three issues *add checks* — fifteen probes and four raised
+floors — and those are the deliverables, not tests of them. What validates the feature is the
+revert set in [quickstart.md](quickstart.md) § 9: six edits, each of which must redden the gate,
+and **one of which is green today**. Those appear below as **T013**, **T025** and **T033**, inside
+the commits that make them fail.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel — different file, no dependency on an unfinished task
+- **[Story]**: which user story the task serves (US1–US3)
+- Every task names the file it touches, and most name the line
+
+**`[P]` is rare here, and that is not an oversight.** The milestone edits three files, and the two
+prose regions US2 and US3 touch are the same table. Marking work parallel that shares a table is
+how a rebase conflict gets planned in.
+
+## Path Conventions
+
+No source tree. Three files outside `specs/`, and line numbers below are as of `906f8d2`:
+
+```text
+scripts/verify.sh          # :573  the Gatling heredoc's imports
+                           # :630  TIME
+                           # :634  def percentile
+                           # :744  value = Fraction(str(...)) * factor
+                           # :865  RENDERABLE
+                           # :866-904  PREDICATE_PROBES
+                           # :920-937  PREDICATE_RENDERS
+                           # :971  FLOORS
+README.md                  # :697  § Aggregations, the percentile row      -- READ, not written
+                           # :713  the reasoning under it                  -- READ, not written
+                           # :752-773 § Units: the table, the derived-row
+                           #       sentence, the whole-number rule
+GLOSSARY.md                # § threshold and unit -- one sentence joins the existing
+                           #       *Rejected* line (T021). No line number: the entry moves,
+                           #       the heading does not
+schema/…/requirementset.schema.json  # $defs/aggregation.pattern           -- READ, not written
+```
+
+**Line numbers move.** T017–T020 rewrite `README.md:752-773` and T027–T029 edit the same table
+again; T008–T009, T022–T023 and T030–T032 edit `scripts/verify.sh` in five places. Locate by the
+quoted text in the contracts, never by the number alone.
+
+---
+
+## Phases are commits
+
+Three repository rules shape this list:
+
+- **1 issue = 1 commit**, each green on `bash scripts/verify.sh` on its own. Three issues, three
+  issue commits, and a phase is a commit.
+- **The milestone's order**: #73, then #59, then #74. #74 adds four conversions that #59's sentence
+  governs, so adding them first would multiply the ambiguity by four.
+- **Spec first.** `specs/013-*/` lands as its own commit before any `fix`, never folded in.
+
+The asymmetry worth naming: **#73 changes no prose and #74 changes no rule.** #73 makes the gate
+agree with a row that is already correct; #74 corrects a row while the rule that governs it stays
+exactly as #59 left it. Only #59 changes both, which is why it sits in the middle.
+
+---
+
+## Phase 1: Setup (baselines)
+
+**Purpose**: write down the before-state. Three of the quickstart's checks are comparisons, and one
+of them — that either count row's integral flag can be flipped green — stops being reproducible the
+moment Phase 4 lands. Record it while it is still true.
+
+- [X] T001 [P] Record the helper/row divergence: run [quickstart.md](quickstart.md) § 4's script against **the current helper** by pasting `def percentile(a): return a.startswith("p") and a[1:].replace(".", "", 1).isdigit()` in place of the `re.fullmatch` line, and keep the output. Expect `p100`, `p999`, `p1234`, `p.5`, `p1.` **and** `p95\n` reported as renders. This is #73's central claim and the baseline for [quickstart.md](quickstart.md) § 4.
+- [X] T002 [P] Record that the count rows' integral flag is unenforced: in `scripts/verify.sh:655` change `("allRequests.count", COUNT, True)` to `... False)`, run `bash scripts/verify.sh`, confirm **PASS**; revert with `git checkout -- scripts/verify.sh`; repeat for `failedRequests.count` at `:652`. Keep both outputs. **This is the one baseline that cannot be reconstructed after T023**, and it is FR-017f's whole justification.
+- [X] T003 [P] Record what the four duration units do today: run the corrected-gate simulation from [research.md](research.md) R4 against the **current** `TIME` at `scripts/verify.sh:630` (`{"ms": 1, "s": 1000}`) for `1500000 us`, `2 min`, `1 h`, `2000000 ns`. Expect four refusals reading `unit … is not a unit of responseTime.percentile`. After T030 the same four render; the message change is the visible half of #74.
+- [X] T004 [P] Record the current probe counts — **after T002 has reverted its mutation**, since this reads the gate T002 temporarily breaks: run `bash scripts/verify.sh` and keep the § *Examples are assertable by Gatling* line. Expect `13 predicate probes still rejected, 16 still rendered`.
+- [X] T005 [P] Record the corpus baseline for FR-026 and SC-011: `git rev-parse HEAD:examples` and keep the tree hash. [quickstart.md](quickstart.md) § 1 compares against it, and a hash is what makes "byte-identical" a check rather than an impression.
+
+**Checkpoint**: five baselines recorded, working tree clean (`git status --short` empty).
+
+---
+
+## Phase 2: Foundational (blocking prerequisite)
+
+**Purpose**: the spec-first rule. `AGENTS.md` requires the `specs/NNN-*/` artifacts to land as
+their own commit before any `fix`, so no issue commit may be made until T006 is done.
+
+- [X] T006 Commit this directory as `docs(speckit): add 013-numbers-a-predicate-carries spec/plan/tasks` — `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/` and `checklists/`. No `README.md` or `scripts/` change rides along.
+
+**Checkpoint**: the argument is reviewable before anything it argues for is written.
+
+---
+
+## Phase 3: #73 — the percentile test is the row it implements (US1 P1) 🎯 MVP
+
+**Goal**: one rule decides what a percentile is. The gate stops calling five shapes assertable that
+the row and the schema both reject.
+
+**Independent test**: [quickstart.md](quickstart.md) § 3 and § 4. Three artifacts hold one string;
+ten aggregations get the same verdict from the row and from the gate.
+
+**Contract**: [contracts/percentile-pattern.md](contracts/percentile-pattern.md).
+
+**No prose change.** `README.md` § *Aggregations* is already correct and is the **source** of this
+rule — the gate is what moves. That is why this commit touches one file.
+
+- [X] T007 [US1] Add `re` to the Gatling heredoc's imports in `scripts/verify.sh:573`, which today reads `import glob, sys`.
+- [X] T008 [US1] Replace the helper at `scripts/verify.sh:634` with the named constant and `re.fullmatch`, per [contracts/percentile-pattern.md](contracts/percentile-pattern.md). The pattern is `^p\d{1,2}(\.\d+)?$` carried **character-for-character including its anchors** — they are redundant under `fullmatch` and kept so the constant, the row and `$defs/aggregation` are comparable by eye (FR-004).
+- [X] T009 [US1] Add the comment above the constant naming the row it implements **and** why `fullmatch` and not `match`: Python's `$` also matches before a trailing newline where ECMA-262's does not, so `match` would admit `"p95\n"` — the row's own defect one input smaller ([research.md](research.md) R1).
+- [X] T010 [US1] Add three rejection probes to `PREDICATE_PROBES` (`scripts/verify.sh:866-904`): `p999`, `p.5` and `"p95\n"`, each expecting `aggregation <a> over a metric has no equivalent`. Each is the sole catcher of one regression — a widened integer part, an optional integer part, and `fullmatch` swapped for `match`.
+- [X] T011 [US1] Raise the predicate rejection floor `13` → `16` in `FLOORS` (`scripts/verify.sh:971`). Leave the other five floors alone.
+- [X] T012 [US1] Run `bash scripts/verify.sh`. Expect **PASS** and `16 predicate probes still rejected, 16 still rendered`. Then run [quickstart.md](quickstart.md) § 3 and expect `all three identical: True` — before this phase it printed `gate: NOT FOUND`.
+- [X] T013 [US1] Apply each of [contracts/percentile-pattern.md](contracts/percentile-pattern.md) § *Acceptance*'s five reverts **on its own**, confirm the gate goes **red** and that the named probe is what fails, then revert. `re.fullmatch` → `re.match` must fail on `p95\n`; if it passes, T008 did not land.
+- [X] T014 [US1] Commit `scripts/verify.sh` as `fix(gate): the percentile test is the row it implements (#73)` with `Closes #73`. One file; `README.md` must not be in the diff.
+
+**Checkpoint**: #73 closed — **SC-001**, **SC-002**. One run of the gate no longer reports one
+predicate as both assertable and invalid.
+
+---
+
+## Phase 4: #59 — the conversion is exact decimal arithmetic (US2 P2)
+
+**Goal**: the whole-number rule gains the arithmetic it was always assuming, the `Target` column
+says whose type it is, and one wrong cell in that column is corrected — which cannot be done
+without rewording the rule.
+
+**Independent test**: [quickstart.md](quickstart.md) § 5, § 6 and § 8. Two implementations built
+from the corrected text alone accept and refuse the same five documents; every cell of the `Target`
+column matches `AssertionBuilders.scala`.
+
+**Contract**: [contracts/threshold-arithmetic.md](contracts/threshold-arithmetic.md).
+
+**Read `GLOSSARY.md` § *threshold and unit* before writing it.** Two different obligations land on
+one entry and only one of them was known when this phase was drafted:
+
+- **Read** (T015): confirm the arithmetic sentence does not contradict the entry's rejection of
+  `threshold: "500ms"`. It does not — the rule is about the value a number denotes, not about
+  admitting a decimal string. If that ever stops being true, the arithmetic sentence is wrong, not
+  the entry.
+- **Write** (T021): the entry's *Rejected* line gains one sentence recording why a precision bound
+  on `threshold` was refused (FR-012). An earlier draft of the contract put that in `README.md`
+  § *Units*; `/speckit-analyze` found that this places a statement about the format's own schema
+  inside a **target description**, which Principle VI defines as what a renderer reads to turn a
+  document into assertions. [spec.md](spec.md) FR-027 had provided for the right home all along.
+
+**No entry is added, renamed or redefined**, so Development Workflow's same-PR rule for a term
+change is not engaged — there is no term change.
+
+- [X] T015 [US2] Read `GLOSSARY.md` § *threshold and unit* and confirm the arithmetic sentence contradicts nothing in it, per the paragraph above. Record the finding in the PR body; change no file **in this task** — the entry is written in T021.
+- [X] T016 [P] [US2] Add the arithmetic paragraph to `README.md` § *Units* immediately **before** the whole-number rule at `:770`, per [contracts/threshold-arithmetic.md](contracts/threshold-arithmetic.md). It must state exact decimal arithmetic on the value the threshold denotes, give the double-recovery route and its fifteen-significant-digit bound, and say that keeping source text is **not** required (FR-007 … FR-010).
+- [X] T017 [US2] Rewrite the whole-number rule at `README.md:770-773` to be conditioned on the target being **integral** rather than on the word `Int`, and add `aggregation: count, threshold: 20.5` as its third worked example (FR-017e). Do not touch the no-rounding sentence.
+- [X] T018 [US2] Correct the `Target` column in the § *Units* table (`README.md:759-763`): `allRequests.count`, `failedRequests.count` becomes **`Long`** (FR-017d). Check the other four cells against [data-model.md](data-model.md) § 7 and leave them as they are.
+- [X] T019 [US2] In `README.md` § *Units* (`:757-763`) retitle the column's meaning and add the sourcing line beneath the table: the types are the **DSL entry points'**, not the target's, sourced to `AssertionBuilders.scala` at `gatling-core` 3.13.5, `gatling-core-java` 3.13.5 and `gatling-shared-model_2.13` 0.0.11, **checked 2026-09-01** — its own versions and date, not § *Gatling*'s 3.15.1 header (FR-017, FR-017a).
+- [X] T020 [US2] Add the recorded non-relaxation to `README.md` § *Units* (FR-017b, FR-017c): a renderer constructing the assertion model itself does not pass through those entry points, and the rule is **not** relaxed for it, because reach is a property of the target and not of how a renderer is built. This is a target fact and belongs here; the rejected schema bound is **not**, and moves to T021.
+- [X] T021 [P] [US2] Add one sentence to `GLOSSARY.md` § *threshold and unit*'s existing *Rejected* line, naming both grounds on which a precision bound on `threshold` was refused (FR-012), per [contracts/threshold-arithmetic.md](contracts/threshold-arithmetic.md). **No entry is added, renamed or redefined** — FR-027's second sentence is what permits this, and the spec provided for it from the start. It goes here rather than in `README.md` § *Units* because that section is a target description, and a renderer reads nothing from a rejected schema change.
+- [X] T022 [P] [US2] Add the comment above `scripts/verify.sh:744`'s `Fraction(str(...))` naming the rule it implements, so replacing it with a float multiplication reads as a change to the rule (FR-013).
+- [X] T023 [US2] In `scripts/verify.sh`, add one rendering probe to `PREDICATE_RENDERS` (`:920-937`) — `{**RENDERABLE, "threshold": 1.001, "unit": "s"}` (FR-014), two keys and no more, because `scripts/verify.sh:863` requires a probe to differ from a passing one *"in exactly the thing it tests"* and an aggregation override would test nothing — and **two** rejection probes to `PREDICATE_PROBES` (`:866-904`) — `aggregation: count, threshold: 20.5, unit: {request}`, and the same carrying `bad: BAD` (FR-017f). One per count row, because they sit in **different shapes**: `allRequests.count` under `requests`, `failedRequests.count` under `fraction`, so one probe reaches one row and leaves the other as unguarded as T002 found it. Raise the floors in `FLOORS` (`:971`): rejection `16` → `20`, rendering `16` → `18`.
+- [X] T024 [US2] Confirm FR-015 by diff, not by the gate: `git diff main -- scripts/verify.sh` shows the `0.1 ms` rejection probe **and its message string** untouched. T017 rewords the whole-number rule and the tempting companion edit is to reword this message to match — it must not be made, and the floors cannot catch it, because deleting this probe and adding two still clears them.
+- [X] T025 [US2] Run `bash scripts/verify.sh` (expect `20 … rejected, 18 … rendered`), then apply [contracts/threshold-arithmetic.md](contracts/threshold-arithmetic.md) § *Acceptance*'s three reverts on their own. The count-flag revert **is the one that passes green today** — T002's baseline — and must now fail.
+- [X] T026 [US2] Commit `README.md`, `GLOSSARY.md` and `scripts/verify.sh` as `fix(format): the conversion is exact decimal arithmetic (#59)` with `Closes #59`. Three files; `schema/` and `examples/` must not be in the diff.
+
+**Checkpoint**: #59 closed — **SC-003**, **SC-004**, **SC-008**, **SC-009**, **SC-010**. No message
+string changed and no document changed renderability.
+
+---
+
+## Phase 5: #74 — responseTime reaches ns, us, min and h (US3 P3)
+
+**Goal**: the Units table stops giving one reason for two different facts. Four units move from
+**cannot** to **can**, governed by the rule #59 just reworded.
+
+**Independent test**: [quickstart.md](quickstart.md) § 7. Seventeen units, ten reached, seven
+unreachable, none in both and none in neither.
+
+**Contract**: [contracts/duration-units.md](contracts/duration-units.md).
+
+**The only commit that changes which documents may be published.**
+
+- [X] T027 [P] [US3] Extend both duration rows' `Accepts` cells in `README.md:759-760` from `ms`, `s` to `ns`, `us`, `ms`, `s`, `min`, `h`. Both rows, because they share one factor table and one `Stats` type, which § *Metrics* already sources and dates. Incidentally: `:760` carries a trailing space — drop it while the row is being edited.
+- [X] T028 [US3] Shrink the last row at `README.md:764` to the seven units no statistic reaches — `By`, `KiBy`, `MiBy`, `GiBy`, `{iteration}`, `{iteration}/s`, `{vu}` — keeping its existing reason, which is now true of all seven (FR-020).
+- [X] T029 [US3] Re-check, and do **not** reword, the derived-row sentence at `README.md:766` (FR-021): the enumeration is 17, the statistics reach 10 distinct units, 17 − 10 = 7. Then name the whole-number rule as what still governs the four new units — they are not an exception to it, they are newly subject to it.
+- [X] T030 [P] [US3] Add four factors to `TIME` (`scripts/verify.sh:630`): `ns` → `Fraction(1, 1000000)`, `us` → `Fraction(1, 1000)`, `min` → `Fraction(60000)`, `h` → `Fraction(3600000)`. All exact; no conversion rounds (FR-019).
+- [X] T031 [US3] Add four rendering probes to `PREDICATE_RENDERS` in `scripts/verify.sh` (`:920-937`), one per new unit — `2000000 ns`, `1500000 us`, `2 min`, `1 h` — so deleting any single factor fails the gate (FR-023).
+- [X] T032 [US3] Add one rejection probe to `PREDICATE_PROBES` in `scripts/verify.sh` (`:866-904`) — `{**RENDERABLE, "threshold": 1500, "unit": "ns"}` expecting `threshold 1500 ns is 3/2000 for responseTime.percentile, whose target is an integer` (FR-024). Confirm the reason comes from the whole-number branch and **not** from `unit … is not a unit of …`; that ordering is the whole of #74. Raise the floors in `FLOORS` (`:971`): rejection `20` → `22`, rendering `18` → `22`.
+- [X] T033 [US3] Run `bash scripts/verify.sh` (expect `22 … rejected, 22 … rendered`), then apply [contracts/duration-units.md](contracts/duration-units.md) § *Acceptance*'s three reverts on their own. Deleting any one of the four factors must name that unit's own probe — if one deletion reddens on a different probe, T031 is short a case.
+- [X] T034 [US3] Commit `README.md` and `scripts/verify.sh` as `fix(format): responseTime reaches ns, us, min and h (#74)` with `Closes #74`. Two files; `examples/` must not be in the diff.
+
+**Checkpoint**: all three issues closed — **SC-005**, **SC-006**, **SC-007**.
+
+---
+
+## Phase 6: Polish — the pull request catches up
+
+**Purpose**: the milestone lands as one pull request, and the rules that are checked outside the
+gate get checked.
+
+- [X] T035 Confirm `examples/` is byte-identical: `git rev-parse HEAD:examples` matches T005's hash, and `git diff --stat main -- examples/` is empty (FR-026, SC-011).
+- [X] T036 Confirm the two read-only surfaces stayed read-only and the one written surface stayed small: `git diff --stat main -- schema/` is **empty** (FR-011), and `git diff main -- GLOSSARY.md` shows **one added sentence inside an existing *Rejected* line** — no heading added, none removed, no entry's definition touched (FR-027). If the schema moved, or if `GLOSSARY.md` gained or lost a heading, the Constitution Check in [plan.md](plan.md) needs re-answering before merge.
+- [X] T037 Run [quickstart.md](quickstart.md) end to end — all nine steps, in order, on the merged branch. Steps 8 and 9 need `javap` and the Gatling jars; if they are absent, **say so** rather than reporting a pass (Principle III).
+- [X] T038 Open the pull request against `main` with a conventional title, assign it to milestone **v0.9.0**, and carry `Closes #73`, `Closes #59`, `Closes #74`. Opened as [galax-io/opennfr#117](https://github.com/galax-io/opennfr/pull/117). `scripts/check-linkage.sh` reads every closing link the PR carries; one PR for the milestone is what `AGENTS.md` asks for.
+- [X] T039 Confirm against `AGENTS.md` § *Commits & PRs* that the PR title is conventional **before** the squash freezes it into the commit message, and that the three issue commits are rebased onto `main` with no merge commit. Update a pushed PR with `--force-with-lease`.
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 (T001-T005)  baselines — T002 must run before T023 or its evidence is gone
+        |
+Phase 2 (T006)       spec commit — blocks every issue commit
+        |
+Phase 3 (T007-T014)  #73  scripts/verify.sh only
+        |
+Phase 4 (T015-T026)  #59  README.md § Units + GLOSSARY.md + scripts/verify.sh
+        |
+Phase 5 (T027-T034)  #74  README.md § Units + scripts/verify.sh
+        |
+Phase 6 (T035-T039)  the PR
+```
+
+**Why the phases are strictly sequential**, even though #73 touches a different region than the
+other two:
+
+- **T002 before T023** is a content dependency, not a convention: T023 makes T002's mutation fail,
+  so the baseline has to be taken first or the claim "this was unenforced" becomes unverifiable.
+- **#59 before #74** is the milestone's own reason: #74 adds four conversions and #59 states the
+  arithmetic that governs them. Reversed, the four new units would ship for one release under a
+  rule with no arithmetic model.
+- **US2 and US3 both edit `README.md:752-773`** — the same six-row table, twice. Sequential is not
+  a preference here; it is the absence of a conflict.
+- Within a phase, the parallel work is one triple and one pair: **T016 ‖ T021 ‖ T022** — three
+  different files, `README.md`, `GLOSSARY.md` and `scripts/verify.sh` — and **T027 ‖ T030**, a
+  `README.md` edit beside a `scripts/verify.sh` edit. Everything else shares a file.
+
+**Parallel opportunities**: T001–T005 are five independent reads and can all run at once. After
+that the milestone is a chain, which three files and one shared table make unavoidable.
+
+---
+
+## Implementation Strategy
+
+**MVP is Phase 3 alone.** #73 is one line of rule, one file, three probes and a floor, and it
+delivers the milestone's headline on its own: one run of the gate stops reporting one predicate as
+both assertable and invalid. It depends on nothing in Phases 4 and 5 and can ship as a release by
+itself.
+
+**Incremental delivery**: each of the three issue commits is green on `bash scripts/verify.sh` on
+its own, so the branch can be reviewed and merged one commit at a time even though it lands as one
+PR. If Phase 5 turns out to want more argument, Phases 3 and 4 are complete work and #74 returns to
+the milestone board.
+
+**The order is not negotiable in one place**: #59 before #74. Everywhere else the sequencing is
+about file contention and can be re-cut.
+
+**What "done" means**: `bash scripts/verify.sh` reports **PASS** with `22 predicate probes still
+rejected, 22 still rendered`; the six reverts in [quickstart.md](quickstart.md) § 9 each redden the
+gate; `examples/` is byte-identical to T005's hash; and § *Units* answers "how is the conversion
+computed?" without a reader opening `scripts/verify.sh`.


### PR DESCRIPTION
Milestone **v0.9.0**. Three issues, one question under all of them: *which numbers may a predicate carry, and which artifact decides?* Three artifacts answered differently.

- **#73** — the gate's percentile test called `p100`, `p999`, `p1234`, `p.5` and `p1.` assertable while the row it implements and the schema reject all five. One run reported a predicate assertable in its reach section and the document invalid in its schema section. The helper becomes the row's pattern, applied with `re.fullmatch` and not `re.match` — Python's `$` also matches before a trailing newline where ECMA-262's does not, so `match` would admit `"p95\n"` and reinstate the same defect one input smaller.
- **#59** — the whole-number rule forbade rounding and never said which arithmetic decides whether a value is whole; exact decimal and IEEE-754 disagree on `1.001 s`. § *Units* now states it, `GLOSSARY.md` records why a schema precision bound was refused, and the `Target` column says whose type it is — one cell was wrong, `count` returns `[Long]`.
- **#74** — the Units table gave one reason for eleven units and it was true of seven. `responseTime.*` reaches `ns`, `us`, `min` and `h` exactly, by the arithmetic that already converts `s`.

**`examples/` is byte-identical.** Four schema-valid documents become publishable that were not; none stops being publishable.

## What review added

Code review found the rule under-stated twice, and both are now in the gate:

- It is a **range**, not only a divisibility. `2149200 s` is 2 149 200 000 ms against an `Int` that stops at 2 147 483 647, so `TABLE` carries a bound per row instead of a boolean.
- The arithmetic is about the value the literal *denotes*, which `Fraction(str(float))` cannot recover past fifteen significant digits — `1.0000000000000001 s` arrived as `1.0` and rendered as a whole 1000 ms while the rule refused it. `ExactLoader` keeps the literal, and `LOADER` carries its own check, because no published threshold is long enough for a probe to reach that wiring.
- `groupCumulatedResponseTime.*` has no DSL entry point of its own; the page now sources it through `responseTime` and path resolution rather than naming a builder that does not exist.

## Verification

`bash scripts/verify.sh` is **PASS** at every commit, not only the last:

| commit | predicate probes rejected / rendered |
|---|---|
| spec | 13 / 16 |
| #73 | 16 / 16 |
| #59 | 21 / 18 |
| #74 | **22 / 22** |

Fifteen probes added, each the sole catcher of one regression; every one was checked by reverting the rule it guards and confirming the gate reddens. Gatling claims re-read locally at `gatling-core` / `gatling-core-java` **3.13.5** and `gatling-shared-model_2.13` **0.0.11**, **2026-09-01**.

Closes #73
Closes #59
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
